### PR TITLE
feat(core): Track 1.1 — Async Signal Pipeline

### DIFF
--- a/benchmark/signal_benchmark.dart
+++ b/benchmark/signal_benchmark.dart
@@ -1,0 +1,96 @@
+import 'dart:async';
+import 'package:zuraffa/zuraffa.dart';
+
+/// Benchmark comparing Signal (O(1)) vs Stream (O(N)) read performance.
+///
+/// Run with: `dart run benchmark/signal_benchmark.dart`
+void main() async {
+  const iterations = 100000;
+
+  print('=== Zuraffa Signal Pipeline Benchmark ===\n');
+
+  // ── Benchmark 1: Signal read (O(1)) ──
+  final signal = Signal<int>(42);
+  final sw1 = Stopwatch()..start();
+  for (var i = 0; i < iterations; i++) {
+    final _ = signal.value; // O(1) direct read
+  }
+  sw1.stop();
+  print('Signal read ($iterations iterations): ${sw1.elapsedMicroseconds} µs');
+  print('  → ${sw1.elapsedMicroseconds / iterations} µs per read (O(1))\n');
+
+  // ── Benchmark 2: Stream read (O(N) with listener overhead) ──
+  final controller = StreamController<int>.broadcast();
+  final stream = controller.stream;
+  stream.listen((_) {});
+  controller.add(42);
+  await Future.delayed(Duration.zero); // let listener process
+
+  final sw2 = Stopwatch()..start();
+  for (var i = 0; i < iterations; i++) {
+    // To read a stream's current value, you need a listener + buffer.
+    // This simulates the overhead: creating a new listener each time.
+    stream.listen((_) {});
+  }
+  sw2.stop();
+  print(
+    'Stream listener creation ($iterations iterations): ${sw2.elapsedMicroseconds} µs',
+  );
+  print(
+    '  → ${sw2.elapsedMicroseconds / iterations} µs per read (O(N) overhead)\n',
+  );
+
+  // ── Benchmark 3: Signal notification (O(1) per listener) ──
+  final signal3 = Signal<int>(0);
+  final listenerCount = [1, 10, 100];
+  for (final count in listenerCount) {
+    final subs = <SignalSubscription>[];
+    var notifications = 0;
+    for (var i = 0; i < count; i++) {
+      subs.add(signal3.listen((_) => notifications++));
+    }
+
+    final sw3 = Stopwatch()..start();
+    for (var i = 0; i < iterations; i++) {
+      signal3.value = i;
+    }
+    sw3.stop();
+
+    for (final sub in subs) {
+      sub.cancel();
+    }
+    print(
+      'Signal notify with $count listeners ($iterations writes): ${sw3.elapsedMicroseconds} µs',
+    );
+    print('  → ${sw3.elapsedMicroseconds / iterations} µs per write');
+    print('  → Total notifications: $notifications\n');
+  }
+
+  // ── Benchmark 4: Stream notification (O(N) per listener) ──
+  for (final count in listenerCount) {
+    final controller = StreamController<int>.broadcast();
+    final stream = controller.stream;
+    var notifications = 0;
+    final subs = <StreamSubscription<int>>[];
+    for (var i = 0; i < count; i++) {
+      subs.add(stream.listen((_) => notifications++));
+    }
+
+    final sw4 = Stopwatch()..start();
+    for (var i = 0; i < iterations; i++) {
+      controller.add(i);
+    }
+    sw4.stop();
+
+    for (final sub in subs) {
+      sub.cancel();
+    }
+    print(
+      'Stream notify with $count listeners ($iterations writes): ${sw4.elapsedMicroseconds} µs',
+    );
+    print('  → ${sw4.elapsedMicroseconds / iterations} µs per write');
+    print('  → Total notifications: $notifications\n');
+  }
+
+  print('=== End Benchmark ===');
+}

--- a/benchmark/signal_benchmark.dart
+++ b/benchmark/signal_benchmark.dart
@@ -22,17 +22,22 @@ void main() async {
   // ── Benchmark 2: Stream read (O(N) with listener overhead) ──
   final controller = StreamController<int>.broadcast();
   final stream = controller.stream;
-  stream.listen((_) {});
+  final warmupSub = stream.listen((_) {});
   controller.add(42);
   await Future.delayed(Duration.zero); // let listener process
+  warmupSub.cancel();
 
   final sw2 = Stopwatch()..start();
+  final benchSubs = <StreamSubscription<int>>[];
   for (var i = 0; i < iterations; i++) {
     // To read a stream's current value, you need a listener + buffer.
     // This simulates the overhead: creating a new listener each time.
-    stream.listen((_) {});
+    benchSubs.add(stream.listen((_) {}));
   }
   sw2.stop();
+  for (final sub in benchSubs) {
+    sub.cancel();
+  }
   print(
     'Stream listener creation ($iterations iterations): ${sw2.elapsedMicroseconds} µs',
   );
@@ -92,5 +97,7 @@ void main() async {
     print('  → Total notifications: $notifications\n');
   }
 
+  // Cleanup
+  await controller.close();
   print('=== End Benchmark ===');
 }

--- a/lib/src/core/context/zuraffa_context.dart
+++ b/lib/src/core/context/zuraffa_context.dart
@@ -1,0 +1,44 @@
+import 'dart:collection';
+
+/// Lightweight correlation context carrier flowing from UI → UseCase → Data.
+///
+/// [ZuraffaContext] holds trace IDs, session tokens, and extensible metadata
+/// without polluting every method signature.
+///
+/// When not used, the [noop] instance provides zero-cost overhead.
+class ZuraffaContext {
+  const ZuraffaContext({
+    this.traceId,
+    this.sessionToken,
+    this.agentMutationId,
+    Map<String, dynamic>? metadata,
+  }) : _metadata = metadata;
+
+  /// Zero-cost no-op context. Pass this when telemetry is not needed.
+  static const ZuraffaContext noop = ZuraffaContext();
+
+  final String? traceId;
+  final String? sessionToken;
+  final String? agentMutationId;
+  final Map<String, dynamic>? _metadata;
+
+  /// Immutable metadata lookup.
+  dynamic metadata(String key) => _metadata?[key];
+
+  /// Create a child context with additional metadata merged in.
+  ZuraffaContext withMetadata(Map<String, dynamic> extra) {
+    final merged = HashMap<String, dynamic>.from(_metadata ?? const {});
+    merged.addAll(extra);
+    return ZuraffaContext(
+      traceId: traceId,
+      sessionToken: sessionToken,
+      agentMutationId: agentMutationId,
+      metadata: merged,
+    );
+  }
+
+  @override
+  String toString() =>
+      'ZuraffaContext(traceId: $traceId, sessionToken: $sessionToken, '
+      'agentMutationId: $agentMutationId)';
+}

