### PR TITLE
fix: address review comments on #152

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -39,14 +39,14 @@ void main() {
   WidgetsFlutterBinding.ensureInitialized();
   setupDependencies()
       .then((_) {
-        runApp(const XRayHost(child: ZuraffaExampleApp()));
         _initializeBridge();
+        runApp(const XRayHost(child: ZuraffaExampleApp()));
       })
       .catchError((Object error, StackTrace st) {
         debugPrint('❌ setupDependencies failed: $error');
         debugPrintStack(stackTrace: st);
-        runApp(const XRayHost(child: ZuraffaExampleApp()));
         _initializeBridge();
+        runApp(const XRayHost(child: ZuraffaExampleApp()));
       });
 }
 

--- a/lib/src/core/api_bridge.dart
+++ b/lib/src/core/api_bridge.dart
@@ -2,7 +2,8 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:developer' as developer;
 
-import 'package:flutter/foundation.dart' show kProfileMode, kReleaseMode;
+import 'package:flutter/foundation.dart'
+    show kProfileMode, kReleaseMode, ValueNotifier;
 import 'package:meta/meta.dart';
 import 'package:uuid/uuid.dart';
 
@@ -60,6 +61,11 @@ class ZuraffaApiBridge {
   static bool _initialized = false;
   static final List<ApiEndpoint> _endpoints = [];
   static final Map<String, _StreamRecord> _streamSubscriptions = {};
+
+  /// Bumped whenever the endpoint catalog changes (registration or
+  /// reset), so listeners — e.g. the x-ray debug overlay — can rebuild
+  /// with fresh data instead of waiting for an unrelated rebuild.
+  static final ValueNotifier<int> revision = ValueNotifier<int>(0);
 
   /// In-process mirror of every handler passed to
   /// [developer.registerExtension], keyed by [ApiEndpoint.method].
@@ -125,6 +131,7 @@ class ZuraffaApiBridge {
   }) {
     _endpoints.add(endpoint);
     _handlers[endpoint.method] = handler;
+    revision.value++;
     developer.registerExtension(endpoint.method, handler);
   }
 
@@ -335,6 +342,7 @@ class ZuraffaApiBridge {
     _streamSubscriptions.clear();
     _endpoints.clear();
     _handlers.clear();
+    revision.value++;
     _initialized = false;
   }
 }

