### PR TITLE
Add PresenterPlugin for VPC; fix GraphQL schema args

### DIFF
--- a/lib/src/generator/code_generator.dart
+++ b/lib/src/generator/code_generator.dart
@@ -6,6 +6,7 @@ import 'provider_generator.dart';
 import '../plugins/usecase/usecase_plugin.dart';
 import '../plugins/repository/repository_plugin.dart';
 import '../plugins/view/view_plugin.dart';
+import '../plugins/presenter/presenter_plugin.dart';
 import 'vpc_generator.dart';
 import 'state_generator.dart';
 import 'observer_generator.dart';
@@ -30,6 +31,7 @@ class CodeGenerator {
   late final ProviderGenerator _providerGenerator;
   late final UseCasePlugin _useCasePlugin;
   late final ViewPlugin _viewPlugin;
+  late final PresenterPlugin _presenterPlugin;
   late final VpcGenerator _vpcGenerator;
   late final StateGenerator _stateGenerator;
   late final ObserverGenerator _observerGenerator;
@@ -66,6 +68,12 @@ class CodeGenerator {
       verbose: verbose,
     );
     _viewPlugin = ViewPlugin(
+      outputDir: outputDir,
+      dryRun: dryRun,
+      force: force,
+      verbose: verbose,
+    );
+    _presenterPlugin = PresenterPlugin(
       outputDir: outputDir,
       dryRun: dryRun,
       force: force,
@@ -153,8 +161,8 @@ class CodeGenerator {
         }
 
         if (config.generateVpc || config.generatePresenter) {
-          final file = await _vpcGenerator.generatePresenter();
-          files.add(file);
+          final presenterFiles = await _presenterPlugin.generate(config);
+          files.addAll(presenterFiles);
         }
 
         if (config.generateVpc || config.generateController) {

--- a/lib/src/graphql/graphql_schema.dart
+++ b/lib/src/graphql/graphql_schema.dart
@@ -81,30 +81,6 @@ class GqlTypeRef {
   }
 }
 
-/// Represents a GraphQL argument.
-class GqlArgument {
-  final String name;
-  final String? description;
-  final GqlTypeRef type;
-  final dynamic defaultValue;
-
-  const GqlArgument({
-    required this.name,
-    this.description,
-    required this.type,
-    this.defaultValue,
-  });
-
-  factory GqlArgument.fromJson(Map<String, dynamic> json) {
-    return GqlArgument(
-      name: json['name'] as String,
-      description: json['description'] as String?,
-      type: GqlTypeRef.fromJson(json['type'] as Map<String, dynamic>?),
-      defaultValue: json['defaultValue'],
-    );
-  }
-}
-
 /// Represents a GraphQL field.
 class GqlField {
   final String name;
@@ -129,6 +105,30 @@ class GqlField {
               ?.map((a) => GqlArgument.fromJson(a as Map<String, dynamic>))
               .toList() ??
           const [],
+    );
+  }
+}
+
+/// Represents a GraphQL field argument.
+class GqlArgument {
+  final String name;
+  final String? description;
+  final GqlTypeRef type;
+  final String? defaultValue;
+
+  const GqlArgument({
+    required this.name,
+    this.description,
+    required this.type,
+    this.defaultValue,
+  });
+
+  factory GqlArgument.fromJson(Map<String, dynamic> json) {
+    return GqlArgument(
+      name: json['name'] as String,
+      description: json['description'] as String?,
+      type: GqlTypeRef.fromJson(json['type'] as Map<String, dynamic>?),
+      defaultValue: json['defaultValue'] as String?,
     );
   }
 }

--- a/lib/src/plugins/presenter/builders/presenter_class_builder.dart
+++ b/lib/src/plugins/presenter/builders/presenter_class_builder.dart
@@ -1,0 +1,42 @@
+import 'package:code_builder/code_builder.dart';
+
+import '../../../core/builder/shared/spec_library.dart';
+
+class PresenterClassSpec {
+  final String className;
+  final List<Field> fields;
+  final Constructor constructor;
+  final List<Method> methods;
+  final List<String> imports;
+
+  const PresenterClassSpec({
+    required this.className,
+    required this.fields,
+    required this.constructor,
+    required this.methods,
+    required this.imports,
+  });
+}
+
+class PresenterClassBuilder {
+  final SpecLibrary specLibrary;
+
+  const PresenterClassBuilder({this.specLibrary = const SpecLibrary()});
+
+  String build(PresenterClassSpec spec) {
+    final clazz = Class(
+      (b) => b
+        ..name = spec.className
+        ..extend = refer('Presenter')
+        ..fields.addAll(spec.fields)
+        ..constructors.add(spec.constructor)
+        ..methods.addAll(spec.methods),
+    );
+
+    final directives = spec.imports.toSet().map(Directive.import).toList();
+
+    return specLibrary.emitLibrary(
+      specLibrary.library(specs: [clazz], directives: directives),
+    );
+  }
+}

--- a/lib/src/plugins/presenter/presenter_plugin.dart
+++ b/lib/src/plugins/presenter/presenter_plugin.dart
@@ -1,0 +1,408 @@
+import 'package:code_builder/code_builder.dart';
+import 'package:path/path.dart' as path;
+
+import '../../core/plugin_system/plugin_interface.dart';
+import '../../generator/usecase_generator.dart';
+import '../../models/generated_file.dart';
+import '../../models/generator_config.dart';
+import '../../utils/file_utils.dart';
+import '../../utils/string_utils.dart';
+import 'builders/presenter_class_builder.dart';
+
+class PresenterPlugin extends FileGeneratorPlugin {
+  final String outputDir;
+  final bool dryRun;
+  final bool force;
+  final bool verbose;
+  final PresenterClassBuilder classBuilder;
+
+  PresenterPlugin({
+    required this.outputDir,
+    required this.dryRun,
+    required this.force,
+    required this.verbose,
+    PresenterClassBuilder? classBuilder,
+  }) : classBuilder = classBuilder ?? const PresenterClassBuilder();
+
+  @override
+  String get id => 'presenter';
+
+  @override
+  String get name => 'Presenter Plugin';
+
+  @override
+  String get version => '1.0.0';
+
+  @override
+  Future<List<GeneratedFile>> generate(GeneratorConfig config) async {
+    if (!(config.generatePresenter || config.generateVpc)) {
+      return [];
+    }
+    final entityName = config.name;
+    final entitySnake = config.nameSnake;
+    final entityCamel = config.nameCamel;
+    final presenterName = '${entityName}Presenter';
+    final fileName = '${entitySnake}_presenter.dart';
+
+    final presenterDirPath = path.join(
+      outputDir,
+      'presentation',
+      'pages',
+      entitySnake,
+    );
+    final filePath = path.join(presenterDirPath, fileName);
+
+    final repoFields = _buildRepoFields(config);
+    final usecaseInfo = _buildUseCaseInfo(config, entityName, entityCamel);
+    final usecaseFields = _buildUseCaseFields(usecaseInfo);
+    final constructor = _buildConstructor(config, usecaseInfo);
+    final methods = _buildMethods(config, usecaseInfo, entityName, entityCamel);
+    final imports = _buildImports(config, usecaseInfo, entitySnake);
+
+    final content = classBuilder.build(
+      PresenterClassSpec(
+        className: presenterName,
+        fields: [...repoFields, ...usecaseFields],
+        constructor: constructor,
+        methods: methods,
+        imports: imports,
+      ),
+    );
+
+    final file = await FileUtils.writeFile(
+      filePath,
+      content,
+      'presenter',
+      force: force,
+      dryRun: dryRun,
+      verbose: verbose,
+    );
+    return [file];
+  }
+
+  List<Field> _buildRepoFields(GeneratorConfig config) {
+    return config.effectiveRepos
+        .map(
+          (repo) => Field(
+            (f) => f
+              ..modifier = FieldModifier.final$
+              ..type = refer(repo)
+              ..name = StringUtils.pascalToCamel(repo),
+          ),
+        )
+        .toList();
+  }
+
+  List<UseCaseInfo> _buildUseCaseInfo(
+    GeneratorConfig config,
+    String entityName,
+    String entityCamel,
+  ) {
+    final generator = UseCaseGenerator(
+      config: config,
+      outputDir: outputDir,
+      dryRun: dryRun,
+      force: force,
+      verbose: verbose,
+    );
+    return config.methods
+        .map(
+          (method) => generator.getUseCaseInfo(method, entityName, entityCamel),
+        )
+        .toList();
+  }
+
+  List<Field> _buildUseCaseFields(List<UseCaseInfo> useCases) {
+    return useCases
+        .map(
+          (info) => Field(
+            (f) => f
+              ..modifier = FieldModifier.final$
+              ..late = true
+              ..type = refer(info.className)
+              ..name = '_${info.fieldName}',
+          ),
+        )
+        .toList();
+  }
+
+  Constructor _buildConstructor(
+    GeneratorConfig config,
+    List<UseCaseInfo> useCases,
+  ) {
+    final repoParams = config.effectiveRepos
+        .map(
+          (repo) => Parameter(
+            (p) => p
+              ..name = StringUtils.pascalToCamel(repo)
+              ..toThis = true
+              ..named = true
+              ..required = true,
+          ),
+        )
+        .toList();
+
+    final mainRepo = config.effectiveRepos.isNotEmpty
+        ? StringUtils.pascalToCamel(config.effectiveRepos.first)
+        : 'repository';
+
+    final registrations = useCases
+        .map(
+          (info) =>
+              '_${info.fieldName} = registerUseCase(${info.className}($mainRepo));',
+        )
+        .join('\n');
+
+    return Constructor(
+      (c) => c
+        ..optionalParameters.addAll(repoParams)
+        ..body = Code(registrations),
+    );
+  }
+
+  List<Method> _buildMethods(
+    GeneratorConfig config,
+    List<UseCaseInfo> useCases,
+    String entityName,
+    String entityCamel,
+  ) {
+    final map = {for (final info in useCases) info.fieldName: info};
+    final methods = <Method>[];
+    for (final method in config.methods) {
+      switch (method) {
+        case 'get':
+          methods.add(
+            _buildGetMethod(config, map['get$entityName']!, entityName),
+          );
+          break;
+        case 'getList':
+          methods.add(
+            _buildGetListMethod(map['get${entityName}List']!, entityName),
+          );
+          break;
+        case 'create':
+          methods.add(
+            _buildCreateMethod(
+              map['create$entityName']!,
+              entityName,
+              entityCamel,
+            ),
+          );
+          break;
+        case 'update':
+          methods.add(
+            _buildUpdateMethod(config, map['update$entityName']!, entityName),
+          );
+          break;
+        case 'delete':
+          methods.add(_buildDeleteMethod(config, map['delete$entityName']!));
+          break;
+        case 'watch':
+          methods.add(
+            _buildWatchMethod(config, map['watch$entityName']!, entityName),
+          );
+          break;
+        case 'watchList':
+          methods.add(
+            _buildWatchListMethod(map['watch${entityName}List']!, entityName),
+          );
+          break;
+      }
+    }
+    return methods;
+  }
+
+  Method _buildGetMethod(
+    GeneratorConfig config,
+    UseCaseInfo info,
+    String entityName,
+  ) {
+    final methodName = info.fieldName;
+    final body = config.queryFieldType == 'NoParams'
+        ? 'return _$methodName.call(const NoParams());'
+        : config.useZorphy
+        ? 'return _$methodName.call(QueryParams<$entityName>(filter: Eq(${entityName}Fields.${config.queryField}, ${config.queryField})));'
+        : "return _$methodName.call(QueryParams<$entityName>(params: Params({'${config.queryField}': ${config.queryField}})));";
+
+    return Method(
+      (m) => m
+        ..name = 'get$entityName'
+        ..returns = refer('Future<Result<$entityName, AppFailure>>')
+        ..requiredParameters.addAll(
+          config.queryFieldType == 'NoParams'
+              ? const []
+              : [
+                  Parameter(
+                    (p) => p
+                      ..name = config.queryField
+                      ..type = refer(config.queryFieldType),
+                  ),
+                ],
+        )
+        ..body = Code(body),
+    );
+  }
+
+  Method _buildGetListMethod(UseCaseInfo info, String entityName) {
+    return Method(
+      (m) => m
+        ..name = 'get${entityName}List'
+        ..returns = refer('Future<Result<List<$entityName>, AppFailure>>')
+        ..optionalParameters.add(
+          Parameter(
+            (p) => p
+              ..name = 'params'
+              ..type = refer('ListQueryParams<$entityName>')
+              ..defaultTo = Code('const ListQueryParams()'),
+          ),
+        )
+        ..body = Code('return _${info.fieldName}.call(params);'),
+    );
+  }
+
+  Method _buildCreateMethod(
+    UseCaseInfo info,
+    String entityName,
+    String entityCamel,
+  ) {
+    return Method(
+      (m) => m
+        ..name = 'create$entityName'
+        ..returns = refer('Future<Result<$entityName, AppFailure>>')
+        ..requiredParameters.add(
+          Parameter(
+            (p) => p
+              ..name = entityCamel
+              ..type = refer(entityName),
+          ),
+        )
+        ..body = Code('return _${info.fieldName}.call($entityCamel);'),
+    );
+  }
+
+  Method _buildUpdateMethod(
+    GeneratorConfig config,
+    UseCaseInfo info,
+    String entityName,
+  ) {
+    final dataType = config.useZorphy
+        ? '${entityName}Patch'
+        : 'Partial<$entityName>';
+    final dataValue = config.useZorphy ? 'data' : 'Partial<$entityName>()';
+    return Method(
+      (m) => m
+        ..name = 'update$entityName'
+        ..returns = refer('Future<Result<$entityName, AppFailure>>')
+        ..requiredParameters.addAll([
+          Parameter(
+            (p) => p
+              ..name = config.idField
+              ..type = refer(config.idType),
+          ),
+          Parameter(
+            (p) => p
+              ..name = 'data'
+              ..type = refer(dataType),
+          ),
+        ])
+        ..body = Code(
+          'return _${info.fieldName}.call(UpdateParams<${config.idType}, $dataType>(id: ${config.idField}, data: $dataValue));',
+        ),
+    );
+  }
+
+  Method _buildDeleteMethod(GeneratorConfig config, UseCaseInfo info) {
+    return Method(
+      (m) => m
+        ..name = 'delete${config.name}'
+        ..returns = refer('Future<Result<void, AppFailure>>')
+        ..requiredParameters.add(
+          Parameter(
+            (p) => p
+              ..name = config.idField
+              ..type = refer(config.idType),
+          ),
+        )
+        ..body = Code(
+          'return _${info.fieldName}.call(DeleteParams<${config.idType}>(id: ${config.idField}));',
+        ),
+    );
+  }
+
+  Method _buildWatchMethod(
+    GeneratorConfig config,
+    UseCaseInfo info,
+    String entityName,
+  ) {
+    final methodName = info.fieldName;
+    final body = config.queryFieldType == 'NoParams'
+        ? 'return _$methodName.call(const NoParams());'
+        : config.useZorphy
+        ? 'return _$methodName.call(QueryParams<$entityName>(filter: Eq(${entityName}Fields.${config.queryField}, ${config.queryField})));'
+        : "return _$methodName.call(QueryParams<$entityName>(params: Params({'${config.queryField}': ${config.queryField}})));";
+
+    return Method(
+      (m) => m
+        ..name = 'watch$entityName'
+        ..returns = refer('Stream<Result<$entityName, AppFailure>>')
+        ..requiredParameters.addAll(
+          config.queryFieldType == 'NoParams'
+              ? const []
+              : [
+                  Parameter(
+                    (p) => p
+                      ..name = config.queryField
+                      ..type = refer(config.queryFieldType),
+                  ),
+                ],
+        )
+        ..body = Code(body),
+    );
+  }
+
+  Method _buildWatchListMethod(UseCaseInfo info, String entityName) {
+    return Method(
+      (m) => m
+        ..name = 'watch${entityName}List'
+        ..returns = refer('Stream<Result<List<$entityName>, AppFailure>>')
+        ..optionalParameters.add(
+          Parameter(
+            (p) => p
+              ..name = 'params'
+              ..type = refer('ListQueryParams<$entityName>')
+              ..defaultTo = Code('const ListQueryParams()'),
+          ),
+        )
+        ..body = Code('return _${info.fieldName}.call(params);'),
+    );
+  }
+
+  List<String> _buildImports(
+    GeneratorConfig config,
+    List<UseCaseInfo> useCases,
+    String entitySnake,
+  ) {
+    final imports = <String>[
+      'package:zuraffa/zuraffa.dart',
+      '../../domain/entities/$entitySnake/$entitySnake.dart',
+    ];
+
+    for (final repo in config.effectiveRepos) {
+      final repoSnake = StringUtils.camelToSnake(
+        repo.replaceAll('Repository', ''),
+      );
+      imports.add('../../domain/repositories/${repoSnake}_repository.dart');
+    }
+
+    for (final info in useCases) {
+      final usecaseSnake = StringUtils.camelToSnake(
+        info.className.replaceAll('UseCase', ''),
+      );
+      imports.add(
+        '../../domain/usecases/$entitySnake/${usecaseSnake}_usecase.dart',
+      );
+    }
+
+    return imports;
+  }
+}

--- a/test/plugins/presenter/presenter_plugin_test.dart
+++ b/test/plugins/presenter/presenter_plugin_test.dart
@@ -1,0 +1,98 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zuraffa/src/models/generator_config.dart';
+import 'package:zuraffa/src/plugins/presenter/presenter_plugin.dart';
+
+void main() {
+  late Directory tempDir;
+  late String outputDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('zuraffa_presenter_');
+    outputDir = Directory('${tempDir.path}/lib/src').path;
+  });
+
+  tearDown(() async {
+    if (tempDir.existsSync()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  test('generates presenter with usecase wiring', () async {
+    final plugin = PresenterPlugin(
+      outputDir: outputDir,
+      dryRun: false,
+      force: true,
+      verbose: false,
+    );
+    final config = GeneratorConfig(
+      name: 'Product',
+      methods: const ['get', 'getList'],
+      generatePresenter: true,
+    );
+    final files = await plugin.generate(config);
+    final content = files.first.content ?? '';
+    expect(
+      content.contains('class ProductPresenter extends Presenter'),
+      isTrue,
+    );
+    expect(
+      content.contains('late final GetProductUseCase _getProduct;'),
+      isTrue,
+    );
+    expect(
+      content.contains('registerUseCase(GetProductUseCase(productRepository))'),
+      isTrue,
+    );
+    expect(
+      content.contains(
+        'Future<Result<List<Product>, AppFailure>> getProductList',
+      ),
+      isTrue,
+    );
+  });
+
+  test('generates query param methods with zorphy filter', () async {
+    final plugin = PresenterPlugin(
+      outputDir: outputDir,
+      dryRun: false,
+      force: true,
+      verbose: false,
+    );
+    final config = GeneratorConfig(
+      name: 'Product',
+      methods: const ['get'],
+      queryField: 'slug',
+      queryFieldType: 'String',
+      useZorphy: true,
+      generatePresenter: true,
+    );
+    final files = await plugin.generate(config);
+    final content = files.first.content ?? '';
+    expect(content.contains('ProductFields.slug'), isTrue);
+    expect(content.contains('filter: Eq(ProductFields.slug, slug)'), isTrue);
+  });
+
+  test('generates watch list method signature', () async {
+    final plugin = PresenterPlugin(
+      outputDir: outputDir,
+      dryRun: false,
+      force: true,
+      verbose: false,
+    );
+    final config = GeneratorConfig(
+      name: 'Order',
+      methods: const ['watchList'],
+      generatePresenter: true,
+    );
+    final files = await plugin.generate(config);
+    final content = files.first.content ?? '';
+    expect(
+      content.contains(
+        'Stream<Result<List<Order>, AppFailure>> watchOrderList',
+      ),
+      isTrue,
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- Extract presenter generation into PresenterPlugin using code_builder
- Integrate with UseCasePlugin and wire UseCases
- Add tests for presenter generation
- Fix GraphQL schema models to include field args, preventing recurring translator errors

Closes #38