### PR TITLE
feat: add zuraffa_setup MCP tool and config_init dependency checks

### DIFF
--- a/bin/zuraffa_mcp_server.dart
+++ b/bin/zuraffa_mcp_server.dart
@@ -1474,12 +1474,21 @@ TIP: Use dry_run=true to preview the changes without modifying pubspec.yaml.''',
     final output = StringBuffer('Zuraffa setup\n');
     for (final command in commands) {
       output.writeln('\n\$ dart ${command.join(' ')}');
-      final result = await Process.run(
-        dartPath,
-        command,
-        workingDirectory: projectDir,
-        environment: environment,
-      );
+      final ProcessResult result;
+      try {
+        result = await Process.run(
+          dartPath,
+          command,
+          workingDirectory: projectDir,
+          environment: environment,
+        ).timeout(Duration(seconds: 120));
+      } on TimeoutException {
+        output.writeln(
+          '\n❌ dart ${command.join(' ')} timed out after 120 seconds.',
+        );
+        _cachedCli = null;
+        return output.toString();
+      }
       // pub reports progress on stderr — surface both streams.
       final details = [
         result.stdout.toString().trim(),
@@ -1496,6 +1505,7 @@ TIP: Use dry_run=true to preview the changes without modifying pubspec.yaml.''',
           'dependency_overrides for the conflicting packages to pubspec.yaml, '
           'run `dart pub get`, then re-run zuraffa_setup.',
         );
+        _cachedCli = null;
         return output.toString();
       }
     }

--- a/bin/zuraffa_mcp_server.dart
+++ b/bin/zuraffa_mcp_server.dart
@@ -256,6 +256,7 @@ class ZuraffaMcpServer {
       _configSetToolDefinition(),
       _graphqlToolDefinition(),
       _doctorToolDefinition(),
+      _setupToolDefinition(),
     ];
 
     // Add plugin tools dynamically
@@ -615,7 +616,7 @@ All v5 generation uses the fixed lib/src and lib/src/domain layout.''',
           result = await _runEntityListCommand(args);
           break;
         case 'zuraffa_config_init':
-          result = await _runConfigCommand(['init', ...?_configArgs(args)]);
+          result = await _runConfigInitCommand(args);
           break;
         case 'zuraffa_config_show':
           result = await _runConfigCommand(['show']);
@@ -635,6 +636,9 @@ All v5 generation uses the fixed lib/src and lib/src/domain layout.''',
           break;
         case 'zuraffa_doctor':
           result = await _runDoctorCommand(args);
