### PR TITLE
feat(di): Track 1.4 — @Datasource & @Repository Decorators for Auto-DI

### DIFF
--- a/lib/src/core/di/datasource.dart
+++ b/lib/src/core/di/datasource.dart
@@ -1,0 +1,25 @@
+import 'dependency_scope.dart';
+
+/// Marks a class as a datasource implementation.
+///
+/// ```dart
+/// @Datasource(name: 'stripe_api', scope: DependencyScope.singleton, env: ['prod'])
+/// class StripeApiDatasource implements PaymentDatasource { ... }
+/// ```
+class Datasource {
+  const Datasource({
+    this.name,
+    this.scope = DependencyScope.singleton,
+    this.env = const ['*'],
+  });
+
+  /// Logical name for this datasource. Defaults to the class name.
+  final String? name;
+
+  /// Lifecycle scope.
+  final DependencyScope scope;
+
+  /// Environments where this datasource is active.
+  /// `['*']` means all environments.
+  final List<String> env;
+}

--- a/lib/src/core/di/dependency_scope.dart
+++ b/lib/src/core/di/dependency_scope.dart
@@ -1,0 +1,11 @@
+/// Lifecycle scope for registered dependencies.
+enum DependencyScope {
+  /// Single instance shared across the app.
+  singleton,
+
+  /// New instance created on every resolution.
+  transient,
+
+  /// Created on first resolution, then cached.
+  lazy,
+}

--- a/lib/src/core/di/repository.dart
+++ b/lib/src/core/di/repository.dart
@@ -1,0 +1,12 @@
+/// Marks a class as a repository implementation.
+///
+/// ```dart
+/// @Repository()
+/// class ProductRepositoryImpl implements ProductRepository { ... }
+/// ```
+class Repository {
+  const Repository({this.name});
+
+  /// Logical name for this repository. Defaults to the class name.
+  final String? name;
+}

--- a/lib/src/core/di/zuraffa_container.dart
+++ b/lib/src/core/di/zuraffa_container.dart
@@ -1,0 +1,89 @@
+import 'dart:collection';
+
+/// Lightweight dependency-injection container for zuraffa.
+///
+/// Replaces manual `get_it` setup. Populated by the generated
+/// `zuraffa_injection.g.dart` file.
+///
+/// ```dart
+/// final container = ZuraffaContainer.instance;
+/// final repo = container.resolve<ProductRepository>();
+/// ```
+class ZuraffaContainer {
+  ZuraffaContainer._();
+  static final ZuraffaContainer instance = ZuraffaContainer._();
+
+  final _registrations = HashMap<Type, _Registration>();
+  final _singletons = HashMap<Type, dynamic>();
+  final _lazy = HashMap<Type, dynamic>();
+
+  /// Register a factory for type [T].
+  void registerFactory<T>(T Function() factory) {
+    _registrations[T] = _Registration(
+      factory: factory,
+      scope: _Scope.transient,
+    );
+  }
+
+  /// Register a singleton for type [T].
+  void registerSingleton<T>(T Function() factory) {
+    _registrations[T] = _Registration(
+      factory: factory,
+      scope: _Scope.singleton,
+    );
+  }
+
+  /// Register a lazy singleton for type [T].
+  void registerLazySingleton<T>(T Function() factory) {
+    _registrations[T] = _Registration(factory: factory, scope: _Scope.lazy);
+  }
+
+  /// Register an instance directly (useful for testing/mocking).
+  void registerInstance<T>(T instance) {
+    _singletons[T] = instance;
+    _registrations[T] = _Registration(
+      factory: () => instance,
+      scope: _Scope.singleton,
+    );
+  }
+
+  /// Resolve a dependency of type [T].
+  ///
+  /// Throws [StateError] if [T] is not registered.
+  T resolve<T>() {
+    final reg = _registrations[T];
+    if (reg == null) {
+      throw StateError(
+        'No registration found for type $T. '
+        'Did you run `zfa build` and import zuraffa_injection.g.dart?',
+      );
+    }
+
+    switch (reg.scope) {
+      case _Scope.transient:
+        return reg.factory() as T;
+      case _Scope.singleton:
+        return _singletons.putIfAbsent(T, reg.factory) as T;
+      case _Scope.lazy:
+        return _lazy.putIfAbsent(T, reg.factory) as T;
+    }
+  }
+
+  /// Whether type [T] is registered.
+  bool isRegistered<T>() => _registrations.containsKey(T);
+
+  /// Clear all registrations. Primarily for testing.
+  void reset() {
+    _registrations.clear();
+    _singletons.clear();
+    _lazy.clear();
+  }
+}
+
+enum _Scope { transient, singleton, lazy }
+
+class _Registration {
+  _Registration({required this.factory, required this.scope});
+  final dynamic Function() factory;
+  final _Scope scope;
+}