--- a/lib/src/plugins/xray/widgets/xray_button.dart
+++ b/lib/src/plugins/xray/widgets/xray_button.dart
@@ -46,8 +46,9 @@ class _XRayButtonState extends State<XRayButton> {
     setState(() => _busy = true);
     try {
       await action();
-    } catch (e) {
-      _snack('Error: $e');
+    } catch (error, stack) {
+      debugPrint('x-ray action failed: $error\n$stack');
+      _snack('Error: $error');
     } finally {
       if (mounted) setState(() => _busy = false);
     }
@@ -163,6 +164,9 @@ class _XRayParamFormState extends State<_XRayParamForm> {
   final Map<String, bool> _boolValues = {};
   final Map<String, DateTime> _dateValues = {};
 
+  /// Shown when submit is blocked by unparseable numeric input.
+  String? _validationError;
+
   @override
   void initState() {
     super.initState();
@@ -201,7 +205,10 @@ class _XRayParamFormState extends State<_XRayParamForm> {
     return null;
   }
 
-  Map<String, String> _collectValues() {
+  /// Collects the form values, or returns null — leaving the dialog open
+  /// with a visible error — when a numeric field holds unparseable text.
+  /// A debug tool must surface bad input, not silently submit 0.
+  Map<String, String>? _collectValues() {
     final entityFields = _entityFields();
     if (entityFields == null) {
       return {
@@ -212,14 +219,27 @@ class _XRayParamFormState extends State<_XRayParamForm> {
     for (final field in entityFields) {
       switch (field.type) {
         case 'int':
-          json[field.name] =
-              int.tryParse(_controllers[field.name]?.text ?? '') ?? 0;
+          final raw = _controllers[field.name]?.text ?? '';
+          final parsed = int.tryParse(raw);
+          if (parsed == null && raw.isNotEmpty) {
+            setState(() => _validationError =
+                '${field.name}: "$raw" is not a valid int');
+            return null;
+          }
+          json[field.name] = parsed ?? 0;
         case 'double':
-          json[field.name] =
-              double.tryParse(_controllers[field.name]?.text ?? '') ?? 0.0;
+          final raw = _controllers[field.name]?.text ?? '';
+          final parsed = double.tryParse(raw);
+          if (parsed == null && raw.isNotEmpty) {
+            setState(() => _validationError =
+                '${field.name}: "$raw" is not a valid double');
+            return null;
+          }
+          json[field.name] = parsed ?? 0.0;
         case 'bool':
           json[field.name] = _boolValues[field.name] ?? false;
         case 'DateTime':
+          // Unpicked dates deliberately default to now — surfaced in the UI.
           json[field.name] = (_dateValues[field.name] ?? DateTime.now())
               .toIso8601String();
         default:
@@ -252,6 +272,15 @@ class _XRayParamFormState extends State<_XRayParamForm> {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
+            if (_validationError != null)
+              Padding(
+                padding: const EdgeInsets.only(bottom: 8),
+                child: Text(
+                  _validationError!,
+                  style:
+                      const TextStyle(color: Colors.redAccent, fontSize: 12),
+                ),
+              ),
             if (entityFields != null)
               for (final field in entityFields) _buildEntityField(field)
             else
@@ -281,7 +310,11 @@ class _XRayParamFormState extends State<_XRayParamForm> {
         ),
         ElevatedButton(
           key: XRayElementKey.formSubmit(widget.endpoint.method),
-          onPressed: () => Navigator.of(context).pop(_collectValues()),
+          onPressed: () {
+            final values = _collectValues();
+            // Invalid input keeps the dialog open with a visible error.
+            if (values != null) Navigator.of(context).pop(values);
+          },
           child: const Text('Call'),
         ),
       ],
@@ -318,7 +351,9 @@ class _XRayParamFormState extends State<_XRayParamForm> {
         return ListTile(
           key: key,
           title: Text(
-            value == null ? '$label — tap to pick' : value.toIso8601String(),
+            value == null
+                ? '$label — tap to pick (defaults to now)'
+                : value.toIso8601String(),
             style: const TextStyle(color: Colors.white, fontSize: 13),
           ),
           trailing: const Icon(Icons.calendar_today, color: Colors.white54),

--- a/lib/src/plugins/xray/widgets/xray_host.dart
+++ b/lib/src/plugins/xray/widgets/xray_host.dart
@@ -45,13 +45,12 @@ class _XRayHostState extends State<XRayHost> {
   void _dismiss() => setState(() => _panelOpen = false);
   void _reopen() => setState(() => _panelOpen = true);
 
-  /// Screen size without requiring a [MediaQuery] ancestor — [XRayHost]
-  /// is typically placed *above* `MaterialApp`, where none exists.
-  Size _screenSize(BuildContext context) {
-    final query = MediaQuery.maybeOf(context);
-    if (query != null) return query.size;
-    final view = View.of(context);
-    return view.physicalSize / view.devicePixelRatio;
+  /// Provides a [MediaQuery] for overlay chrome when the host sits above
+  /// the app's own MediaQuery (e.g. above `MaterialApp`) — widgets like
+  /// [SafeArea] require one. Sourced from the view so it stays live.
+  Widget _mediaQueryScope(BuildContext context, Widget child) {
+    if (MediaQuery.maybeOf(context) != null) return child;
+    return MediaQuery.fromView(view: View.of(context), child: child);
   }
 
   Positioned _panelPosition(Size screen, OverlayPosition position) {
@@ -96,10 +95,13 @@ class _XRayHostState extends State<XRayHost> {
     }
   }
 
-  Positioned _launcherPosition(OverlayPosition position) {
+  Positioned _launcherPosition(BuildContext context, OverlayPosition position) {
     final child = Directionality(
       textDirection: TextDirection.ltr,
-      child: SafeArea(child: _Launcher(onTap: _reopen)),
+      child: _mediaQueryScope(
+        context,
+        SafeArea(child: _Launcher(onTap: _reopen)),
+      ),
     );
     switch (position) {
       case OverlayPosition.topLeft:
@@ -116,24 +118,37 @@ class _XRayHostState extends State<XRayHost> {
   @override
   Widget build(BuildContext context) {
     final plugin = XRayPlugin();
-    if (!plugin.enabled) return widget.child;
+    // Listen to revision so enable()/disable() after the first build still
+    // mount or drop the overlay (no silent no-ops).
+    return ValueListenableBuilder<int>(
+      valueListenable: plugin.revision,
+      builder: (context, _, __) {
+        if (!plugin.enabled) return widget.child;
 
-    final position = plugin.config.overlayPosition;
-    final screen = _screenSize(context);
-    return Stack(
-      // XRayHost usually sits *above* MaterialApp, where no ambient
-      // Directionality exists yet.
-      textDirection: TextDirection.ltr,
-      children: [
-        // Index 0: the app itself. Never remounted by x-ray toggles.
-        widget.child,
-        // Index 1: only the panel (or launcher) rectangle — gestures
-        // outside it fall through to the app.
-        if (_panelOpen)
-          _panelPosition(screen, position)
-        else
-          _launcherPosition(position),
-      ],
+        final position = plugin.config.overlayPosition;
+        // Size the panel from live constraints so window resizes and
+        // orientation changes never leave it at stale dimensions.
+        return LayoutBuilder(
+          builder: (context, constraints) {
+            final screen = Size(constraints.maxWidth, constraints.maxHeight);
+            return Stack(
+              // XRayHost usually sits *above* MaterialApp, where no ambient
+              // Directionality exists yet.
+              textDirection: TextDirection.ltr,
+              children: [
+                // Index 0: the app itself. Never remounted by x-ray toggles.
+                widget.child,
+                // Index 1: only the panel (or launcher) rectangle — gestures
+                // outside it fall through to the app.
+                if (_panelOpen)
+                  _panelPosition(screen, position)
+                else
+                  _launcherPosition(context, position),
+              ],
+            );
+          },
+        );
+      },
     );
   }
 }

--- a/lib/src/plugins/xray/widgets/xray_overlay.dart
+++ b/lib/src/plugins/xray/widgets/xray_overlay.dart
@@ -26,16 +26,9 @@ class XRayOverlay extends StatefulWidget {
 }
 
 class _XRayOverlayState extends State<XRayOverlay> {
+  // Escape works once the panel has focus (e.g. via tap); the panel never
+  // grabs focus on its own, so the app underneath keeps the keyboard.
   late final FocusNode _focusNode = FocusNode();
-
-  @override
-  void initState() {
-    super.initState();
-    // Grab focus so Escape works without clicking into the panel first.
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) _focusNode.requestFocus();
-    });
-  }
 
   @override
   void dispose() {
@@ -49,7 +42,6 @@ class _XRayOverlayState extends State<XRayOverlay> {
 
     return Focus(
       focusNode: _focusNode,
-      autofocus: true,
       onKeyEvent: (node, event) {
         if (event is KeyDownEvent &&
             event.logicalKey == LogicalKeyboardKey.escape) {
@@ -70,9 +62,11 @@ class _XRayOverlayState extends State<XRayOverlay> {
             _Header(onClose: widget.onClose),
             const Divider(height: 1, color: Color(0xFF2A2D34)),
             Expanded(
-              child: ValueListenableBuilder<int>(
-                valueListenable: plugin.revision,
-                builder: (context, _, __) =>
+              child: AnimatedBuilder(
+                // Element-registry changes AND bridge endpoint-catalog
+                // changes both rebuild the section list.
+                animation: plugin.contentRevision,
+                builder: (context, _) =>
                     _SectionList(config: widget.config, plugin: plugin),
               ),
             ),

--- a/lib/src/plugins/xray/xray_plugin.dart
+++ b/lib/src/plugins/xray/xray_plugin.dart
@@ -112,6 +112,13 @@ class XRayPlugin {
   /// registry, so a mounted overlay rebuilds with fresh data.
   final ValueNotifier<int> revision = ValueNotifier<int>(0);
 
+  /// Rebuild trigger for overlay *content*: fires on element-registry
+  /// changes (own [revision]) and on bridge endpoint-catalog changes, so
+  /// endpoints registered after the overlay mounts still appear without
+  /// waiting for an unrelated rebuild.
+  Listenable get contentRevision =>
+      Listenable.merge([revision, ZuraffaApiBridge.revision]);
+
   /// Test hook for the "release mode is a no-op" acceptance case: when set
   /// to `true`, [enable] behaves exactly as if `kReleaseMode` were true.
   /// Never set this in app code.
@@ -130,6 +137,9 @@ class XRayPlugin {
     if (kReleaseMode || debugSimulateReleaseMode) return;
     _enabled = true;
     _config = config;
+    // Notify mounted hosts/overlays so late enable() calls take effect
+    // without waiting for an unrelated rebuild.
+    revision.value++;
     developer.log(
       'XRayPlugin enabled '
       '(useCases: ${config.useCases}, '
@@ -141,6 +151,7 @@ class XRayPlugin {
   /// Disable x-ray (drops the overlay). Mostly useful for tests.
   void disable() {
     _enabled = false;
+    revision.value++;
   }
 
   /// The live endpoint catalog, read straight from [ZuraffaApiBridge] so


### PR DESCRIPTION
🪄 **Autofix (Beta)** — resolves all unresolved review comments from #152, mirroring CodeRabbit's *"Create a new PR with the fixes"* flow (the original PR was authored by @arrrrny, so fixes land on a new branch instead of a direct commit).

## Fixed

| File | Finding | Fix |
|---|---|---|
| `example/lib/main.dart` | 🟠 `runApp` raced `setupDependencies` — `XRayHost`'s first build could run before `enableXRay()`, leaving the overlay permanently hidden | `_initializeBridge()` (which calls `Zuraffa.enableXRay`) now runs before `runApp` in both the `then` and `catchError` branches |
| `lib/src/plugins/xray/widgets/xray_host.dart` | 🟠 Late `enable()`/`disable()` calls were silent no-ops (state read once at build); panel sized from a stale `View.of` fallback; launcher's `SafeArea` crashed with no `MediaQuery` ancestor | Rebuilds on `plugin.revision`; sizes the panel from live `LayoutBuilder` constraints; `_mediaQueryScope` wraps the launcher in `MediaQuery.fromView` when no ambient query exists |
| `lib/src/plugins/xray/widgets/xray_overlay.dart` | 🟠 Endpoints/elements registered after the overlay mounted never appeared; `autofocus` + post-frame `requestFocus` stole keyboard focus from the app | Section list rebuilds on `plugin.contentRevision`; autofocus and the post-frame focus grab removed — Escape still works once the panel has focus |
| `lib/src/plugins/xray/xray_plugin.dart` | 🟠 (supporting) `enable()`/`disable()` never notified listeners | `revision.value++` in both; new `contentRevision` merges the element registry with the bridge endpoint catalog |
| `lib/src/core/api_bridge.dart` | 🟠 (supporting) No signal when the endpoint catalog changed | Static `ValueNotifier<int> revision`, bumped on `registerEndpoint` and `resetForTesting` |
| `lib/src/plugins/xray/widgets/xray_button.dart` | 🟡 `_guarded` swallowed errors silently; typed form coerced unparseable int/double input to `0`/`0.0` and submitted; unpicked `DateTime` silently defaulted to `now()` | Catch logs the stack via `debugPrint` and snacks the error; submit is blocked with a visible validation error on unparseable numeric input; the `DateTime` tile now states the `now()` default |

## Skipped

- `xray_button.dart` `_guarded` catch (zikzak-ai thread) — already fixed by e5506c1 on the source branch; superseded by the equivalent coderabbitai variant applied here.

Base: `feat/xray-plugin` @ e5506c1 · Branch: `coderabbit-fixes/pr-152`

---
*Generated by the coderabbit skill `--fix` mode.*