+          break;
+        case 'zuraffa_setup':
+          result = await _runSetupCommand(args);
           break;
         default:
           if (toolName.startsWith('zuraffa_')) {
@@ -1064,6 +1068,52 @@ May take 30-60 seconds depending on project size.''',
     return await _runZuraffaProcess(['config', ...subArgs]);
   }
 
+  /// Run config init, then report any missing code-generation dependencies
+  /// so the gap surfaces now — not when entity creation fails later.
+  Future<String> _runConfigInitCommand(Map<String, dynamic> args) async {
+    final initOutput = await _runConfigCommand(['init', ...?_configArgs(args)]);
+    return '${initOutput.trimRight()}\n\n${await _dependencyReport()}';
+  }
+
+  /// Detect zuraffa code-generation dependencies missing from the current
+  /// project's pubspec.yaml. Names use the `dev:` prefix for packages that
+  /// belong in dev_dependencies.
+  Future<List<String>> _missingCodegenDeps() async {
+    final pubspecFile = File('${Directory.current.path}/pubspec.yaml');
+    if (!await pubspecFile.exists()) return const [];
+    final content = await pubspecFile.readAsString();
+    return [
+      if (!content.contains('zuraffa:')) 'zuraffa',
+      if (!content.contains('zorphy_annotation:')) 'zorphy_annotation',
+      if (!content.contains('build_runner:')) 'dev:build_runner',
+    ];
+  }
+
+  /// Human-readable dependency status with actionable remediation.
+  Future<String> _dependencyReport() async {
+    final missing = await _missingCodegenDeps();
+    if (missing.isEmpty) {
+      return 'Dependency check: ✅ zuraffa, zorphy_annotation and build_runner all present.';
+    }
+    final runtime = missing.where((d) => !d.startsWith('dev:')).toList();
+    final dev = missing.where((d) => d.startsWith('dev:')).toList();
+    final buffer = StringBuffer('Dependency check: ⚠️ missing packages:\n');
+    for (final dep in missing) {
+      buffer.writeln('  - $dep');
+    }
+    buffer.writeln('\nRun the zuraffa_setup tool to add them automatically, or:');
+    if (runtime.isNotEmpty) {
+      buffer.writeln('  dart pub add ${runtime.join(' ')}');
+    }
+    if (dev.isNotEmpty) {
+      buffer.writeln('  dart pub add ${dev.join(' ')}');
+    }
+    buffer.write(
+      'Without these, entity generation and builds will fail — run zuraffa_doctor for details.',
+    );
+    return buffer.toString();
+  }
+
   /// Run the graphql command
   Future<String> _runGraphqlCommand(Map<String, dynamic> args) async {
     final List<String> cliArgs = ['graphql', '--url=${args["url"]}'];
@@ -1358,6 +1408,127 @@ Use quick for fast diagnostics, full for troubleshooting.''',
     return output.toString();
   }
 