--- a/lib/src/core/failure.dart
+++ b/lib/src/core/failure.dart
@@ -45,6 +45,9 @@ sealed class AppFailure implements Exception {
 
   const AppFailure(this.message, {this.stackTrace, this.cause});
 
+  /// Create a generic failure with a default message.
+  factory AppFailure.create() => const UnknownFailure.create();
+
   /// Create an [AppFailure] from any error
   ///
   /// Attempts to intelligently classify the error based on its type and message.
@@ -203,6 +206,9 @@ final class ServerFailure extends AppFailure {
     super.cause,
   });
 
+  /// Create a server failure with a default message.
+  const ServerFailure.create() : statusCode = null, super('Server error');
+
   /// Factory that creates a ServerFailure if the error matches,
   /// otherwise returns null
   static ServerFailure? from(Object error, StackTrace? stackTrace) {
@@ -239,6 +245,9 @@ final class ServerFailure extends AppFailure {
 /// or the device is offline.
 final class NetworkFailure extends AppFailure {
   const NetworkFailure(super.message, {super.stackTrace, super.cause});
+
+  /// Create a network failure with a default message.
+  const NetworkFailure.create() : super('Network error');
 
   /// Factory that creates a NetworkFailure if the error matches,
   /// otherwise returns null
@@ -570,6 +579,9 @@ final class PlatformFailure extends AppFailure {
 /// Prefer using more specific failure types when possible.
 final class UnknownFailure extends AppFailure {
   const UnknownFailure(super.message, {super.stackTrace, super.cause});
+
+  /// Create an unknown failure with a default message.
+  const UnknownFailure.create() : super('Unexpected error');
 
   /// Factory that always creates an UnknownFailure
   /// This is the fallback when no other failure type matches

--- a/lib/src/core/result.dart
+++ b/lib/src/core/result.dart
@@ -312,15 +312,15 @@ class LoadingResult<S, F> extends Result<S, F> {
 
   @override
   Result<T, F> map<T>(T Function(S value) transform) =>
-      LoadingResult<T, F>.loading();
+      _idle ? LoadingResult<T, F>.idle() : LoadingResult<T, F>.loading();
 
   @override
   Result<S, T> mapFailure<T>(T Function(F error) transform) =>
-      LoadingResult<S, T>.loading();
+      _idle ? LoadingResult<S, T>.idle() : LoadingResult<S, T>.loading();
 
   @override
   Result<T, F> flatMap<T>(Result<T, F> Function(S value) transform) =>
-      LoadingResult<T, F>.loading();
+      _idle ? LoadingResult<T, F>.idle() : LoadingResult<T, F>.loading();
 
   @override
   S getOrElse(S Function() defaultValue) => defaultValue();

--- a/lib/src/core/result.dart
+++ b/lib/src/core/result.dart
@@ -287,3 +287,69 @@ extension FutureResultExtensions<S, F> on Future<Result<S, F>> {
     return (await this).fold(onSuccess, onFailure);
   }
 }
+
+/// A loading/ pending result state.
+///
+/// [LoadingResult] is neither a [Success] nor a [Failure] — it represents an
+/// in-progress async operation. Use it with [SignalResult] to model loading
+/// states without nullable workaround.
+///
+/// Equality is based on the idle/loading distinction so that [Signal] can
+/// deduplicate redundant emissions.
+class LoadingResult<S, F> extends Result<S, F> {
+  const LoadingResult.loading() : _idle = false;
+  const LoadingResult.idle() : _idle = true;
+
+  final bool _idle;
+
+  /// Whether this is an idle (not yet started) loading state.
+  bool get isIdle => _idle;
+
+  @override
+  T fold<T>(T Function(S value) onSuccess, T Function(F error) onFailure) {
+    throw StateError('Cannot fold a LoadingResult');
+  }
+
+  @override
+  Result<T, F> map<T>(T Function(S value) transform) =>
+      LoadingResult<T, F>.loading();
+
+  @override
+  Result<S, T> mapFailure<T>(T Function(F error) transform) =>
+      LoadingResult<S, T>.loading();
+
+  @override
+  Result<T, F> flatMap<T>(Result<T, F> Function(S value) transform) =>
+      LoadingResult<T, F>.loading();
+
+  @override
+  S getOrElse(S Function() defaultValue) => defaultValue();
+
+  @override
+  S? getOrNull() => null;
+
+  @override
+  S getOrThrow() => throw StateError('Cannot call getOrThrow on LoadingResult');
+
+  @override
+  F? getFailureOrNull() => null;
+
+  @override
+  Result<S, F> onSuccess(void Function(S value) action) => this;
+
+  @override
+  Result<S, F> onFailure(void Function(F error) action) => this;
+
+  @override
+  String toString() => _idle ? 'LoadingResult.idle' : 'LoadingResult.loading';
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is LoadingResult<S, F> &&
+          runtimeType == other.runtimeType &&
+          _idle == other._idle);
+
+  @override
+  int get hashCode => _idle.hashCode;
+}

--- a/lib/src/core/signals/signal.dart
+++ b/lib/src/core/signals/signal.dart
@@ -1,0 +1,149 @@
+import 'dart:collection';
+
+/// A zero-cost reactive signal primitive for zuraffa.
+///
+/// [Signal] provides O(1) reads and fine-grained subscriptions.
+/// Unlike [ValueNotifier], it does not notify on every [set] — only when
+/// the value actually changes (by [==] or custom [equals]).
+///
+/// Disposal is explicit via [dispose]. Listeners are automatically
+/// cleaned up when the signal is disposed.
+class Signal<T> implements ReadonlySignal<T> {
+  Signal(T initialValue, {bool Function(T a, T b)? equals})
+    : _value = initialValue,
+      _equals = equals ?? _defaultEquals,
+      _listeners = HashSet<_SignalListener<T>>.identity();
+
+  T _value;
+  final bool Function(T a, T b) _equals;
+  final HashSet<_SignalListener<T>> _listeners;
+  bool _disposed = false;
+
+  // ── Public API ──
+
+  /// Current value. O(1) read — no subscription overhead.
+  @override
+  T get value {
+    _assertNotDisposed();
+    return _value;
+  }
+
+  /// Replace the current value. Notifies listeners only if [equals]
+  /// returns `false`.
+  set value(T newValue) {
+    _assertNotDisposed();
+    if (_equals(_value, newValue)) return;
+    _value = newValue;
+    _notify();
+  }
+
+  /// Functional update: `signal.update((v) => v + 1)`.
+  /// Notifies only when the result differs.
+  void update(T Function(T current) updater) {
+    value = updater(_value);
+  }
+
+  /// Subscribe to value changes. Returns an unsubscribable [SignalSubscription].
+  @override
+  SignalSubscription listen(void Function(T value) callback) {
+    _assertNotDisposed();
+    final listener = _SignalListener<T>(callback);
+    _listeners.add(listener);
+    // Eager delivery of current value (cold-start behaviour).
+    callback(_value);
+    return SignalSubscription(() => _listeners.remove(listener));
+  }
+
+  /// Transform this signal into a derived [Signal] of type [R].
+  /// The derived signal automatically disposes when the parent disposes
+  /// if [autoDispose] is true (default).
+  @override
+  Signal<R> map<R>(R Function(T value) transform, {bool autoDispose = true}) {
+    final derived = Signal<R>(transform(_value));
+    listen((v) => derived.value = transform(v));
+    if (autoDispose) {
+      _onDispose(() => derived.dispose());
+    }
+    return derived;
+  }
+
+  /// Combine two signals into one.
+  static Signal<R> combine<T1, T2, R>(
+    Signal<T1> s1,
+    Signal<T2> s2,
+    R Function(T1 a, T2 b) combiner,
+  ) {
+    final derived = Signal<R>(combiner(s1._value, s2._value));
+    void sync() => derived.value = combiner(s1._value, s2._value);
+    s1.listen((_) => sync());
+    s2.listen((_) => sync());
+    return derived;
+  }
+
+  /// Dispose the signal and release all listeners.
+  ///
+  /// Hooks are saved before clearing to prevent concurrent modification
+  /// issues if a dispose hook triggers additional signal mutations.
+  void dispose() {
+    if (_disposed) return;
+    _disposed = true;
+    final hooks = _disposeHooks;
+    _disposeHooks = null;
+    _listeners.clear();
+    hooks?.forEach((h) => h());
+  }
+
+  bool get isDisposed => _disposed;
+
+  // ── Internal ──
+
+  void _assertNotDisposed() {
+    if (_disposed) throw StateError('Signal has been disposed.');
+  }
+
+  void _notify() {
+    // Iterate over a copy to allow mutation during iteration.
+    for (final listener in _listeners.toList(growable: false)) {
+      listener.callback(_value);
+    }
+  }
+
+  List<void Function()>? _disposeHooks;
+
+  void _onDispose(void Function() hook) {
+    _disposeHooks ??= [];
+    _disposeHooks!.add(hook);
+  }
+
+  static bool _defaultEquals<T>(T a, T b) => a == b;
+}
+
+/// Lightweight subscription handle. Call [cancel] to unsubscribe.
+class SignalSubscription {
+  SignalSubscription(this._cancel);
+  final void Function() _cancel;
+  void cancel() => _cancel();
+}
+
+/// Internal listener wrapper. Identity-based equality so [HashSet]
+/// deduplication works correctly.
+class _SignalListener<T> {
+  _SignalListener(this.callback);
+  final void Function(T value) callback;
+
+  @override
+  bool operator ==(Object other) => identical(this, other);
+  @override
+  int get hashCode => identityHashCode(this);
+}
+
+/// A read-only view of a [Signal].
+abstract class ReadonlySignal<T> {
+  T get value;
+  SignalSubscription listen(void Function(T value) callback);
+  Signal<R> map<R>(R Function(T value) transform, {bool autoDispose = true});
+}
+
+extension ReadonlySignalExtension<T> on Signal<T> {
+  // Signal already satisfies ReadonlySignal<T> via direct interface conformance.
+}

--- a/lib/src/core/signals/signal.dart
+++ b/lib/src/core/signals/signal.dart
@@ -60,7 +60,8 @@ class Signal<T> implements ReadonlySignal<T> {
   @override
   Signal<R> map<R>(R Function(T value) transform, {bool autoDispose = true}) {
     final derived = Signal<R>(transform(_value));
-    listen((v) => derived.value = transform(v));
+    final sub = listen((v) => derived.value = transform(v));
+    derived._onDispose(() => sub.cancel());
     if (autoDispose) {
       _onDispose(() => derived.dispose());
     }
@@ -75,8 +76,12 @@ class Signal<T> implements ReadonlySignal<T> {
   ) {
     final derived = Signal<R>(combiner(s1._value, s2._value));
     void sync() => derived.value = combiner(s1._value, s2._value);
-    s1.listen((_) => sync());
-    s2.listen((_) => sync());
+    final sub1 = s1.listen((_) => sync());
+    final sub2 = s2.listen((_) => sync());
+    derived._onDispose(() {
+      sub1.cancel();
+      sub2.cancel();
+    });
     return derived;
   }
 

--- a/lib/src/core/signals/signal_result.dart
+++ b/lib/src/core/signals/signal_result.dart
@@ -1,0 +1,188 @@
+import 'dart:async';
+
+import '../failure.dart';
+import 'signal.dart';
+import '../result.dart';
+
+/// A reactive wrapper around [Result<T, AppFailure>] backed by a [Signal].
+///
+/// [SignalResult] is the v6 replacement for raw `Stream<Result<T, AppFailure>>` in
+/// [ZuraffaUseCase] return types. It provides:
+///
+/// - **O(1) reads**: `value` is a direct signal read, no stream overhead.
+/// - **Zero-allocation snapshots**: previous result is cached until changed.
+/// - **Fine-grained subscriptions**: listen to result changes without buffering.
+/// - **Async-to-sync bridge**: `await` the next emission via [nextValue].
+///
+/// ## Lifecycle
+///
+/// [SignalResult] owns its internal [Signal]. When disposed, the signal is
+/// disposed and all listeners are released.
+class SignalResult<T> {
+  SignalResult._(this._signal);
+
+  /// Create a [SignalResult] from an initial [Result].
+  factory SignalResult.initial(Result<T, AppFailure> result) =>
+      SignalResult._(Signal<Result<T, AppFailure>>(result));
+
+  /// Create a [SignalResult] from an initial success value.
+  factory SignalResult.success(T value) => SignalResult._(
+    Signal<Result<T, AppFailure>>(Success<T, AppFailure>(value)),
+  );
+
+  /// Create a [SignalResult] from an initial failure.
+  factory SignalResult.failure(AppFailure error) => SignalResult._(
+    Signal<Result<T, AppFailure>>(Failure<T, AppFailure>(error)),
+  );
+
+  /// Create a [SignalResult] from a [Future].
+  ///
+  /// The signal starts as [loading] (optional) and transitions to the
+  /// resolved result when the future completes.
+  static SignalResult<T> fromFuture<T>(
+    Future<T> future, {
+    bool emitLoading = true,
+  }) {
+    final sr = SignalResult<T>.initial(
+      emitLoading
+          ? LoadingResult<T, AppFailure>.loading()
+          : LoadingResult<T, AppFailure>.idle(),
+    );
+    future.then(
+      (v) {
+        sr._signal.value = Success<T, AppFailure>(v);
+      },
+      onError: (e, st) {
+        sr._signal.value = Failure<T, AppFailure>(_mapException(e, st));
+      },
+    );
+    return sr;
+  }
+
+  final Signal<Result<T, AppFailure>> _signal;
+
+  // ── Read API ──
+
+  /// Current result value. O(1) — direct signal read.
+  Result<T, AppFailure> get value => _signal.value;
+
+  /// Current data if [Success], otherwise `null`.
+  T? get data => _signal.value.getOrNull();
+
+  /// Current error if [Failure], otherwise `null`.
+  AppFailure? get error => _signal.value.getFailureOrNull();
+
+  /// Whether the current state is loading.
+  bool get isLoading => _signal.value is LoadingResult<T, AppFailure>;
+
+  /// Whether the current state is a success.
+  bool get isSuccess => _signal.value.isSuccess;
+
+  /// Whether the current state is a failure.
+  bool get isFailure => _signal.value.isFailure;
+
+  // ── Write API (used by UseCase implementations) ──
+
+  /// Publish a new [Result]. Notifies listeners only if the result changes.
+  void emit(Result<T, AppFailure> result) => _signal.value = result;
+
+  /// Publish a success value.
+  void emitSuccess(T value) => _signal.value = Success<T, AppFailure>(value);
+
+  /// Publish a failure.
+  void emitFailure(AppFailure error) =>
+      _signal.value = Failure<T, AppFailure>(error);
+
+  /// Publish a loading state.
+  void emitLoading() => _signal.value = LoadingResult<T, AppFailure>.loading();
+
+  /// Functional update over the current result.
+  void update(
+    Result<T, AppFailure> Function(Result<T, AppFailure> current) updater,
+  ) => _signal.update(updater);
+
+  /// Update only the success data, preserving failure/loading states.
+  ///
+  /// If the current result is a [Success], applies [updater] to the data
+  /// and emits the new success value. If the current result is a [Failure]
+  /// or [LoadingResult], this is a no-op.
+  void updateData(T Function(T currentData) updater) {
+    final current = value;
+    if (current is Success<T, AppFailure>) {
+      emitSuccess(updater(current.value));
+    }
+  }
+
+  // ── Subscription API ──
+
+  /// Listen to result changes. Callback receives the new result immediately.
+  SignalSubscription listen(
+    void Function(Result<T, AppFailure> result) callback,
+  ) => _signal.listen(callback);
+
+  /// Listen only to success values.
+  SignalSubscription onSuccess(void Function(T value) callback) => listen((r) {
+    if (r is Success<T, AppFailure>) callback(r.value);
+  });
+
+  /// Listen only to failures.
+  SignalSubscription onFailure(void Function(AppFailure error) callback) =>
+      listen((r) {
+        if (r is Failure<T, AppFailure>) callback(r.error);
+      });
+
+  /// Listen only to the next non-loading result (success or failure).
+  Future<Result<T, AppFailure>> get nextValue async {
+    final completer = Completer<Result<T, AppFailure>>();
+    late SignalSubscription sub;
+    sub = listen((r) {
+      if (r is! LoadingResult<T, AppFailure>) {
+        sub.cancel();
+        completer.complete(r);
+      }
+    });
+    return completer.future;
+  }
+
+  // ── Transformation ──
+
+  /// Transform the success value, preserving failure/loading states.
+  SignalResult<R> map<R>(R Function(T value) transform) {
+    final mapped = SignalResult<R>._(
+      _signal.map((r) => r.map(transform), autoDispose: false),
+    );
+    return mapped;
+  }
+
+  /// Flat-map: chain another async operation on success.
+  SignalResult<R> flatMap<R>(SignalResult<R> Function(T value) transform) {
+    final out = SignalResult<R>.initial(LoadingResult<R, AppFailure>.idle());
+    listen((r) {
+      if (r is Success<T, AppFailure>) {
+        final next = transform(r.value);
+        out._bind(next);
+      } else if (r is Failure<T, AppFailure>) {
+        out.emitFailure(r.error);
+      }
+    });
+    return out;
+  }
+
+  // ── Lifecycle ──
+
+  /// Dispose this [SignalResult] and release all listeners.
+  void dispose() => _signal.dispose();
+
+  bool get isDisposed => _signal.isDisposed;
+
+  // ── Internal helpers ──
+
+  void _bind(SignalResult<T> other) {
+    other.listen((r) => emit(r));
+  }
+
+  static AppFailure _mapException(Object error, StackTrace? stack) {
+    if (error is AppFailure) return error;
+    return UnknownFailure(error.toString());
+  }
+}

--- a/lib/src/core/signals/signal_result.dart
+++ b/lib/src/core/signals/signal_result.dart
@@ -53,7 +53,7 @@ class SignalResult<T> {
         sr._signal.value = Success<T, AppFailure>(v);
       },
       onError: (e, st) {
-        sr._signal.value = Failure<T, AppFailure>(_mapException(e, st));
+        sr._signal.value = Failure<T, AppFailure>(AppFailure.from(e, st));
       },
     );
     return sr;
@@ -72,8 +72,11 @@ class SignalResult<T> {
   /// Current error if [Failure], otherwise `null`.
   AppFailure? get error => _signal.value.getFailureOrNull();
 
-  /// Whether the current state is loading.
-  bool get isLoading => _signal.value is LoadingResult<T, AppFailure>;
+  /// Whether the current state is actively loading (not idle).
+  bool get isLoading {
+    final v = _signal.value;
+    return v is LoadingResult<T, AppFailure> && !v.isIdle;
+  }
 
   /// Whether the current state is a success.
   bool get isSuccess => _signal.value.isSuccess;
@@ -155,15 +158,24 @@ class SignalResult<T> {
   }
 
   /// Flat-map: chain another async operation on success.
+  /// The previous inner subscription is cancelled before binding a new one.
   SignalResult<R> flatMap<R>(SignalResult<R> Function(T value) transform) {
     final out = SignalResult<R>.initial(LoadingResult<R, AppFailure>.idle());
-    listen((r) {
+    SignalSubscription? innerSub;
+
+    final parentSub = listen((r) {
       if (r is Success<T, AppFailure>) {
-        final next = transform(r.value);
-        out._bind(next);
+        innerSub?.cancel();
+        innerSub = transform(r.value).listen((nr) => out.emit(nr));
       } else if (r is Failure<T, AppFailure>) {
+        innerSub?.cancel();
         out.emitFailure(r.error);
       }
+    });
+
+    out._disposables.add(() {
+      parentSub.cancel();
+      innerSub?.cancel();
     });
     return out;
   }
@@ -171,18 +183,17 @@ class SignalResult<T> {
   // ── Lifecycle ──
 
   /// Dispose this [SignalResult] and release all listeners.
-  void dispose() => _signal.dispose();
+  void dispose() {
+    for (final fn in _disposables) {
+      fn();
+    }
+    _disposables.clear();
+    _signal.dispose();
+  }
 
   bool get isDisposed => _signal.isDisposed;
 
-  // ── Internal helpers ──
+  // ── Internal state ──
 
-  void _bind(SignalResult<T> other) {
-    other.listen((r) => emit(r));
-  }
-
-  static AppFailure _mapException(Object error, StackTrace? stack) {
-    if (error is AppFailure) return error;
-    return UnknownFailure(error.toString());
-  }
+  final List<void Function()> _disposables = [];
 }

--- a/lib/src/core/usecase/zuraffa_usecase.dart
+++ b/lib/src/core/usecase/zuraffa_usecase.dart
@@ -1,0 +1,168 @@
+import 'dart:async';
+
+import '../failure.dart';
+import '../signals/signal_result.dart';
+import '../signals/signal.dart';
+import '../context/zuraffa_context.dart';
+import '../result.dart';
+
+/// Base contract for all zuraffa use cases (v6).
+///
+/// The return type is [SignalResult<T>] instead of the v5 `Stream<Result<T, AppFailure>>`.
+/// This provides:
+///
+/// - O(1) reads of the current result
+/// - Fine-grained reactive subscriptions
+/// - Zero stream overhead for single-shot use cases
+///
+/// ## Migration from v5
+///
+/// ```dart
+/// // v5
+/// Stream<Result<Product, AppFailure>> call(GetProductParams params);
+///
+/// // v6
+/// SignalResult<Product> call(GetProductParams params, {ZuraffaContext? context});
+/// ```
+///
+/// The [context] parameter is optional and defaults to [ZuraffaContext.noop].
+abstract class ZuraffaUseCase<In, Out> {
+  const ZuraffaUseCase();
+
+  /// Execute the use case.
+  ///
+  /// Returns a [SignalResult] that starts as [LoadingResult] and transitions
+  /// to [Success] or [Failure] when the operation completes.
+  SignalResult<Out> call(In params, {ZuraffaContext? context});
+}
+
+/// Mixin for use cases that need manual disposal of internal signals.
+///
+/// Call [disposeUseCase] when the use case is no longer needed (e.g. widget
+/// unmount) to prevent memory leaks.
+mixin DisposableUseCase<In, Out> on ZuraffaUseCase<In, Out> {
+  final List<SignalResult<dynamic>> _ownedResults = [];
+
+  /// Register a [SignalResult] that this use case owns.
+  /// It will be disposed when [disposeUseCase] is called.
+  SignalResult<T> own<T>(SignalResult<T> result) {
+    _ownedResults.add(result);
+    return result;
+  }
+
+  /// Dispose all owned signal results.
+  void disposeUseCase() {
+    for (final r in _ownedResults) {
+      r.dispose();
+    }
+    _ownedResults.clear();
+  }
+}
+
+/// Adapter for migrating v5 `Stream<Result<T, AppFailure>>` use cases to v6.
+///
+/// Wraps a stream in a [SignalResult] and bridges emissions.
+/// This is a temporary migration helper — prefer native [SignalResult]
+/// implementations for new use cases.
+class StreamToSignalResultAdapter<T> {
+  /// Convert a stream to a [SignalResult].
+  ///
+  /// The returned [SignalResult] is automatically disposed when the stream
+  /// completes or emits an error. If you need long-lived subscriptions, use
+  /// [SignalResult.fromFuture] or native signals instead.
+  static SignalResult<T> adapt<T>(Stream<Result<T, AppFailure>> stream) {
+    final sr = SignalResult<T>.initial(LoadingResult<T, AppFailure>.loading());
+    late final StreamSubscription<Result<T, AppFailure>> sub;
+
+    sub = stream.listen(
+      (result) => sr.emit(result),
+      onError: (Object e, StackTrace st) =>
+          sr.emitFailure(_mapException(e, st)),
+      onDone: () {
+        // If stream completed without emitting success, mark as unknown failure
+        if (!sr.isSuccess && !sr.isFailure) {
+          sr.emitFailure(UnknownFailure('Stream completed without result'));
+        }
+      },
+    );
+
+    // Return a disposable wrapper that cancels the stream sub on dispose.
+    return _DisposableSignalResult(sr, sub);
+  }
+
+  static AppFailure _mapException(Object error, StackTrace? stack) {
+    if (error is AppFailure) return error;
+    return UnknownFailure(error.toString());
+  }
+}
+
+/// A [SignalResult] wrapper that cancels an underlying stream subscription
+/// when disposed. Used by [StreamToSignalResultAdapter].
+class _DisposableSignalResult<T> implements SignalResult<T> {
+  _DisposableSignalResult(this._delegate, this._subscription);
+
+  final SignalResult<T> _delegate;
+  final StreamSubscription<Result<T, AppFailure>> _subscription;
+
+  bool _disposed = false;
+
+  @override
+  Result<T, AppFailure> get value => _delegate.value;
+  @override
+  T? get data => _delegate.data;
+  @override
+  AppFailure? get error => _delegate.error;
+  @override
+  bool get isLoading => _delegate.isLoading;
+  @override
+  bool get isSuccess => _delegate.isSuccess;
+  @override
+  bool get isFailure => _delegate.isFailure;
+  @override
+  bool get isDisposed => _disposed;
+
+  @override
+  void emit(Result<T, AppFailure> result) => _delegate.emit(result);
+  @override
+  void emitSuccess(T value) => _delegate.emitSuccess(value);
+  @override
+  void emitFailure(AppFailure error) => _delegate.emitFailure(error);
+  @override
+  void emitLoading() => _delegate.emitLoading();
+  @override
+  void update(
+    Result<T, AppFailure> Function(Result<T, AppFailure> current) updater,
+  ) => _delegate.update(updater);
+  @override
+  void updateData(T Function(T currentData) updater) =>
+      _delegate.updateData(updater);
+
+  @override
+  SignalSubscription listen(
+    void Function(Result<T, AppFailure> result) callback,
+  ) => _delegate.listen(callback);
+  @override
+  SignalSubscription onSuccess(void Function(T value) callback) =>
+      _delegate.onSuccess(callback);
+  @override
+  SignalSubscription onFailure(void Function(AppFailure error) callback) =>
+      _delegate.onFailure(callback);
+
+  @override
+  Future<Result<T, AppFailure>> get nextValue => _delegate.nextValue;
+
+  @override
+  SignalResult<R> map<R>(R Function(T value) transform) =>
+      _delegate.map(transform);
+  @override
+  SignalResult<R> flatMap<R>(SignalResult<R> Function(T value) transform) =>
+      _delegate.flatMap(transform);
+
+  @override
+  void dispose() {
+    if (_disposed) return;
+    _disposed = true;
+    _subscription.cancel();
+    _delegate.dispose();
+  }
+}

--- a/lib/src/core/usecase/zuraffa_usecase.dart
+++ b/lib/src/core/usecase/zuraffa_usecase.dart
@@ -72,27 +72,24 @@ class StreamToSignalResultAdapter<T> {
   /// [SignalResult.fromFuture] or native signals instead.
   static SignalResult<T> adapt<T>(Stream<Result<T, AppFailure>> stream) {
     final sr = SignalResult<T>.initial(LoadingResult<T, AppFailure>.loading());
-    late final StreamSubscription<Result<T, AppFailure>> sub;
+    _DisposableSignalResult<T>? wrapper;
 
-    sub = stream.listen(
+    final sub = stream.listen(
       (result) => sr.emit(result),
-      onError: (Object e, StackTrace st) =>
-          sr.emitFailure(_mapException(e, st)),
+      onError: (Object e, StackTrace st) {
+        sr.emitFailure(AppFailure.from(e, st));
+        wrapper?.dispose();
+      },
       onDone: () {
-        // If stream completed without emitting success, mark as unknown failure
         if (!sr.isSuccess && !sr.isFailure) {
           sr.emitFailure(UnknownFailure('Stream completed without result'));
         }
+        wrapper?.dispose();
       },
     );
 
-    // Return a disposable wrapper that cancels the stream sub on dispose.
-    return _DisposableSignalResult(sr, sub);
-  }
-
-  static AppFailure _mapException(Object error, StackTrace? stack) {
-    if (error is AppFailure) return error;
-    return UnknownFailure(error.toString());
+    wrapper = _DisposableSignalResult(sr, sub);
+    return wrapper;
   }
 }
 

--- a/lib/zuraffa.dart
+++ b/lib/zuraffa.dart
@@ -351,6 +351,22 @@ export 'src/extensions/future_extensions.dart';
 export 'src/utils/test_utils.dart';
 
 // ============================================================
+// V6 Reactive Signals
+// ============================================================
+
+/// Signal — zero-cost reactive primitive.
+export 'src/core/signals/signal.dart';
+
+/// SignalResult — reactive Result wrapper backed by Signal.
+export 'src/core/signals/signal_result.dart';
+
+/// ZuraffaUseCase — v6 UseCase contract with SignalResult return type.
+export 'src/core/usecase/zuraffa_usecase.dart';
+
+/// ZuraffaContext — lightweight correlation context carrier.
+export 'src/core/context/zuraffa_context.dart';
+
+// ============================================================
 // Framework Configuration
 // ============================================================
 

--- a/test/core/signal_pipeline_test.dart
+++ b/test/core/signal_pipeline_test.dart
@@ -1,0 +1,420 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zuraffa/zuraffa.dart';
+
+void main() {
+  group('Signal<T>', () {
+    test('value getter returns current value', () {
+      final s = Signal<int>(42);
+      expect(s.value, 42);
+    });
+
+    test('set updates value and notifies listeners', () {
+      final s = Signal<int>(0);
+      final values = <int>[];
+      s.listen(values.add);
+
+      s.value = 1;
+      s.value = 2;
+
+      // listen() emits current value immediately, then each change
+      expect(values, [0, 1, 2]);
+    });
+
+    test('update applies functional transformation', () {
+      final s = Signal<int>(10);
+      s.update((v) => v * 2);
+      expect(s.value, 20);
+    });
+
+    test('does not notify when value is equal', () {
+      final s = Signal<int>(5);
+      var count = 0;
+      s.listen((_) => count++);
+
+      s.value = 5; // same value
+      expect(count, 1); // only the initial emission
+    });
+
+    test('custom equals prevents notification', () {
+      final s = Signal<List<int>>([
+        1,
+        2,
+      ], equals: (a, b) => a.length == b.length);
+      var count = 0;
+      s.listen((_) => count++);
+
+      s.value = [3, 4]; // different contents, same length
+      expect(count, 1); // no notification because length is equal
+    });
+
+    test('cancel subscription stops notifications', () {
+      final s = Signal<int>(0);
+      final values = <int>[];
+      final sub = s.listen(values.add);
+
+      s.value = 1;
+      sub.cancel();
+      s.value = 2;
+
+      expect(values, [0, 1]);
+    });
+
+    test('map creates derived signal', () {
+      final s = Signal<int>(2);
+      final doubled = s.map((v) => v * 2);
+
+      expect(doubled.value, 4);
+      s.value = 5;
+      expect(doubled.value, 10);
+    });
+
+    test('combine merges two signals', () {
+      final a = Signal<int>(1);
+      final b = Signal<int>(2);
+      final sum = Signal.combine(a, b, (x, y) => x + y);
+
+      expect(sum.value, 3);
+      a.value = 10;
+      expect(sum.value, 12);
+    });
+
+    test('dispose releases all listeners', () {
+      final s = Signal<int>(0);
+      var count = 0;
+      s.listen((_) => count++);
+
+      s.dispose();
+      expect(s.isDisposed, true);
+      expect(() => s.value = 1, throwsStateError);
+    });
+
+    test('disposed signal throws on read', () {
+      final s = Signal<int>(0);
+      s.dispose();
+      expect(() => s.value, throwsStateError);
+    });
+
+    test('multiple listeners receive updates', () {
+      final s = Signal<String>('a');
+      final log1 = <String>[];
+      final log2 = <String>[];
+
+      s.listen(log1.add);
+      s.listen(log2.add);
+
+      s.value = 'b';
+      expect(log1, ['a', 'b']);
+      expect(log2, ['a', 'b']);
+    });
+
+    test('concurrent reads are safe', () {
+      final s = Signal<int>(0);
+      final results = <int>[];
+
+      // Simulate 100 concurrent reads
+      for (var i = 0; i < 100; i++) {
+        results.add(s.value);
+      }
+
+      expect(results.every((v) => v == 0), true);
+    });
+  });
+
+  group('SignalResult<T>', () {
+    test('initial value is accessible', () {
+      final sr = SignalResult<int>.success(42);
+      expect(sr.value, isA<Success<int, AppFailure>>());
+      expect(sr.data, 42);
+      expect(sr.isSuccess, true);
+    });
+
+    test('emit transitions state', () {
+      final sr = SignalResult<int>.initial(
+        const LoadingResult<int, AppFailure>.loading(),
+      );
+      expect(sr.isLoading, true);
+
+      sr.emitSuccess(100);
+      expect(sr.isSuccess, true);
+      expect(sr.data, 100);
+    });
+
+    test('emitFailure sets error state', () {
+      final sr = SignalResult<int>.success(0);
+      sr.emitFailure(const NetworkFailure('timeout'));
+
+      expect(sr.isFailure, true);
+      expect(sr.error, isA<NetworkFailure>());
+    });
+
+    test('listen receives current and future values', () {
+      final sr = SignalResult<int>.success(1);
+      final log = <Result<int, AppFailure>>[];
+      sr.listen(log.add);
+
+      sr.emitSuccess(2);
+      sr.emitSuccess(3);
+
+      expect(log.length, 3);
+      expect((log[0] as Success<int, AppFailure>).value, 1);
+      expect((log[2] as Success<int, AppFailure>).value, 3);
+    });
+
+    test('onSuccess filters to success values only', () {
+      final sr = SignalResult<int>.initial(
+        const LoadingResult<int, AppFailure>.loading(),
+      );
+      final values = <int>[];
+      sr.onSuccess(values.add);
+
+      sr.emitSuccess(10);
+      sr.emitFailure(const UnknownFailure('unexpected failure'));
+      sr.emitSuccess(20);
+
+      expect(values, [10, 20]);
+    });
+
+    test('onFailure filters to failure values only', () {
+      final sr = SignalResult<int>.initial(
+        const LoadingResult<int, AppFailure>.loading(),
+      );
+      final errors = <AppFailure>[];
+      sr.onFailure(errors.add);
+
+      sr.emitSuccess(1);
+      sr.emitFailure(const ServerFailure('server error occurred'));
+      sr.emitSuccess(2);
+
+      expect(errors.length, 1);
+      expect(errors.first, isA<ServerFailure>());
+    });
+
+    test('nextValue awaits next non-loading result', () async {
+      final sr = SignalResult<int>.initial(
+        const LoadingResult<int, AppFailure>.loading(),
+      );
+      final future = sr.nextValue;
+
+      // Simulate async work
+      Future.delayed(const Duration(milliseconds: 10), () {
+        sr.emitSuccess(99);
+      });
+
+      final result = await future;
+      expect(result, isA<Success<int, AppFailure>>());
+      expect((result as Success<int, AppFailure>).value, 99);
+    });
+
+    test('map transforms success, preserves failure', () {
+      final sr = SignalResult<int>.success(5);
+      final mapped = sr.map((v) => v.toString());
+
+      expect(mapped.data, '5');
+
+      sr.emitFailure(const NetworkFailure('network error on map'));
+      expect(mapped.isFailure, true);
+    });
+
+    test('flatMap chains async operations', () {
+      final sr = SignalResult<int>.success(2);
+      final chained = sr.flatMap(
+        (v) => SignalResult<String>.success('value: $v'),
+      );
+
+      expect(chained.data, 'value: 2');
+    });
+
+    test('fromFuture resolves to success', () async {
+      final sr = SignalResult.fromFuture<int>(
+        Future.delayed(const Duration(milliseconds: 5), () => 42),
+      );
+
+      final result = await sr.nextValue;
+      expect(result, isA<Success<int, AppFailure>>());
+      expect((result as Success<int, AppFailure>).value, 42);
+    });
+
+    test('fromFuture resolves to failure on exception', () async {
+      final sr = SignalResult.fromFuture<int>(
+        Future.delayed(
+          const Duration(milliseconds: 5),
+          () => throw Exception('boom'),
+        ),
+      );
+
+      final result = await sr.nextValue;
+      expect(result, isA<Failure<int, AppFailure>>());
+    });
+
+    test('dispose releases listeners', () {
+      final sr = SignalResult<int>.success(0);
+      var count = 0;
+      sr.listen((_) => count++);
+
+      sr.dispose();
+      expect(sr.isDisposed, true);
+    });
+
+    test('loading state is distinct from success/failure', () {
+      final sr = SignalResult<int>.initial(
+        const LoadingResult<int, AppFailure>.loading(),
+      );
+      expect(sr.isLoading, true);
+      expect(sr.isSuccess, false);
+      expect(sr.isFailure, false);
+      expect(sr.data, null);
+      expect(sr.error, null);
+    });
+
+    test('updateData updates success value only', () {
+      final sr = SignalResult<int>.success(10);
+      sr.updateData((v) => v + 5);
+      expect(sr.data, 15);
+
+      // updateData is a no-op on failure
+      sr.emitFailure(const NetworkFailure('update skipped for failure'));
+      sr.updateData((v) => v + 1);
+      expect(sr.isFailure, true);
+    });
+  });
+
+  group('ZuraffaUseCase contract', () {
+    test('use case returns SignalResult', () {
+      final useCase = _TestUseCase();
+      final result = useCase.call(_TestParams(10));
+
+      expect(result, isA<SignalResult<int>>());
+      expect(result.isLoading, true);
+    });
+
+    test('use case with context parameter', () {
+      final useCase = _TestUseCase();
+      final result = useCase.call(
+        _TestParams(5),
+        context: const ZuraffaContext(traceId: 'abc-123'),
+      );
+
+      expect(result.isLoading, true);
+    });
+
+    test('use case default context is noop', () {
+      final useCase = _TestUseCase();
+      // Should compile and run without explicit context
+      final result = useCase.call(_TestParams(1));
+      expect(result, isNotNull);
+    });
+  });
+
+  group('DisposableUseCase mixin', () {
+    test('owns and disposes signal results', () {
+      final useCase = _DisposableTestUseCase();
+      final sr = useCase.call(_TestParams(1));
+
+      expect(sr.isDisposed, false);
+      useCase.disposeUseCase();
+      expect(sr.isDisposed, true);
+    });
+  });
+
+  group('StreamToSignalResultAdapter', () {
+    test('adapts stream to SignalResult', () async {
+      final stream = Stream.fromIterable([
+        const Success<int, AppFailure>(1),
+        const Success<int, AppFailure>(2),
+      ]);
+
+      final sr = StreamToSignalResultAdapter.adapt<int>(stream);
+      expect(sr.isLoading, true);
+
+      final result = await sr.nextValue;
+      expect(result, isA<Success<int, AppFailure>>());
+    });
+
+    test('adapts stream error to failure', () async {
+      final stream = Stream<Result<int, AppFailure>>.error(
+        Exception('stream error'),
+      );
+      final sr = StreamToSignalResultAdapter.adapt<int>(stream);
+
+      final result = await sr.nextValue;
+      expect(result, isA<Failure<int, AppFailure>>());
+    });
+
+    test('disposal cancels stream subscription', () {
+      final controller = StreamController<Result<int, AppFailure>>();
+      final sr = StreamToSignalResultAdapter.adapt<int>(controller.stream);
+
+      sr.dispose();
+      expect(controller.isClosed, false); // controller itself is not closed
+      // But the subscription is cancelled — adding to controller won't crash
+      controller.add(const Success<int, AppFailure>(1));
+      controller.close();
+    });
+  });
+
+  group('Memory & lifecycle', () {
+    test('signal does not leak listeners after dispose', () {
+      final s = Signal<int>(0);
+      for (var i = 0; i < 1000; i++) {
+        s.listen((_) {});
+      }
+      s.dispose();
+      // If listeners leaked, this would retain 1000 closures.
+      // Test passes if dispose runs without error.
+      expect(s.isDisposed, true);
+    });
+
+    test('SignalResult disposal cleans up internal signal', () {
+      final sr = SignalResult<int>.success(0);
+      var count = 0;
+      sr.listen((_) => count++);
+
+      sr.dispose();
+      // After disposal, the internal signal is disposed.
+      // Any further interaction should throw or be safe.
+      expect(sr.isDisposed, true);
+    });
+
+    test('derived signals dispose with parent when autoDispose', () {
+      final parent = Signal<int>(1);
+      final child = parent.map((v) => v * 2);
+
+      expect(child.isDisposed, false);
+      parent.dispose();
+      // With autoDispose=true (default), child should be disposed
+      expect(child.isDisposed, true);
+    });
+  });
+}
+
+// ── Test doubles ──
+
+class _TestParams {
+  _TestParams(this.value);
+  final int value;
+}
+
+class _TestUseCase extends ZuraffaUseCase<_TestParams, int> {
+  @override
+  SignalResult<int> call(_TestParams params, {ZuraffaContext? context}) {
+    final sr = SignalResult<int>.initial(
+      const LoadingResult<int, AppFailure>.loading(),
+    );
+    // Simulate async work
+    Future.delayed(const Duration(milliseconds: 10), () {
+      sr.emitSuccess(params.value * 2);
+    });
+    return sr;
+  }
+}
+
+class _DisposableTestUseCase extends ZuraffaUseCase<_TestParams, int>
+    with DisposableUseCase<_TestParams, int> {
+  @override
+  SignalResult<int> call(_TestParams params, {ZuraffaContext? context}) {
+    final sr = own(SignalResult<int>.success(params.value));
+    return sr;
+  }
+}

--- a/test/core/signal_pipeline_test.dart
+++ b/test/core/signal_pipeline_test.dart
@@ -109,14 +109,13 @@ void main() {
       expect(log2, ['a', 'b']);
     });
 
-    test('concurrent reads are safe', () {
+    test('reads remain consistent across interleaved async access', () async {
       final s = Signal<int>(0);
       final results = <int>[];
 
-      // Simulate 100 concurrent reads
-      for (var i = 0; i < 100; i++) {
-        results.add(s.value);
-      }
+      await Future.wait([
+        for (var i = 0; i < 100; i++) Future(() => results.add(s.value)),
+      ]);
 
       expect(results.every((v) => v == 0), true);
     });
@@ -297,13 +296,14 @@ void main() {
       );
 
       expect(result.isLoading, true);
+      expect(useCase.lastContext?.traceId, 'abc-123');
     });
 
     test('use case default context is noop', () {
       final useCase = _TestUseCase();
       // Should compile and run without explicit context
-      final result = useCase.call(_TestParams(1));
-      expect(result, isNotNull);
+      useCase.call(_TestParams(1));
+      expect(useCase.lastContext, isNull);
     });
   });
 
@@ -364,6 +364,7 @@ void main() {
       // If listeners leaked, this would retain 1000 closures.
       // Test passes if dispose runs without error.
       expect(s.isDisposed, true);
+      expect(() => s.value = 1, throwsStateError);
     });
 
     test('SignalResult disposal cleans up internal signal', () {
@@ -375,6 +376,7 @@ void main() {
       // After disposal, the internal signal is disposed.
       // Any further interaction should throw or be safe.
       expect(sr.isDisposed, true);
+      expect(() => sr.value, throwsStateError);
     });
 
     test('derived signals dispose with parent when autoDispose', () {
@@ -397,8 +399,11 @@ class _TestParams {
 }
 
 class _TestUseCase extends ZuraffaUseCase<_TestParams, int> {
+  ZuraffaContext? lastContext;
+
   @override
   SignalResult<int> call(_TestParams params, {ZuraffaContext? context}) {
+    lastContext = context;
     final sr = SignalResult<int>.initial(
       const LoadingResult<int, AppFailure>.loading(),
     );


### PR DESCRIPTION
## Overview

Track 1.1 of the V6 architecture: replaces the clunky `Stream<Result<T>>` paradigm with a zero-cost reactive `Signal<T>` pipeline.

This patch was generated by an external agent and reviewed by an architectural agent. All review comments have been addressed.

## Changes

### New Modules

- **`Signal<T>`** — Zero-cost reactive primitive with O(1) reads, identity-based listener deduplication, and fine-grained subscriptions with eager cold-start delivery.
- **`SignalResult<T>`** — Reactive wrapper around `Result<T, AppFailure>` that replaces `Stream<Result<T, AppFailure>>` as the `ZuraffaUseCase` return type.
- **`ZuraffaUseCase<In, Out>`** — v6 base contract returning `SignalResult<Out>` with optional `ZuraffaContext`.
- **`DisposableUseCase<In, Out>`** — Mixin for lifecycle-managed signal disposal.
- **`StreamToSignalResultAdapter<T>`** — v5 → v6 migration adapter wrapping `Stream<Result<T, AppFailure>>`.
- **`ZuraffaContext`** — Lightweight correlation context carrier stub (prep for Track 1.2 telemetry).
- **`LoadingResult<S, F>`** — Loading/pending state added to the sealed `Result<S, F>` hierarchy.

### Enhancements

- Added `updateData(T Function(T))` to `SignalResult` for ergonomic success-only updates.
- `Signal.dispose()` now saves hooks before clearing (prevents concurrent modification).
- Added `NetworkFailure.create()`, `ServerFailure.create()`, `UnknownFailure.create()` named constructors with default messages, plus `factory AppFailure.create()` delegating to `UnknownFailure.create()`.

### Testing

- 36 unit tests across Signal, SignalResult, use case contracts, migration adapter, and lifecycle (all pass).
- O(1) vs O(N) benchmark comparing Signal reads/notifications against Stream.

## Review Comments Addressed

| # | Comment | Resolution |
|---|---------|-----------|
| 1 | Add `updateData()` helper | Added to `SignalResult` — only updates when current state is Success |
| 2 | Dispose safety in `Signal.dispose()` | Hooks are now saved to local variable before `_disposeHooks` is set to null |
| 3 | Result equality | Already handled by existing `Result<S, F>` which overrides `==`/`hashCode` on `Success` and `Failure`. Also added equality to `LoadingResult`. |

## Closes

Closes #170 — [v6] Track 1.1 — Async Signal Pipeline

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reactive `Signal` and `SignalResult` APIs for observable state, transformations, and asynchronous results.
  * Added loading, success, and failure state handling with convenient failure constructors.
  * Added context support for tracing and metadata across use-case operations.
  * Added a signal-based use-case contract, lifecycle management, and stream compatibility adapter.
  * Exposed the new APIs through the main library entry point.

* **Tests**
  * Added comprehensive coverage for signal updates, subscriptions, transformations, disposal, async workflows, and use-case integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #170 