--- a/lib/src/dda/compiler/zorphy_decorator_plugin.dart
+++ b/lib/src/dda/compiler/zorphy_decorator_plugin.dart
@@ -21,6 +21,13 @@ abstract class ZorphyDecoratorPlugin {
   /// The decorator name this plugin handles, without the `@` prefix.
   String get targetDecorator;
 
+  /// All decorator names this plugin handles, without the `@` prefix.
+  ///
+  /// Defaults to just [targetDecorator]. Override to handle multiple
+  /// decorator names (e.g. a plugin that processes both `@Datasource`
+  /// and `@Repository`).
+  List<String> get targetDecorators => [targetDecorator];
+
   /// Priority for ordering when multiple plugins target the same method.
   ///
   /// Higher values → applied later → outermost wrapper.
@@ -43,7 +50,9 @@ class ZorphyPluginRegistry {
   static final Map<String, ZorphyDecoratorPlugin> _plugins = {};
 
   static void register(ZorphyDecoratorPlugin plugin) {
-    _plugins[plugin.targetDecorator] = plugin;
+    for (final name in plugin.targetDecorators) {
+      _plugins[name] = plugin;
+    }
   }
 
   static void registerAll(List<ZorphyDecoratorPlugin> plugins) {

--- a/lib/src/dda/compiler/zorphy_decorator_plugin.dart
+++ b/lib/src/dda/compiler/zorphy_decorator_plugin.dart
@@ -35,7 +35,11 @@ abstract class ZorphyDecoratorPlugin {
   /// Fine-grained plugins (auth, validation): lower values.
   int get priority => 0;
 
-  /// Called when the AST scanner finds [targetDecorator] on an element.
+  /// Called when the AST scanner finds a decorator this plugin handles.
+  ///
+  /// The [decorator] may be any name listed in [targetDecorators] (which
+  /// defaults to just [targetDecorator]). The callback should inspect
+  /// [decorator.name] to handle each annotation it supports.
   void onApply(MethodAST method, DecoratorAST decorator, ZorphyContext context);
 
   /// Optional: called once per build before scanning begins.
@@ -56,7 +60,9 @@ class ZorphyPluginRegistry {
   }
 
   static void registerAll(List<ZorphyDecoratorPlugin> plugins) {
-    for (final p in plugins) register(p);
+    for (final p in plugins) {
+      register(p);
+    }
   }
 
   static ZorphyDecoratorPlugin? get(String decoratorName) =>

--- a/lib/src/dda/plugins/di/di_generator.dart
+++ b/lib/src/dda/plugins/di/di_generator.dart
@@ -19,6 +19,7 @@ class DIGenerator {
       _datasources.isNotEmpty || _repositories.isNotEmpty;
 
   void addDatasource({
+    required String name,
     required String className,
     required String importUri,
     String? interfaceName,
@@ -29,6 +30,7 @@ class DIGenerator {
     if (!_matchesEnv(env)) return;
     _datasources.add(
       _DiRegistration(
+        name: name,
         className: className,
         importUri: importUri,
         interfaceName: interfaceName,
@@ -39,6 +41,7 @@ class DIGenerator {
   }
 
   void addRepository({
+    required String name,
     required String className,
     required String importUri,
     String? interfaceName,
@@ -46,6 +49,7 @@ class DIGenerator {
   }) {
     _repositories.add(
       _DiRegistration(
+        name: name,
         className: className,
         importUri: importUri,
         interfaceName: interfaceName,
@@ -103,20 +107,21 @@ class DIGenerator {
     final namedArgs = <String, cb.Expression>{};
     for (final param in reg.constructorParams) {
       if (param.isNamed) {
-        namedArgs[param.name] = cb.refer('container').property('resolve').call(
-          [],
-          {},
-          [cb.refer(param.type)],
-        );
+        namedArgs[param.name] = cb
+            .refer('ZuraffaContainer.instance')
+            .property('resolve')
+            .call([], {}, [cb.refer(param.type)]);
       }
     }
 
     final positionalArgs = reg.constructorParams
         .where((p) => !p.isNamed)
         .map(
-          (p) => cb.refer('container').property('resolve').call([], {}, [
-            cb.refer(p.type),
-          ]),
+          (p) => cb.refer('ZuraffaContainer.instance').property('resolve').call(
+            [],
+            {},
+            [cb.refer(p.type)],
+          ),
         )
         .toList();
 
@@ -141,6 +146,7 @@ class DIGenerator {
 
 class _DiRegistration {
   _DiRegistration({
+    required this.name,
     required this.className,
     required this.importUri,
     this.interfaceName,
@@ -148,6 +154,7 @@ class _DiRegistration {
     required this.constructorParams,
   });
 
+  final String name;
   final String className;
   final String importUri;
   final String? interfaceName;

--- a/lib/src/dda/plugins/di/di_generator.dart
+++ b/lib/src/dda/plugins/di/di_generator.dart
@@ -1,0 +1,168 @@
+import 'package:code_builder/code_builder.dart' as cb;
+import 'package:dart_style/dart_style.dart';
+
+/// Generates `lib/src/di/zuraffa_injection.g.dart` from collected
+/// @Datasource and @Repository metadata.
+class DIGenerator {
+  DIGenerator({this.targetEnv = '*'});
+
+  final String targetEnv;
+
+  static final _formatter = DartFormatter(
+    languageVersion: DartFormatter.latestLanguageVersion,
+  );
+
+  final List<_DiRegistration> _datasources = [];
+  final List<_DiRegistration> _repositories = [];
+
+  bool get hasRegistrations =>
+      _datasources.isNotEmpty || _repositories.isNotEmpty;
+
+  void addDatasource({
+    required String className,
+    required String importUri,
+    String? interfaceName,
+    required String scope,
+    required List<String> env,
+    required List<ConstructorParam> constructorParams,
+  }) {
+    if (!_matchesEnv(env)) return;
+    _datasources.add(
+      _DiRegistration(
+        className: className,
+        importUri: importUri,
+        interfaceName: interfaceName,
+        scope: scope,
+        constructorParams: constructorParams,
+      ),
+    );
+  }
+
+  void addRepository({
+    required String className,
+    required String importUri,
+    String? interfaceName,
+    required List<ConstructorParam> constructorParams,
+  }) {
+    _repositories.add(
+      _DiRegistration(
+        className: className,
+        importUri: importUri,
+        interfaceName: interfaceName,
+        scope: 'singleton',
+        constructorParams: constructorParams,
+      ),
+    );
+  }
+
+  bool _matchesEnv(List<String> env) {
+    return env.contains('*') || env.contains(targetEnv);
+  }
+
+  String generate() {
+    final library = cb.Library((b) {
+      b.generatedByComment = 'zfa DDA pipeline';
+
+      final allImports = <String>{};
+      for (final reg in [..._datasources, ..._repositories]) {
+        allImports.add(reg.importUri);
+      }
+      b.directives.add(cb.Directive.import('package:zuraffa/zuraffa.dart'));
+      for (final uri in allImports) {
+        b.directives.add(cb.Directive.import(uri));
+      }
+
+      b.body.add(
+        cb.Method((m) {
+          m
+            ..name = 'configureZuraffaInjections'
+            ..returns = cb.refer('void')
+            ..body = cb.Block((bl) {
+              for (final reg in _datasources) {
+                bl.addExpression(_buildRegistration(reg));
+              }
+              for (final reg in _repositories) {
+                bl.addExpression(_buildRegistration(reg));
+              }
+            });
+        }),
+      );
+    });
+
+    final emitter = cb.DartEmitter();
+    final raw = library.accept(emitter).toString();
+    return _formatter.format(raw);
+  }
+
+  cb.Expression _buildRegistration(_DiRegistration reg) {
+    final classRef = cb.refer(reg.className);
+    final interfaceRef = reg.interfaceName != null
+        ? cb.refer(reg.interfaceName!)
+        : classRef;
+
+    final namedArgs = <String, cb.Expression>{};
+    for (final param in reg.constructorParams) {
+      if (param.isNamed) {
+        namedArgs[param.name] = cb.refer('container').property('resolve').call(
+          [],
+          {},
+          [cb.refer(param.type)],
+        );
+      }
+    }
+
+    final positionalArgs = reg.constructorParams
+        .where((p) => !p.isNamed)
+        .map(
+          (p) => cb.refer('container').property('resolve').call([], {}, [
+            cb.refer(p.type),
+          ]),
+        )
+        .toList();
+
+    final instanceCreation = classRef.call(positionalArgs, namedArgs);
+
+    final registerMethod = reg.scope == 'singleton'
+        ? 'registerSingleton'
+        : reg.scope == 'lazy'
+        ? 'registerLazySingleton'
+        : 'registerFactory';
+
+    return cb
+        .refer('ZuraffaContainer.instance')
+        .property(registerMethod)
+        .call(
+          [cb.Method((m) => m..body = instanceCreation.code).closure],
+          {},
+          [interfaceRef],
+        );
+  }
+}
+
+class _DiRegistration {
+  _DiRegistration({
+    required this.className,
+    required this.importUri,
+    this.interfaceName,
+    required this.scope,
+    required this.constructorParams,
+  });
+
+  final String className;
+  final String importUri;
+  final String? interfaceName;
+  final String scope;
+  final List<ConstructorParam> constructorParams;
+}
+
+class ConstructorParam {
+  ConstructorParam({
+    required this.name,
+    required this.type,
+    this.isNamed = false,
+  });
+
+  final String name;
+  final String type;
+  final bool isNamed;
+}

--- a/lib/src/dda/plugins/di/di_plugin.dart
+++ b/lib/src/dda/plugins/di/di_plugin.dart
@@ -1,0 +1,103 @@
+import '../../compiler/zorphy_decorator_plugin.dart';
+import '../../models/decorator_ast.dart';
+import '../../models/zorphy_context.dart';
+import 'di_generator.dart';
+
+/// DDA plugin that processes `@Datasource` and `@Repository` annotations
+/// and accumulates DI registration metadata.
+///
+/// This plugin is registered automatically when `zfa build` runs.
+/// After the build, call [generateInjectionFile] to emit
+/// `lib/src/di/zuraffa_injection.g.dart`.
+class DIPlugin extends ZorphyDecoratorPlugin {
+  DIPlugin({this.targetEnv = '*'});
+
+  final String targetEnv;
+  final _generator = DIGenerator();
+
+  @override
+  String get targetDecorator => 'Datasource'; // Also handles Repository via onApply
+
+  @override
+  void onApply(
+    MethodAST method,
+    DecoratorAST decorator,
+    ZorphyContext context,
+  ) {
+    if (method.elementKind != 'class') return;
+
+    final className = method.name;
+    final importUri = _extractImportUri(method.libraryUri);
+    final interfaceName = _extractInterface(method);
+    final constructorParams = _extractConstructorParams(method);
+
+    if (decorator.name == 'Datasource') {
+      decorator.get<String>('name') ?? className;
+      final scopeStr = decorator.get<String>('scope') ?? 'singleton';
+      final env = _parseEnv(decorator.get<dynamic>('env'));
+
+      _generator.addDatasource(
+        className: className,
+        importUri: importUri,
+        interfaceName: interfaceName,
+        scope: scopeStr,
+        env: env,
+        constructorParams: constructorParams,
+      );
+    } else if (decorator.name == 'Repository') {
+      decorator.get<String>('name') ?? className;
+
+      _generator.addRepository(
+        className: className,
+        importUri: importUri,
+        interfaceName: interfaceName,
+        constructorParams: constructorParams,
+      );
+    }
+  }
+
+  /// Generate the DI registration file content.
+  String generateInjectionFile() => _generator.generate();
+
+  /// Whether any registrations were collected.
+  bool get hasRegistrations => _generator.hasRegistrations;
+
+  // ── Helpers ──
+
+  String _extractImportUri(String? libraryUri) {
+    if (libraryUri == null) return '';
+    if (libraryUri.contains('/lib/')) {
+      final parts = libraryUri.split('/lib/');
+      if (parts.length == 2) {
+        return 'package:zuraffa/${parts[1]}';
+      }
+    }
+    return libraryUri;
+  }
+
+  String? _extractInterface(MethodAST method) {
+    if (method.interfaces.isNotEmpty) {
+      return method.interfaces.first;
+    }
+    if (method.superclassName != null && method.superclassName != 'Object') {
+      return method.superclassName;
+    }
+    return null;
+  }
+
+  List<ConstructorParam> _extractConstructorParams(MethodAST method) {
+    return method.parameters
+        .map(
+          (p) =>
+              ConstructorParam(name: p.name, type: p.type, isNamed: p.isNamed),
+        )
+        .toList();
+  }
+
+  List<String> _parseEnv(dynamic envValue) {
+    if (envValue == null) return const ['*'];
+    if (envValue is List) return envValue.cast<String>();
+    if (envValue is String) return [envValue];
+    return const ['*'];
+  }
+}

--- a/lib/src/dda/plugins/di/di_plugin.dart
+++ b/lib/src/dda/plugins/di/di_plugin.dart
@@ -10,13 +10,23 @@ import 'di_generator.dart';
 /// After the build, call [generateInjectionFile] to emit
 /// `lib/src/di/zuraffa_injection.g.dart`.
 class DIPlugin extends ZorphyDecoratorPlugin {
-  DIPlugin({this.targetEnv = '*'});
+  DIPlugin({this.targetEnv = '*', this.packageName = 'zuraffa'});
 
+  /// The active environment. Only datasources whose `env` includes
+  /// this value (or `*`) are registered.
   final String targetEnv;
-  final _generator = DIGenerator();
+
+  /// The package name used to build import URIs. Defaults to `zuraffa`.
+  final String packageName;
+
+  late final _generator = DIGenerator(targetEnv: targetEnv);
 
   @override
-  String get targetDecorator => 'Datasource'; // Also handles Repository via onApply
+  String get targetDecorator => 'Datasource';
+
+  /// Handles both `@Datasource` and `@Repository` annotations.
+  @override
+  List<String> get targetDecorators => const ['Datasource', 'Repository'];
 
   @override
   void onApply(
@@ -32,11 +42,12 @@ class DIPlugin extends ZorphyDecoratorPlugin {
     final constructorParams = _extractConstructorParams(method);
 
     if (decorator.name == 'Datasource') {
-      decorator.get<String>('name') ?? className;
+      final name = decorator.get<String>('name') ?? className;
       final scopeStr = decorator.get<String>('scope') ?? 'singleton';
       final env = _parseEnv(decorator.get<dynamic>('env'));
 
       _generator.addDatasource(
+        name: name,
         className: className,
         importUri: importUri,
         interfaceName: interfaceName,
@@ -45,9 +56,10 @@ class DIPlugin extends ZorphyDecoratorPlugin {
         constructorParams: constructorParams,
       );
     } else if (decorator.name == 'Repository') {
-      decorator.get<String>('name') ?? className;
+      final name = decorator.get<String>('name') ?? className;
 
       _generator.addRepository(
+        name: name,
         className: className,
         importUri: importUri,
         interfaceName: interfaceName,
@@ -69,7 +81,7 @@ class DIPlugin extends ZorphyDecoratorPlugin {
     if (libraryUri.contains('/lib/')) {
       final parts = libraryUri.split('/lib/');
       if (parts.length == 2) {
-        return 'package:zuraffa/${parts[1]}';
+        return 'package:$packageName/${parts[1]}';
       }
     }
     return libraryUri;

--- a/lib/zuraffa.dart
+++ b/lib/zuraffa.dart
@@ -395,6 +395,28 @@ export 'src/dda/compiler/decorator_dispatcher.dart';
 export 'src/dda/compiler/build_pipeline.dart';
 
 // ============================================================
+// V6 DI — Auto-Dependency Injection
+// ============================================================
+
+/// DependencyScope — lifecycle scopes for DI.
+export 'src/core/di/dependency_scope.dart';
+
+/// @Datasource annotation.
+export 'src/core/di/datasource.dart';
+
+/// @Repository annotation.
+export 'src/core/di/repository.dart';
+
+/// ZuraffaContainer — lightweight DI container.
+export 'src/core/di/zuraffa_container.dart';
+
+/// DIPlugin — DDA plugin for @Datasource/@Repository processing.
+export 'src/dda/plugins/di/di_plugin.dart';
+
+/// DIGenerator — code_builder-based DI registration generation.
+export 'src/dda/plugins/di/di_generator.dart';
+
+// ============================================================
 // Framework Configuration
 // ============================================================
 

--- a/test/core/container_test.dart
+++ b/test/core/container_test.dart
@@ -1,0 +1,85 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zuraffa/zuraffa.dart';
+
+class _TestService {
+  _TestService();
+  String greet() => 'hello';
+}
+
+class _TestRepo {
+  _TestRepo(this.service);
+  final _TestService service;
+}
+
+void main() {
+  group('ZuraffaContainer', () {
+    setUp(() => ZuraffaContainer.instance.reset());
+    tearDown(() => ZuraffaContainer.instance.reset());
+
+    test('register and resolve transient', () {
+      ZuraffaContainer.instance.registerFactory<_TestService>(
+        () => _TestService(),
+      );
+      final instance = ZuraffaContainer.instance.resolve<_TestService>();
+      expect(instance, isA<_TestService>());
+      expect(instance.greet(), 'hello');
+    });
+
+    test('transient creates new instance each time', () {
+      ZuraffaContainer.instance.registerFactory<_TestService>(
+        () => _TestService(),
+      );
+      final a = ZuraffaContainer.instance.resolve<_TestService>();
+      final b = ZuraffaContainer.instance.resolve<_TestService>();
+      expect(a, isNot(same(b)));
+    });
+
+    test('singleton returns same instance', () {
+      ZuraffaContainer.instance.registerSingleton<_TestService>(
+        () => _TestService(),
+      );
+      final a = ZuraffaContainer.instance.resolve<_TestService>();
+      final b = ZuraffaContainer.instance.resolve<_TestService>();
+      expect(a, same(b));
+    });
+
+    test('lazy singleton returns same instance after first resolution', () {
+      ZuraffaContainer.instance.registerLazySingleton<_TestService>(
+        () => _TestService(),
+      );
+      final a = ZuraffaContainer.instance.resolve<_TestService>();
+      final b = ZuraffaContainer.instance.resolve<_TestService>();
+      expect(a, same(b));
+    });
+
+    test('registerInstance stores the provided value', () {
+      final service = _TestService();
+      ZuraffaContainer.instance.registerInstance<_TestService>(service);
+      final resolved = ZuraffaContainer.instance.resolve<_TestService>();
+      expect(resolved, same(service));
+    });
+
+    test('isRegistered returns true for registered types', () {
+      ZuraffaContainer.instance.registerFactory<_TestService>(
+        () => _TestService(),
+      );
+      expect(ZuraffaContainer.instance.isRegistered<_TestService>(), true);
+      expect(ZuraffaContainer.instance.isRegistered<_TestRepo>(), false);
+    });
+
+    test('resolve throws StateError for unregistered types', () {
+      expect(
+        () => ZuraffaContainer.instance.resolve<_TestService>(),
+        throwsStateError,
+      );
+    });
+
+    test('reset clears all registrations', () {
+      ZuraffaContainer.instance.registerFactory<_TestService>(
+        () => _TestService(),
+      );
+      ZuraffaContainer.instance.reset();
+      expect(ZuraffaContainer.instance.isRegistered<_TestService>(), false);
+    });
+  });
+}


### PR DESCRIPTION
## Overview

Track 1.4 of the V6 architecture — **Auto-Dependency Injection** via `@Datasource` and `@Repository` decorators. Eliminates manual `get_it`/Service Locator configuration. Developers annotate classes, and `zfa build` auto-generates the complete DI registration file.

Follows Tracks 1.1 (Signal Pipeline), 1.2 (Telemetry Mesh), and 1.3 (DDA Foundation).

### New Modules

- **`@Datasource(name, scope, env)`** — Runtime annotation marking a class as a datasource implementation with lifecycle scope and environment filters.
- **`@Repository(name)`** — Runtime annotation marking a class as a repository implementation.
- **`DependencyScope`** — Enum: `singleton`, `transient`, `lazy`.
- **`ZuraffaContainer`** — Lightweight DI container replacing manual `get_it` setup. Supports `registerFactory`, `registerSingleton`, `registerLazySingleton`, `registerInstance`, and `resolve<T>()`.
- **`DIPlugin`** — DDA plugin that scans `@Datasource`/`@Repository` annotations, extracts interface bindings and constructor params, and delegates to `DIGenerator`.
- **`DIGenerator`** — `code_builder`-based emission of `zuraffa_injection.g.dart` with `configureZuraffaInjections()` function. Constructor params are auto-resolved via `container.resolve<DepType>()`.

### Testing & Validation

- 8 container unit tests (transient, singleton, lazy, instance registration, `isRegistered`, `resolve` error, `reset`)
- `dart analyze` — 0 errors, 0 warnings

### Dependencies

Uses existing `code_builder: ^4.11.1` and `dart_style` — no new dependencies added.

Closes #171

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dependency-injection annotations for datasources and repositories.
  * Added configurable singleton, transient, and lazy instance lifecycles.
  * Added a container for registering, resolving, checking, and resetting dependencies.
  * Added automatic injection generation with environment-specific datasource support.
  * Added support for plugins with multiple decorator names.
  * Exported all dependency-injection APIs through the main package entry point.

* **Tests**
  * Added coverage for registration, resolution, lifecycle behavior, errors, and reset operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->