+  /// Setup tool definition
+  Map<String, dynamic> _setupToolDefinition() {
+    return {
+      'name': 'zuraffa_setup',
+      'description': '''Add zuraffa and its required code-generation dependencies (zorphy_annotation, build_runner) to the current project's pubspec.yaml via dart pub add.
+
+Use this FIRST when other zuraffa tools report that the zfa CLI cannot be found — the MCP server needs zuraffa in the project (or a global zfa activation) before it can execute commands. This solves the chicken-and-egg onboarding problem.
+
+TIP: Use dry_run=true to preview the changes without modifying pubspec.yaml.''',
+      'inputSchema': {
+        'type': 'object',
+        'properties': {
+          'dry_run': {
+            'type': 'boolean',
+            'description':
+                'Preview the dependency changes without modifying pubspec.yaml',
+          },
+        },
+      },
+    };
+  }
+
+  /// Add zuraffa and its code-generation dependencies to the current
+  /// project. Implemented server-side (not delegated to the zfa CLI)
+  /// precisely because it serves the case where no CLI is resolvable yet.
+  Future<String> _runSetupCommand(Map<String, dynamic> args) async {
+    final dryRun = args['dry_run'] == true;
+    final projectDir = Directory.current.path;
+
+    final pubspecFile = File('$projectDir/pubspec.yaml');
+    if (!await pubspecFile.exists()) {
+      return 'Error: No pubspec.yaml found in $projectDir.\n'
+          'Create a project first (e.g. `flutter create my_app`) and run '
+          'zuraffa_setup from the project root.';
+    }
+
+    final dartPath = await _findDartExecutable();
+    if (dartPath == null) {
+      return 'Error: dart executable not found. Install the Flutter/Dart SDK '
+          'and make sure dart is in PATH, then re-run zuraffa_setup.';
+    }
+
+    final missing = await _missingCodegenDeps();
+    if (missing.isEmpty) {
+      return '✅ Setup already complete — zuraffa, zorphy_annotation and '
+          'build_runner are all present in pubspec.yaml.';
+    }
+
+    final runtimeDeps = missing.where((d) => !d.startsWith('dev:')).toList();
+    final devDeps = missing.where((d) => d.startsWith('dev:')).toList();
+    final commands = <List<String>>[
+      if (runtimeDeps.isNotEmpty) ['pub', 'add', ...runtimeDeps],
+      if (devDeps.isNotEmpty) ['pub', 'add', ...devDeps],
+    ];
+
+    if (dryRun) {
+      final planned = commands.map((c) => 'dart ${c.join(' ')}').join('\n  ');
+      return 'Dry run — would execute:\n  $planned';
+    }
+
+    final environment = Map<String, String>.from(Platform.environment)
+      ..addAll(_pathWithDart(dartPath));
+
+    final output = StringBuffer('Zuraffa setup\n');
+    for (final command in commands) {
+      output.writeln('\n\$ dart ${command.join(' ')}');
+      final result = await Process.run(
+        dartPath,
+        command,
+        workingDirectory: projectDir,
+        environment: environment,
+      );
+      // pub reports progress on stderr — surface both streams.
+      final details = [
+        result.stdout.toString().trim(),
+        result.stderr.toString().trim(),
+      ].where((s) => s.isNotEmpty).join('\n');
+      if (details.isNotEmpty) output.writeln(details);
+      if (result.exitCode != 0) {
+        output.writeln(
+          '\n❌ dart ${command.join(' ')} failed (exit ${result.exitCode}).',
+        );
+        output.write(
+          'This is usually a version conflict with SDK-pinned packages '
+          '(commonly meta or analyzer, pinned by flutter_test). Add '
+          'dependency_overrides for the conflicting packages to pubspec.yaml, '
+          'run `dart pub get`, then re-run zuraffa_setup.',
+        );
+        return output.toString();
+      }
+    }
+
+    // The project now depends on zuraffa — re-resolve the CLI so the
+    // project-pinned `dart run zuraffa:zfa` is picked up.
+    _cachedCli = null;
+
+    // Pub may resolve an older zuraffa when SDK-pinned packages constrain
+    // version solving — an outdated CLI can lack commands the MCP tools
+    // expect, so flag it with the way out.
+    final stale = RegExp(
+      r'zuraffa\s+(\S+)\s+\((\S+)\s+available\)',
+    ).firstMatch(output.toString());
+    if (stale != null && stale.group(1) != stale.group(2)) {
+      output.writeln(
+        '\n⚠️ zuraffa resolved to ${stale.group(1)}, but ${stale.group(2)} is '
+        'available — version solving was limited by SDK-pinned packages '
+        '(commonly meta or analyzer via flutter_test).',
+      );
+      output.writeln(
+        'An older CLI may not support every MCP tool. To use the latest: '
+        'add dependency_overrides for the conflicting packages to '
+        "pubspec.yaml, then run `dart pub add 'zuraffa:^${stale.group(2)}'`.",
+      );
+    }
+
+    output.writeln('\n✅ Setup complete. Next steps:');
+    output.writeln('  1. zuraffa_config_init — create .zfa.json');
+    output.write('  2. zuraffa_entity_create — define your entities');
+    return output.toString();
+  }
+
   /// Cached zfa CLI invocation (resolved once, reused)
   _ResolvedCli? _cachedCli;
 
@@ -1406,7 +1577,10 @@ Use quick for fast diagnostics, full for troubleshooting.''',
         return 'Error (exit ${result.exitCode}): $details';
       }
 
-      return output.isNotEmpty ? output : 'Success';
+      // Some CLIs (dart pub, flutter) print real output to stderr even on
+      // success — surface it instead of a bare 'Success'.
+      if (output.isNotEmpty) return output;
+      return error.isNotEmpty ? error : 'Success';
     } catch (e, stack) {
       stderr.writeln('Process error: $e\n$stack');
       return 'Error: $e';

--- a/bin/zuraffa_mcp_server.dart
+++ b/bin/zuraffa_mcp_server.dart
@@ -1480,21 +1480,35 @@ TIP: Use dry_run=true to preview the changes without modifying pubspec.yaml.''',
     final output = StringBuffer('Zuraffa setup\n');
     for (final command in commands) {
       output.writeln('\n\$ dart ${command.join(' ')}');
-      final ProcessResult result;
-      try {
-        result = await Process.run(
-          dartPath,
-          command,
-          workingDirectory: projectDir,
-          environment: environment,
-        ).timeout(Duration(seconds: 120));
-      } on TimeoutException {
+      var timedOut = false;
+      final process = await Process.start(
+        dartPath,
+        command,
+        workingDirectory: projectDir,
+        environment: environment,
+      );
+      final timer = Timer(const Duration(seconds: 120), () {
+        timedOut = true;
+        process.kill();
+      });
+      final stdoutBuf = StringBuffer();
+      final stderrBuf = StringBuffer();
+      process.stdout.transform(utf8.decoder).listen(stdoutBuf.write);
+      process.stderr.transform(utf8.decoder).listen(stderrBuf.write);
+      final exitCode = await process.exitCode.whenComplete(timer.cancel);
+      if (timedOut) {
         output.writeln(
-          '\n❌ dart ${command.join(' ')} timed out after 120 seconds.',
+          '\n❌ dart ${command.join(' ')} timed out after 120 seconds and was killed.',
         );
         _cachedCli = null;
         return output.toString();
       }
+      final result = ProcessResult(
+        process.pid,
+        exitCode,
+        stdoutBuf.toString(),
+        stderrBuf.toString(),
+      );
       // pub reports progress on stderr — surface both streams.
       final details = [
         result.stdout.toString().trim(),

--- a/bin/zuraffa_mcp_server.dart
+++ b/bin/zuraffa_mcp_server.dart
@@ -1091,6 +1091,12 @@ May take 30-60 seconds depending on project size.''',
 
   /// Human-readable dependency status with actionable remediation.
   Future<String> _dependencyReport() async {
+    final pubspecFile = File('${Directory.current.path}/pubspec.yaml');
+    if (!await pubspecFile.exists()) {
+      return 'Dependency check: ⚠️ no pubspec.yaml found in '
+          '${Directory.current.path} — cannot verify code-generation '
+          'dependencies. Run from a Flutter/Dart project root.';
+    }
     final missing = await _missingCodegenDeps();
     if (missing.isEmpty) {
       return 'Dependency check: ✅ zuraffa, zorphy_annotation and build_runner all present.';

--- a/test/regression/v5_pipeline_contract_test.dart
+++ b/test/regression/v5_pipeline_contract_test.dart
@@ -63,6 +63,28 @@ void main() {
       );
     });
 
+    test('MCP server never falls back to echoing commands', () {
+      final content = readText('bin/zuraffa_mcp_server.dart');
+      // The silent echo fallback made tools pretend to succeed (#150, #156).
+      expect(content, isNot(contains("_cachedExecutable = 'echo'")));
+      expect(content, contains('Never echo'));
+    });
+
+    test('MCP server advertises zuraffa_setup and adds deps via pub add', () {
+      final content = readText('bin/zuraffa_mcp_server.dart');
+      expect(content, contains("'name': 'zuraffa_setup'"));
+      expect(content, contains("case 'zuraffa_setup':"));
+      // Setup exists for the case where no zfa CLI is resolvable yet, so it
+      // cannot delegate to the CLI — it must run `dart pub add` directly.
+      expect(content, contains("'pub', 'add'"));
+    });
+
+    test('MCP config_init reports missing code-gen dependencies', () {
+      final content = readText('bin/zuraffa_mcp_server.dart');
+      expect(content, contains('_runConfigInitCommand'));
+      expect(content, contains('Dependency check'));
+    });
+
     test('example .zfa.json uses v5 config shape', () {
       final content = readText('example/.zfa.json');
       final json = jsonDecode(content) as Map<String, dynamic>;

--- a/website/docs/features/mcp-server.md
+++ b/website/docs/features/mcp-server.md
@@ -32,6 +32,14 @@ zuraffa_mcp_server
 
 ## Available tools
 
+### `zuraffa_setup`
+
+Onboarding helper: adds `zuraffa`, `zorphy_annotation`, and `dev:build_runner`
+to the current project's `pubspec.yaml` via `dart pub add`. Use it when other
+tools report that the zfa CLI cannot be found — the MCP server needs zuraffa
+in the project (or a global activation) before it can execute commands.
+Supports `dry_run` to preview the changes.
+
 ### `zuraffa_make`
 
 This tool should follow the same v5 contract as the CLI docs:


### PR DESCRIPTION
Closes #156

## Summary

Follow-up to the hotel-booking Zuraffa-only MCP trial (PASS with gaps). The trial ran against commit c504635 — three of its six documented gaps were already fixed on `development` by 6fcd71d (Fixes #150). This PR closes out the remaining onboarding gaps and adds a regression contract so they stay closed.

### Already fixed on `development` (re-verified at runtime here)

- **Silent `echo` fallback** — tools now return an actionable "zuraffa CLI (zfa) not found" error
- **Bare `dart` resolution** — dart is probed via PATH → flutter-relative → `FLUTTER_ROOT` → common install locations (`/opt/flutter/bin/dart`)
- **Shell-script `zfa` rejected** — pub global activation scripts in PATH are now used, with dart injected into the child PATH
- **Masked CLI errors** — non-zero exits now surface stdout *and* stderr

### New in this PR

- **`zuraffa_setup` MCP tool** (trial top-3 recommendation #2): adds `zuraffa`, `zorphy_annotation`, and `dev:build_runner` to the project's `pubspec.yaml` via `dart pub add`. Implemented server-side (not delegated to the zfa CLI) precisely because it serves the case where no CLI is resolvable yet — the chicken-and-egg blocker from the trial. Supports `dry_run`, warns when pub resolves an older zuraffa due to SDK-pinned packages (with the `dependency_overrides` way out), and resets the cached CLI resolution afterwards.
- **`zuraffa_config_init` dependency report** (trial gap 6): after init, the output includes a dependency check listing missing code-gen packages with remediation (`zuraffa_setup` or explicit `dart pub add` commands), so the gap surfaces at init time instead of when entity creation fails deep in the pipeline.
- **Success-path stderr passthrough** (trial gap 5 polish): CLIs like `dart pub`/`flutter` print real output to stderr on exit 0; it is now returned instead of a bare "Success".
- **Regression contract tests**: no echo fallback, `zuraffa_setup` advertised and implemented via `dart pub add`, config_init dependency report.
- **Docs**: `zuraffa_setup` added to the MCP server feature page.

## Verification

Reproduced the trial's hostile environment — fresh `flutter create` project, MCP server launched with `dart` **not** in PATH and no global `zfa` activation:

1. `zuraffa_config_init` → honest CLI-not-found error + dependency report (no silent echo)
2. `zuraffa_setup` (`dry_run`, then real) → deps added; the tool flagged zuraffa resolving to 4.0.10, and following its own guidance (`dependency_overrides` + `dart pub add 'zuraffa:^5.6.2'`) resolved 5.6.2
3. `zuraffa_config_init` → `.zfa.json` created, dependency check ✅
4. `zuraffa_entity_create Hotel` → entity scaffolded at `lib/src/domain/entities/hotel/hotel.dart`

Gates:

- `dart analyze bin/zuraffa_mcp_server.dart` — no issues (whole-repo analyze shows only the 41 pre-existing example infos, identical to the `development` baseline)
- `flutter test` — **691 tests, all passed**, including the 3 new regression contract tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `zuraffa_setup` tool to help configure required project dependencies.
  * Supports previewing changes with `dry_run` before modifying the project.
  * Provides clear next steps after setup completes.
* **Bug Fixes**
  * Improved command results so successful operations return useful output or status messages.
  * Added timeout handling for commands that do not complete promptly.
* **Documentation**
  * Documented the new setup tool and its dependency configuration workflow.
* **Improvements**
  * Configuration initialization now reports missing code-generation dependencies and suggests remediation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->