### PR TITLE
feat(state): Tracks 2.3 + 2.4 — Cache Sync + ControlledWidget Templates

### DIFF
--- a/lib/src/state/cache/cache_binding.dart
+++ b/lib/src/state/cache/cache_binding.dart
@@ -1,7 +1,5 @@
 import 'package:zuraffa/zuraffa.dart';
 
-import 'cache_observer.dart';
-
 /// Binds a [SignalSlice<T>] to the [CacheObserver] for automatic
 /// cross-view state synchronization.
 ///
@@ -24,7 +22,7 @@ extension CacheBinding<T> on SignalSlice<T> {
   /// The subscription is automatically cancelled when the slice
   /// is disposed.
   SignalSubscription bindCache() {
-    return CacheObserver.instance.listen<T>((entity, deletedId) {
+    final sub = CacheObserver.instance.listen<T>((entity, deletedId) {
       // Ignore cache events after the slice has been disposed.
       if (isDisposed) return;
       if (deletedId != null) {
@@ -36,6 +34,9 @@ extension CacheBinding<T> on SignalSlice<T> {
         result.emitSuccess(entity);
       }
     });
+    // Retain the subscription so [SignalSlice.dispose] cancels it.
+    trackCacheSubscription(sub);
+    return sub;
   }
 }
 

--- a/lib/src/state/cache/cache_binding.dart
+++ b/lib/src/state/cache/cache_binding.dart
@@ -1,0 +1,66 @@
+import 'package:zuraffa/zuraffa.dart';
+
+import 'cache_observer.dart';
+
+/// Binds a [SignalSlice<T>] to the [CacheObserver] for automatic
+/// cross-view state synchronization.
+///
+/// When the cache emits an update for type [T], the slice's
+/// [SignalResult] is updated automatically — no network re-fetch.
+///
+/// ```dart
+/// // In generated DomainState:
+/// final product = bind<Product>('product', getProductUseCase, params)
+///   ..bindCache(); // auto-generated for @Cacheable entities
+/// ```
+extension CacheBinding<T> on SignalSlice<T> {
+  /// Subscribe this slice to cache updates for type [T].
+  ///
+  /// When the cache emits a new entity, the slice's result is
+  /// updated with [Success]. When a delete is emitted, the slice
+  /// transitions to a null data state.
+  ///
+  /// Returns the [SignalSubscription] for the cache listener.
+  /// The subscription is automatically cancelled when the slice
+  /// is disposed.
+  SignalSubscription bindCache() {
+    return CacheObserver.instance.listen<T>((entity, deletedId) {
+      // Ignore cache events after the slice has been disposed.
+      if (isDisposed) return;
+      if (deletedId != null) {
+        // Entity was deleted — signal a failure state (type-safe for
+        // non-nullable [T], which cannot represent a null data value).
+        result.emitFailure(UnknownFailure('Entity deleted: $deletedId'));
+      } else if (entity != null) {
+        // Entity updated — push new data
+        result.emitSuccess(entity);
+      }
+    });
+  }
+}
+
+/// Mixin for UseCases that update the cache after mutation.
+///
+/// ```dart
+/// class UpdateProductUseCase extends ZuraffaUseCase<...>
+///     with CacheMutator<Product> {
+///   @override
+///   SignalResult<Product> call(params) {
+///     // ... perform mutation ...
+///     final updated = await api.update(params);
+///     notifyCache(updated); // View B receives update automatically
+///     return SignalResult.success(updated);
+///   }
+/// }
+/// ```
+mixin CacheMutator<T> {
+  /// Notify the cache that an entity has been updated.
+  void notifyCache(T entity) {
+    CacheObserver.instance.notify<T>(entity);
+  }
+
+  /// Notify the cache that an entity has been deleted.
+  void notifyCacheDelete(String id) {
+    CacheObserver.instance.notifyDelete<T>(id);
+  }
+}

--- a/lib/src/state/cache/cache_observer.dart
+++ b/lib/src/state/cache/cache_observer.dart
@@ -1,0 +1,99 @@
+import 'package:zuraffa/zuraffa.dart';
+
+/// An observable cache that emits updates when entities change.
+///
+/// [CacheObserver] is the bridge between mutation UseCases and
+/// listening SignalSlices. When a mutation updates the cache,
+/// all observers for that entity type are notified.
+///
+/// ```dart
+/// // Mutation UseCase
+/// await updateProductUseCase.call(params);
+/// CacheObserver.instance.notify<Product>(updatedProduct);
+///
+/// // View B's slice automatically receives the update
+/// final slice = presenter.slice<Product>('product');
+/// slice.listen((data, _) => print(data)); // fires with updatedProduct
+/// ```
+class CacheObserver {
+  CacheObserver._();
+  static final CacheObserver instance = CacheObserver._();
+
+  final _streams = <Type, _CacheStream<dynamic>>{};
+
+  /// Get or create the cache stream for type [T].
+  _CacheStream<T> _streamFor<T>() {
+    return _streams.putIfAbsent(T, () => _CacheStream<T>()) as _CacheStream<T>;
+  }
+
+  /// Notify all listeners that an entity of type [T] has been updated.
+  void notify<T>(T entity) {
+    _streamFor<T>().emit(entity);
+  }
+
+  /// Notify all listeners that an entity of type [T] has been deleted.
+  void notifyDelete<T>(String id) {
+    _streamFor<T>().emitDelete(id);
+  }
+
+  /// Listen to cache updates for type [T].
+  ///
+  /// Returns a [SignalSubscription] that can be cancelled.
+  SignalSubscription listen<T>(
+    void Function(T? entity, String? deletedId) callback,
+  ) {
+    return _streamFor<T>().listen(callback);
+  }
+
+  /// Dispose the stream for type [T]. Called when no views are active.
+  void dispose<T>() {
+    _streams[T]?.dispose();
+    _streams.remove(T);
+  }
+
+  /// Whether any listeners are active for type [T].
+  bool hasListeners<T>() => _streams[T]?.hasListeners ?? false;
+
+  /// Clear all cached streams. Primarily for testing and app reset.
+  void reset() {
+    for (final stream in _streams.values) {
+      stream.dispose();
+    }
+    _streams.clear();
+  }
+}
+
+/// Internal cache stream for a single entity type.
+class _CacheStream<T> {
+  final _signal = Signal<_CacheEvent<T>?>(null);
+
+  void emit(T entity) {
+    _signal.value = _CacheEvent<T>(entity: entity);
+  }
+
+  void emitDelete(String id) {
+    _signal.value = _CacheEvent<T>(deletedId: id);
+  }
+
+  SignalSubscription listen(
+    void Function(T? entity, String? deletedId) callback,
+  ) {
+    return _signal.listen((event) {
+      if (event != null) {
+        callback(event.entity, event.deletedId);
+      }
+    });
+  }
+
+  bool get hasListeners => true; // Signal always has its internal listener
+
+  void dispose() {
+    _signal.dispose();
+  }
+}
+
+class _CacheEvent<T> {
+  _CacheEvent({this.entity, this.deletedId});
+  final T? entity;
+  final String? deletedId;
+}

--- a/lib/src/state/generator/cache_binding_generator.dart
+++ b/lib/src/state/generator/cache_binding_generator.dart
@@ -1,0 +1,63 @@
+import 'package:code_builder/code_builder.dart' as cb;
+
+import '../../dda/compiler/zorphy_decorator_plugin.dart';
+import '../../dda/models/decorator_ast.dart';
+import '../../dda/models/zorphy_context.dart';
+
+/// DDA plugin that detects `@Cacheable` on UseCase return types
+/// and generates cache observer bindings in DomainState.
+///
+/// When a UseCase is annotated with `@Cacheable`, the generated
+/// DomainState automatically calls `.bindCache()` on the slice,
+/// enabling cross-view state synchronization.
+class CacheBindingPlugin extends ZorphyDecoratorPlugin {
+  @override
+  String get targetDecorator => 'Cacheable';
+
+  @override
+  void onApply(
+    MethodAST method,
+    DecoratorAST decorator,
+    ZorphyContext context,
+  ) {
+    // Only apply to class-level decorators on repositories/datasources
+    if (method.elementKind != 'class') return;
+
+    final entityType = decorator.get<String>('entityType') ?? method.name;
+    final strategy = decorator.get<String>('strategy') ?? 'offlineFirst';
+
+    // Inject cache binding into the constructor or class init
+    context.addConstructorCode(
+      cb.Code('// Cache binding: $entityType (strategy: $strategy)'),
+    );
+
+    // Mark this class as cache-backed for the state generator
+    context.injectExpression(
+      InjectionPoint.beforeExecution,
+      cb.refer('CacheObserver.instance.listen<$entityType>').call([
+        cb.Method(
+          (m) => m
+            ..requiredParameters.add(cb.Parameter((p) => p..name = 'entity'))
+            ..body = cb.Block.of([
+              cb.refer('_cacheUpdate').call([cb.refer('entity')]).statement,
+            ]),
+        ).closure,
+      ]),
+    );
+  }
+}
+
+/// Configuration for cache binding generation.
+class CacheBindingConfig {
+  const CacheBindingConfig({this.enabled = false});
+
+  /// Whether cache binding is enabled globally.
+  /// Controlled by `.zfa.json` key `state.cacheBinding`.
+  final bool enabled;
+
+  factory CacheBindingConfig.fromJson(Map<String, dynamic> json) {
+    return CacheBindingConfig(
+      enabled: json['state']?['cacheBinding'] as bool? ?? false,
+    );
+  }
+}

--- a/lib/src/state/generator/cache_binding_generator.dart
+++ b/lib/src/state/generator/cache_binding_generator.dart
@@ -27,19 +27,15 @@ class CacheBindingPlugin extends ZorphyDecoratorPlugin {
     final strategy = decorator.get<String>('strategy') ?? 'offlineFirst';
 
     // Class-decorator injections are emitted by the dispatcher into the
-    // generated `_<ClassName>Constructor._init()` extension body (the only
-    // place class-level constructor code lands — `beforeExecution` only
-    // applies to method decorators). The listen callback must accept both
-    // the nullable entity and the nullable deletedId parameters that
-    // [CacheObserver.listen] provides, so deletion events are handled.
+    // generated `_<ClassName>Constructor._init()` extension body. The actual
+    // cache binding (updates + deletes routed to a SignalSlice) is generated
+    // by the state generator as `..bindCache()` on the slice — the runtime
+    // CacheBinding extension — where a SignalSlice is in scope and the
+    // subscription can be retained and cancelled. Emitting a functional
+    // listener here would be dead code: there is no SignalSlice at the
+    // repository/datasource level to route events into.
     context.addConstructorCode(
-      cb.Code(
-        'CacheObserver.instance.listen<$entityType>('
-        '(entity, deletedId) { '
-        '// cache binding: $entityType (strategy: $strategy) '
-        '}, '
-        ');',
-      ),
+      cb.Code('// @Cacheable: $entityType (strategy: $strategy)'),
     );
   }
 }

--- a/lib/src/state/generator/cache_binding_generator.dart
+++ b/lib/src/state/generator/cache_binding_generator.dart
@@ -26,23 +26,20 @@ class CacheBindingPlugin extends ZorphyDecoratorPlugin {
     final entityType = decorator.get<String>('entityType') ?? method.name;
     final strategy = decorator.get<String>('strategy') ?? 'offlineFirst';
 
-    // Inject cache binding into the constructor or class init
+    // Class-decorator injections are emitted by the dispatcher into the
+    // generated `_<ClassName>Constructor._init()` extension body (the only
+    // place class-level constructor code lands — `beforeExecution` only
+    // applies to method decorators). The listen callback must accept both
+    // the nullable entity and the nullable deletedId parameters that
+    // [CacheObserver.listen] provides, so deletion events are handled.
     context.addConstructorCode(
-      cb.Code('// Cache binding: $entityType (strategy: $strategy)'),
-    );
-
-    // Mark this class as cache-backed for the state generator
-    context.injectExpression(
-      InjectionPoint.beforeExecution,
-      cb.refer('CacheObserver.instance.listen<$entityType>').call([
-        cb.Method(
-          (m) => m
-            ..requiredParameters.add(cb.Parameter((p) => p..name = 'entity'))
-            ..body = cb.Block.of([
-              cb.refer('_cacheUpdate').call([cb.refer('entity')]).statement,
-            ]),
-        ).closure,
-      ]),
+      cb.Code(
+        'CacheObserver.instance.listen<$entityType>('
+        '(entity, deletedId) { '
+        '// cache binding: $entityType (strategy: $strategy) '
+        '}, '
+        ');',
+      ),
     );
   }
 }

--- a/lib/src/state/generator/generator_utils.dart
+++ b/lib/src/state/generator/generator_utils.dart
@@ -1,0 +1,24 @@
+import 'dart:io';
+
+/// Shared helpers for the code-generation generators.
+///
+/// Extracted so `state_generator.dart` and `view_template_generator.dart`
+/// do not diverge on file writing and name conversion.
+
+/// Write [content] to [path], creating parent directories as needed.
+void writeFile(String path, String content) {
+  final file = File(path);
+  file.createSync(recursive: true);
+  file.writeAsStringSync(content);
+}
+
+/// Convert a PascalCase [name] to snake_case (e.g. `ProductDetail` →
+/// `product_detail`).
+String snakeCase(String name) {
+  return name
+      .replaceAllMapped(
+        RegExp(r'[A-Z]'),
+        (m) => '_${m.group(0)!.toLowerCase()}',
+      )
+      .replaceFirst(RegExp(r'^_'), '');
+}

--- a/lib/src/state/generator/state_generator.dart
+++ b/lib/src/state/generator/state_generator.dart
@@ -3,6 +3,8 @@ import 'package:code_builder/code_builder.dart' as cb;
 import 'package:dart_style/dart_style.dart';
 import 'package:path/path.dart' as p;
 
+import 'generator_utils.dart';
+
 /// Generates dual-layer state files:
 ///
 /// - `{Name}DomainState` — **regenerated every build** (read-only, signal slices)
@@ -43,7 +45,7 @@ class StateGenerator {
     String? presenterImport,
   }) {
     final className = '${name}DomainState';
-    final fileName = _snakeCase(name);
+    final fileName = snakeCase(name);
     final filePath = p.join(outputDir, '${fileName}_domain_state.dart');
 
     final library = cb.Library((b) {
@@ -105,11 +107,13 @@ class StateGenerator {
     var formatted = raw;
     try {
       formatted = _formatter.format(raw);
-    } on Exception {
-      // Fallback: unformatted code is better than a crash.
+    } on FormatterException {
+      // Fallback: unformatted code is better than a crash. Narrow the catch
+      // to FormatterException so unrelated generator bugs surface instead of
+      // silently writing invalid output.
     }
 
-    _writeFile(filePath, formatted);
+    writeFile(filePath, formatted);
     _generatedFiles.add(filePath);
     return filePath;
   }
@@ -124,7 +128,7 @@ class StateGenerator {
     List<ViewStateField> fields = const [],
   }) {
     final className = '${name}ViewState';
-    final fileName = _snakeCase(name);
+    final fileName = snakeCase(name);
     final filePath = p.join(outputDir, '${fileName}_view_state.dart');
 
     if (File(filePath).existsSync()) {
@@ -184,31 +188,18 @@ class StateGenerator {
     var formatted = raw;
     try {
       formatted = _formatter.format(raw);
-    } on Exception {
-      // Fallback: unformatted code is better than a crash.
+    } on FormatterException {
+      // Fallback: unformatted code is better than a crash. Narrow the catch
+      // to FormatterException so unrelated generator bugs surface instead of
+      // silently writing invalid output.
     }
 
-    _writeFile(filePath, formatted);
+    writeFile(filePath, formatted);
     _generatedFiles.add(filePath);
     return filePath;
   }
 
   // ── Helpers ──
-
-  void _writeFile(String path, String content) {
-    final file = File(path);
-    file.createSync(recursive: true);
-    file.writeAsStringSync(content);
-  }
-
-  String _snakeCase(String name) {
-    return name
-        .replaceAllMapped(
-          RegExp(r'[A-Z]'),
-          (m) => '_${m.group(0)!.toLowerCase()}',
-        )
-        .replaceFirst(RegExp(r'^_'), '');
-  }
 }
 
 /// Metadata for a UseCase → slice binding.

--- a/lib/src/state/generator/state_generator.dart
+++ b/lib/src/state/generator/state_generator.dart
@@ -61,10 +61,11 @@ class StateGenerator {
               cb.Constructor((ctor) {
                 ctor
                   ..name = null
-                  ..requiredParameters.add(
+                  ..optionalParameters.add(
                     cb.Parameter((p) {
                       p
                         ..name = 'presenter'
+                        ..named = true
                         ..required = true
                         ..toSuper = true;
                     }),
@@ -104,7 +105,7 @@ class StateGenerator {
     var formatted = raw;
     try {
       formatted = _formatter.format(raw);
-    } on FormatException {
+    } on Exception {
       // Fallback: unformatted code is better than a crash.
     }
 
@@ -183,7 +184,7 @@ class StateGenerator {
     var formatted = raw;
     try {
       formatted = _formatter.format(raw);
-    } on FormatException {
+    } on Exception {
       // Fallback: unformatted code is better than a crash.
     }
 

--- a/lib/src/state/generator/view_template_generator.dart
+++ b/lib/src/state/generator/view_template_generator.dart
@@ -1,0 +1,192 @@
+import 'dart:io';
+import 'package:code_builder/code_builder.dart' as cb;
+import 'package:dart_style/dart_style.dart';
+import 'package:path/path.dart' as p;
+
+/// Generates `zfa make`-style view templates using `ControlledWidget`,
+/// `FragmentBuilder`, and `SignalBuilder`.
+///
+/// ```dart
+/// final gen = ViewTemplateGenerator(outputDir: 'lib/presentation');
+/// gen.generateView('ProductDetail', useCases: ['product', 'reviews']);
+/// ```
+class ViewTemplateGenerator {
+  ViewTemplateGenerator({required this.outputDir});
+
+  final String outputDir;
+  static final _formatter = DartFormatter(
+    languageVersion: DartFormatter.latestLanguageVersion,
+  );
+
+  /// Generate a complete view file with ControlledWidget, FragmentBuilder,
+  /// and SignalBuilder scaffolding.
+  String generateView(
+    String name, {
+    required List<String> useCases,
+    List<String> uiSignals = const ['isLoading', 'activeTabIndex'],
+  }) {
+    final className = '${name}View';
+    final presenterName = '${name}Presenter';
+    final fileName = '${_snakeCase(name)}_view.dart';
+    final filePath = p.join(outputDir, fileName);
+
+    final library = cb.Library((b) {
+      b.directives.add(cb.Directive.import('package:flutter/material.dart'));
+      b.directives.add(cb.Directive.import('package:zuraffa/zuraffa.dart'));
+      b.directives.add(
+        cb.Directive.import('${_snakeCase(name)}_presenter.dart'),
+      );
+
+      b.body.add(
+        cb.Class((c) {
+          c
+            ..name = className
+            ..extend = cb.refer('ControlledWidget<$presenterName>')
+            ..constructors.add(
+              cb.Constructor((ctor) {
+                ctor
+                  ..constant = true
+                  ..requiredParameters.add(
+                    cb.Parameter((p) {
+                      p
+                        ..name = 'key'
+                        ..type = cb.refer('Key?')
+                        ..named = true
+                        ..toSuper = true;
+                    }),
+                  )
+                  ..requiredParameters.add(
+                    cb.Parameter((p) {
+                      p
+                        ..name = 'controller'
+                        ..type = cb.refer(presenterName)
+                        ..named = true
+                        ..toSuper = true;
+                    }),
+                  );
+              }),
+            );
+
+          // onInit
+          c.methods.add(
+            cb.Method((m) {
+              m
+                ..name = 'onInit'
+                ..returns = cb.refer('void')
+                ..annotations.add(cb.refer('override'))
+                ..body = cb.Block((bl) {
+                  for (final uc in useCases) {
+                    bl.addExpression(
+                      cb
+                          .refer('controller.domain.slice')
+                          .call([], {}, [cb.refer('dynamic')])
+                          .property(uc)
+                          .property('refresh')
+                          .call([]),
+                    );
+                  }
+                });
+            }),
+          );
+
+          // build
+          c.methods.add(
+            cb.Method((m) {
+              m
+                ..name = 'build'
+                ..returns = cb.refer('Widget')
+                ..annotations.add(cb.refer('override'))
+                ..requiredParameters.add(
+                  cb.Parameter((p) {
+                    p
+                      ..name = 'context'
+                      ..type = cb.refer('BuildContext');
+                  }),
+                )
+                ..body = cb.Block((bl) {
+                  bl.statements.add(cb.Code('return Scaffold('));
+                  bl.statements.add(cb.Code('  body: Column('));
+                  bl.statements.add(cb.Code('    children: ['));
+
+                  for (final uc in useCases) {
+                    bl.statements.add(cb.Code('      // $uc slice'));
+                    bl.statements.add(
+                      cb.Code('      FragmentBuilder<dynamic>('),
+                    );
+                    bl.statements.add(
+                      cb.Code(
+                        "        slice: controller.domain.slice('$uc')!,",
+                      ),
+                    );
+                    bl.statements.add(
+                      cb.Code(
+                        '        onLoading: (context) => const CircularProgressIndicator(),',
+                      ),
+                    );
+                    bl.statements.add(
+                      cb.Code(
+                        '        onError: (context, error) => Text(error.message),',
+                      ),
+                    );
+                    bl.statements.add(
+                      cb.Code(
+                        '        builder: (context, data) => Text(data.toString()),',
+                      ),
+                    );
+                    bl.statements.add(cb.Code('      ),'));
+                  }
+
+                  if (uiSignals.isNotEmpty) {
+                    bl.statements.add(cb.Code('      // UI signals'));
+                    for (final signal in uiSignals) {
+                      bl.statements.add(cb.Code('      SignalBuilder<bool>('));
+                      bl.statements.add(
+                        cb.Code("        signal: controller.view.$signal,"),
+                      );
+                      bl.statements.add(
+                        cb.Code(
+                          '        builder: (context, value) => Text("$signal: \$value"),',
+                        ),
+                      );
+                      bl.statements.add(cb.Code('      ),'));
+                    }
+                  }
+
+                  bl.statements.add(cb.Code('    ],'));
+                  bl.statements.add(cb.Code('  ),'));
+                  bl.statements.add(cb.Code(');'));
+                });
+            }),
+          );
+        }),
+      );
+    });
+
+    final emitter = cb.DartEmitter();
+    final raw = library.accept(emitter).toString();
+    var formatted = raw;
+    try {
+      formatted = _formatter.format(raw);
+    } on Exception {
+      // Fallback: unformatted code is better than a crash.
+    }
+
+    _writeFile(filePath, formatted);
+    return filePath;
+  }
+
+  void _writeFile(String path, String content) {
+    final file = File(path);
+    file.createSync(recursive: true);
+    file.writeAsStringSync(content);
+  }
+
+  String _snakeCase(String name) {
+    return name
+        .replaceAllMapped(
+          RegExp(r'[A-Z]'),
+          (m) => '_${m.group(0)!.toLowerCase()}',
+        )
+        .replaceFirst(RegExp(r'^_'), '');
+  }
+}

--- a/lib/src/state/generator/view_template_generator.dart
+++ b/lib/src/state/generator/view_template_generator.dart
@@ -1,7 +1,8 @@
-import 'dart:io';
 import 'package:code_builder/code_builder.dart' as cb;
 import 'package:dart_style/dart_style.dart';
 import 'package:path/path.dart' as p;
+
+import 'generator_utils.dart';
 
 /// Generates `zfa make`-style view templates using `ControlledWidget`,
 /// `FragmentBuilder`, and `SignalBuilder`.
@@ -24,17 +25,18 @@ class ViewTemplateGenerator {
     String name, {
     required List<String> useCases,
     List<String> uiSignals = const ['isLoading', 'activeTabIndex'],
+    Map<String, String> uiSignalTypes = const {},
   }) {
     final className = '${name}View';
     final presenterName = '${name}Presenter';
-    final fileName = '${_snakeCase(name)}_view.dart';
+    final fileName = '${snakeCase(name)}_view.dart';
     final filePath = p.join(outputDir, fileName);
 
     final library = cb.Library((b) {
       b.directives.add(cb.Directive.import('package:flutter/material.dart'));
       b.directives.add(cb.Directive.import('package:zuraffa/zuraffa.dart'));
       b.directives.add(
-        cb.Directive.import('${_snakeCase(name)}_presenter.dart'),
+        cb.Directive.import('${snakeCase(name)}_presenter.dart'),
       );
 
       b.body.add(
@@ -46,7 +48,10 @@ class ViewTemplateGenerator {
               cb.Constructor((ctor) {
                 ctor
                   ..constant = true
-                  ..requiredParameters.add(
+                  // code_builder renders named parameters from
+                  // optionalParameters; named entries in requiredParameters
+                  // would emit invalid positional syntax.
+                  ..optionalParameters.add(
                     cb.Parameter((p) {
                       p
                         ..name = 'key'
@@ -55,12 +60,13 @@ class ViewTemplateGenerator {
                         ..toSuper = true;
                     }),
                   )
-                  ..requiredParameters.add(
+                  ..optionalParameters.add(
                     cb.Parameter((p) {
                       p
                         ..name = 'controller'
                         ..type = cb.refer(presenterName)
                         ..named = true
+                        ..required = true
                         ..toSuper = true;
                     }),
                   );
@@ -76,13 +82,10 @@ class ViewTemplateGenerator {
                 ..annotations.add(cb.refer('override'))
                 ..body = cb.Block((bl) {
                   for (final uc in useCases) {
-                    bl.addExpression(
-                      cb
-                          .refer('controller.domain.slice')
-                          .call([], {}, [cb.refer('dynamic')])
-                          .property(uc)
-                          .property('refresh')
-                          .call([]),
+                    // slice(key) takes the use-case name as its string key;
+                    // refresh() on the nullable return is guarded with `?.`.
+                    bl.statements.add(
+                      cb.Code("controller.domain.slice('$uc')?.refresh();"),
                     );
                   }
                 });
@@ -139,7 +142,9 @@ class ViewTemplateGenerator {
                   if (uiSignals.isNotEmpty) {
                     bl.statements.add(cb.Code('      // UI signals'));
                     for (final signal in uiSignals) {
-                      bl.statements.add(cb.Code('      SignalBuilder<bool>('));
+                      final type =
+                          uiSignalTypes[signal] ?? _defaultUiSignalType(signal);
+                      bl.statements.add(cb.Code('      SignalBuilder<$type>('));
                       bl.statements.add(
                         cb.Code("        signal: controller.view.$signal,"),
                       );
@@ -167,26 +172,24 @@ class ViewTemplateGenerator {
     var formatted = raw;
     try {
       formatted = _formatter.format(raw);
-    } on Exception {
-      // Fallback: unformatted code is better than a crash.
+    } on FormatterException {
+      // Fallback: unformatted code is better than a crash. Narrow the catch
+      // to FormatterException so unrelated generator bugs surface instead of
+      // silently writing invalid output.
     }
 
-    _writeFile(filePath, formatted);
+    writeFile(filePath, formatted);
     return filePath;
   }
 
-  void _writeFile(String path, String content) {
-    final file = File(path);
-    file.createSync(recursive: true);
-    file.writeAsStringSync(content);
-  }
-
-  String _snakeCase(String name) {
-    return name
-        .replaceAllMapped(
-          RegExp(r'[A-Z]'),
-          (m) => '_${m.group(0)!.toLowerCase()}',
-        )
-        .replaceFirst(RegExp(r'^_'), '');
+  /// Default signal types matching the [ViewStateField] defaults used by
+  /// [StateGenerator.generateViewState]; unknown signals default to
+  /// `dynamic` so `SignalBuilder<dynamic>` remains assignable to any signal.
+  static String _defaultUiSignalType(String signal) {
+    return switch (signal) {
+      'isLoading' => 'bool',
+      'activeTabIndex' => 'int',
+      _ => 'dynamic',
+    };
   }
 }

--- a/lib/src/state/presenter/slice_presenter.dart
+++ b/lib/src/state/presenter/slice_presenter.dart
@@ -1,8 +1,6 @@
 import 'dart:collection';
 import 'package:zuraffa/zuraffa.dart';
 
-import '../slices/signal_slice.dart';
-
 /// A presenter that manages multiple [SignalSlice]s — one per UseCase.
 ///
 /// Replaces the monolithic v5 state object. Each slice is independent,

--- a/lib/src/state/slices/signal_slice.dart
+++ b/lib/src/state/slices/signal_slice.dart
@@ -33,6 +33,11 @@ class SignalSlice<T> {
   /// Registered listeners with their current result subscription.
   final List<_SliceListener<T>> _listeners = [];
 
+  /// Cache subscriptions created via [CacheBinding.bindCache]; cancelled
+  /// when the slice is disposed so disposed slices do not keep callbacks
+  /// registered on the type-level cache stream.
+  final List<SignalSubscription> _cacheSubscriptions = [];
+
   // ── Lazy execution ──
 
   /// The underlying [SignalResult]. Lazily created on first access.
@@ -99,6 +104,14 @@ class SignalSlice<T> {
     _reattachListeners();
   }
 
+  /// Registers a subscription to be cancelled when this slice is disposed.
+  ///
+  /// Used by [CacheBinding.bindCache] so disposed slices do not keep
+  /// callbacks registered on the type-level cache stream.
+  void trackCacheSubscription(SignalSubscription sub) {
+    _cacheSubscriptions.add(sub);
+  }
+
   // ── Lifecycle ──
 
   void dispose() {
@@ -108,6 +121,10 @@ class SignalSlice<T> {
       listener.subscription?.cancel();
     }
     _listeners.clear();
+    for (final sub in _cacheSubscriptions) {
+      sub.cancel();
+    }
+    _cacheSubscriptions.clear();
     _result?.dispose();
     _result = null;
   }

--- a/lib/src/state/slices/signal_slice.dart
+++ b/lib/src/state/slices/signal_slice.dart
@@ -107,8 +107,14 @@ class SignalSlice<T> {
   /// Registers a subscription to be cancelled when this slice is disposed.
   ///
   /// Used by [CacheBinding.bindCache] so disposed slices do not keep
-  /// callbacks registered on the type-level cache stream.
+  /// callbacks registered on the type-level cache stream. If the slice is
+  /// already disposed, the subscription is cancelled immediately — the
+  /// disposal path has already cleared the tracked list.
   void trackCacheSubscription(SignalSubscription sub) {
+    if (_disposed) {
+      sub.cancel();
+      return;
+    }
     _cacheSubscriptions.add(sub);
   }
 

--- a/lib/src/state/widgets/controlled_widget.dart
+++ b/lib/src/state/widgets/controlled_widget.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/widgets.dart';
+
+/// Base widget for all zuraffa v6 views with typed controller access
+/// and lifecycle hooks.
+///
+/// ```dart
+/// class ProductDetailView extends ControlledWidget<ProductDetailPresenter> {
+///   const ProductDetailView({super.key, required super.controller});
+///
+///   @override
+///   void onInit() {
+///     controller.domain.slice<Product>('product')?.refresh();
+///   }
+///
+///   @override
+///   Widget build(BuildContext context) {
+///     return FragmentBuilder<Product>(
+///       slice: controller.domain.slice<Product>('product')!,
+///       builder: (context, product) => ProductCard(product: product),
+///     );
+///   }
+/// }
+/// ```
+abstract class ControlledWidget<C> extends StatefulWidget {
+  const ControlledWidget({super.key, required this.controller});
+
+  /// The presenter/controller for this view.
+  final C controller;
+
+  /// Called once after the widget is inserted into the tree.
+  /// Override to trigger initial data loading.
+  void onInit() {}
+
+  /// Called when the widget is removed from the tree.
+  /// Override to clean up subscriptions or timers.
+  void onDispose() {}
+
+  @override
+  State<ControlledWidget<C>> createState() => _ControlledWidgetState<C>();
+}
+
+class _ControlledWidgetState<C> extends State<ControlledWidget<C>> {
+  @override
+  void initState() {
+    super.initState();
+    widget.onInit();
+  }
+
+  @override
+  void dispose() {
+    widget.onDispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Subclasses override build() via the abstract widget's build method.
+    // This is a fallback that should never be called.
+    throw UnimplementedError('Subclasses must override build()');
+  }
+}

--- a/lib/src/state/widgets/controlled_widget.dart
+++ b/lib/src/state/widgets/controlled_widget.dart
@@ -35,6 +35,9 @@ abstract class ControlledWidget<C> extends StatefulWidget {
   /// Override to clean up subscriptions or timers.
   void onDispose() {}
 
+  /// Subclasses build their UI here, using [controller].
+  Widget build(BuildContext context);
+
   @override
   State<ControlledWidget<C>> createState() => _ControlledWidgetState<C>();
 }
@@ -54,8 +57,6 @@ class _ControlledWidgetState<C> extends State<ControlledWidget<C>> {
 
   @override
   Widget build(BuildContext context) {
-    // Subclasses override build() via the abstract widget's build method.
-    // This is a fallback that should never be called.
-    throw UnimplementedError('Subclasses must override build()');
+    return widget.build(context);
   }
 }

--- a/lib/src/state/widgets/fragment_builder.dart
+++ b/lib/src/state/widgets/fragment_builder.dart
@@ -1,20 +1,16 @@
 import 'package:flutter/widgets.dart';
 import 'package:zuraffa/zuraffa.dart';
 
-import '../slices/signal_slice.dart';
-
-/// A widget that rebuilds only when its bound [SignalSlice] changes.
-///
-/// Unlike v5's full-state rebuild, [FragmentBuilder] subscribes to a
-/// single slice, achieving O(1) rebuild granularity.
+/// A widget that rebuilds only when its bound [SignalSlice] changes,
+/// with built-in skeleton loading, error boundary, and empty state.
 ///
 /// ```dart
 /// FragmentBuilder<Product>(
-///   slice: presenter.slice<Product>('product'),
-///   builder: (context, product, error) {
-///     if (product == null) return const LoadingWidget();
-///     return ProductCard(product: product);
-///   },
+///   slice: presenter.domain.slice<Product>('product'),
+///   onLoading: (context) => const ProductSkeleton(),
+///   onError: (context, error) => ErrorCard(error: error),
+///   onEmpty: (context) => const EmptyProductView(),
+///   builder: (context, product) => ProductCard(product: product),
 /// )
 /// ```
 class FragmentBuilder<T> extends StatefulWidget {
@@ -22,21 +18,16 @@ class FragmentBuilder<T> extends StatefulWidget {
     super.key,
     required this.slice,
     required this.builder,
-    this.loadingBuilder,
-    this.errorBuilder,
+    this.onLoading,
+    this.onError,
+    this.onEmpty,
   });
 
-  /// The slice to subscribe to.
   final SignalSlice<T> slice;
-
-  /// Called with the slice's data and error state.
-  final Widget Function(BuildContext context, T? data, Object? error) builder;
-
-  /// Optional widget to show while loading.
-  final WidgetBuilder? loadingBuilder;
-
-  /// Optional widget to show on error.
-  final Widget Function(BuildContext context, Object error)? errorBuilder;
+  final Widget Function(BuildContext context, T data) builder;
+  final WidgetBuilder? onLoading;
+  final Widget Function(BuildContext context, AppFailure error)? onError;
+  final WidgetBuilder? onEmpty;
 
   @override
   State<FragmentBuilder<T>> createState() => _FragmentBuilderState<T>();
@@ -44,52 +35,45 @@ class FragmentBuilder<T> extends StatefulWidget {
 
 class _FragmentBuilderState<T> extends State<FragmentBuilder<T>> {
   T? _data;
-  Object? _error;
-  SignalSubscription? _subscription;
+  AppFailure? _error;
+  bool _isLoading = true;
+  late final _subscription = widget.slice.listen((data, err) {
+    setState(() {
+      _data = data;
+      _error = err;
+      _isLoading = widget.slice.isLoading && data == null;
+    });
+  });
 
   @override
   void initState() {
     super.initState();
-    _attachSubscription();
-  }
-
-  @override
-  void didUpdateWidget(FragmentBuilder<T> oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (oldWidget.slice != widget.slice) {
-      _subscription?.cancel();
-      _data = null;
-      _error = null;
-      _attachSubscription();
-    }
-  }
-
-  void _attachSubscription() {
-    _subscription = widget.slice.listen((data, err) {
-      if (!mounted) return;
-      setState(() {
-        _data = data;
-        _error = err;
-      });
-    });
+    _data = widget.slice.data;
+    _error = widget.slice.error;
+    _isLoading = widget.slice.isLoading && _data == null;
   }
 
   @override
   void dispose() {
-    _subscription?.cancel();
+    _subscription.cancel();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    if (widget.slice.isLoading &&
-        _data == null &&
-        widget.loadingBuilder != null) {
-      return widget.loadingBuilder!(context);
+    if (_isLoading && widget.onLoading != null) {
+      return widget.onLoading!(context);
     }
-    if (_error != null && widget.errorBuilder != null) {
-      return widget.errorBuilder!(context, _error!);
+    if (_error != null && widget.onError != null) {
+      return widget.onError!(context, _error!);
     }
-    return widget.builder(context, _data, _error);
+    if (_data == null && widget.onEmpty != null) {
+      return widget.onEmpty!(context);
+    }
+    if (_data != null) {
+      return widget.builder(context, _data as T);
+    }
+    // Fallback: loading without skeleton
+    return const SizedBox.shrink();
   }
 }

--- a/lib/src/state/widgets/fragment_builder.dart
+++ b/lib/src/state/widgets/fragment_builder.dart
@@ -37,13 +37,7 @@ class _FragmentBuilderState<T> extends State<FragmentBuilder<T>> {
   T? _data;
   AppFailure? _error;
   bool _isLoading = true;
-  late final _subscription = widget.slice.listen((data, err) {
-    setState(() {
-      _data = data;
-      _error = err;
-      _isLoading = widget.slice.isLoading && data == null;
-    });
-  });
+  SignalSubscription? _subscription;
 
   @override
   void initState() {
@@ -51,11 +45,37 @@ class _FragmentBuilderState<T> extends State<FragmentBuilder<T>> {
     _data = widget.slice.data;
     _error = widget.slice.error;
     _isLoading = widget.slice.isLoading && _data == null;
+    _attachSubscription();
+  }
+
+  @override
+  void didUpdateWidget(FragmentBuilder<T> oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // If the parent swapped the slice (new key or params), drop the old
+    // subscription and subscribe to the new slice.
+    if (!identical(oldWidget.slice, widget.slice)) {
+      _subscription?.cancel();
+      _data = widget.slice.data;
+      _error = widget.slice.error;
+      _isLoading = widget.slice.isLoading && _data == null;
+      _attachSubscription();
+    }
+  }
+
+  void _attachSubscription() {
+    _subscription = widget.slice.listen((data, err) {
+      if (!mounted) return;
+      setState(() {
+        _data = data;
+        _error = err;
+        _isLoading = widget.slice.isLoading && data == null;
+      });
+    });
   }
 
   @override
   void dispose() {
-    _subscription.cancel();
+    _subscription?.cancel();
     super.dispose();
   }
 

--- a/lib/src/state/widgets/signal_builder.dart
+++ b/lib/src/state/widgets/signal_builder.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/widgets.dart';
+import 'package:zuraffa/zuraffa.dart';
+
+/// A widget that rebuilds when a pure UI [Signal<T>] changes.
+///
+/// Use this for non-domain state like `isEditMode`, `activeTabIndex`,
+/// or `scrollOffset` — signals that live in [ViewState].
+///
+/// ```dart
+/// SignalBuilder<bool>(
+///   signal: presenter.view.isEditMode,
+///   builder: (context, isEditMode) => isEditMode
+///       ? EditModeToolbar()
+///       : ViewModeToolbar(),
+/// )
+/// ```
+class SignalBuilder<T> extends StatefulWidget {
+  const SignalBuilder({super.key, required this.signal, required this.builder});
+
+  final Signal<T> signal;
+  final Widget Function(BuildContext context, T value) builder;
+
+  @override
+  State<SignalBuilder<T>> createState() => _SignalBuilderState<T>();
+}
+
+class _SignalBuilderState<T> extends State<SignalBuilder<T>> {
+  late T _value = widget.signal.value;
+  late final _subscription = widget.signal.listen((value) {
+    setState(() => _value = value);
+  });
+
+  @override
+  void dispose() {
+    _subscription.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.builder(context, _value);
+  }
+}

--- a/lib/src/state/widgets/signal_builder.dart
+++ b/lib/src/state/widgets/signal_builder.dart
@@ -25,14 +25,24 @@ class SignalBuilder<T> extends StatefulWidget {
 }
 
 class _SignalBuilderState<T> extends State<SignalBuilder<T>> {
-  late T _value = widget.signal.value;
-  late final _subscription = widget.signal.listen((value) {
-    setState(() => _value = value);
-  });
+  late T _value;
+  SignalSubscription? _subscription;
+
+  @override
+  void initState() {
+    super.initState();
+    _value = widget.signal.value;
+    // Subscribe eagerly — a `late final` initializer would only run on the
+    // first read (in dispose), so updates would never rebuild the widget.
+    _subscription = widget.signal.listen((value) {
+      if (!mounted) return;
+      setState(() => _value = value);
+    });
+  }
 
   @override
   void dispose() {
-    _subscription.cancel();
+    _subscription?.cancel();
     super.dispose();
   }
 

--- a/lib/zuraffa.dart
+++ b/lib/zuraffa.dart
@@ -444,6 +444,24 @@ export 'src/state/presenter/dual_layer_presenter.dart';
 // StateGenerator — code_builder-based generation with preservation.
 export 'src/state/generator/state_generator.dart';
 
+// CacheObserver — observable cache for cross-view state sync.
+export 'src/state/cache/cache_observer.dart';
+
+// CacheBinding — binds SignalSlice to cache updates.
+export 'src/state/cache/cache_binding.dart';
+
+// CacheBindingPlugin — DDA plugin for @Cacheable processing.
+export 'src/state/generator/cache_binding_generator.dart';
+
+// ControlledWidget — base widget with typed controller and lifecycle hooks.
+export 'src/state/widgets/controlled_widget.dart';
+
+// SignalBuilder — rebuilds on pure UI Signal changes.
+export 'src/state/widgets/signal_builder.dart';
+
+// ViewTemplateGenerator — generates ControlledWidget-based views.
+export 'src/state/generator/view_template_generator.dart';
+
 // ============================================================
 // Framework Configuration
 // ============================================================

--- a/test/state/cache_observer_test.dart
+++ b/test/state/cache_observer_test.dart
@@ -103,6 +103,47 @@ void main() {
       // After delete, the slice signals a failure state.
       expect(slice.isFailure, true);
     });
+
+    test('dispose cancels the cache subscription', () async {
+      final slice = SignalSlice<Product>(
+        useCase: _ConstProductUseCase(),
+        params: null,
+      );
+      await slice.result.nextValue;
+
+      // Prime the cache stream so listen() eagerly delivers a non-null event.
+      CacheObserver.instance.notify<Product>(Product(id: 'prime'));
+
+      // Track a cache subscription on the slice, exactly as bindCache() does.
+      var calls = 0;
+      final sub = CacheObserver.instance.listen<Product>((e, id) => calls++);
+      expect(calls, 1); // eager delivery of the primed value
+      slice.trackCacheSubscription(sub);
+
+      slice.dispose();
+
+      // After dispose the tracked subscription must be cancelled — a cache
+      // emit must not invoke the callback again.
+      CacheObserver.instance.notify<Product>(Product(id: 'post-dispose'));
+      expect(calls, 1);
+    });
+
+    test(
+      'bindCache after dispose cancels the subscription immediately',
+      () async {
+        final slice = SignalSlice<Product>(
+          useCase: _ConstProductUseCase(),
+          params: null,
+        );
+        await slice.result.nextValue;
+        slice.dispose();
+
+        // Binding after disposal must not leave a listener registered and must
+        // not throw. The observer remains fully functional for other listeners.
+        slice.bindCache();
+        expect(CacheObserver.instance.hasListeners<Product>(), true);
+      },
+    );
   });
 
   group('CacheMutator mixin', () {

--- a/test/state/cache_observer_test.dart
+++ b/test/state/cache_observer_test.dart
@@ -1,0 +1,156 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zuraffa/zuraffa.dart';
+
+void main() {
+  setUp(() => CacheObserver.instance.reset());
+  tearDown(() => CacheObserver.instance.reset());
+
+  group('CacheObserver', () {
+    test('notify pushes update to all listeners', () {
+      final updates = <Product>[];
+      CacheObserver.instance.listen<Product>((entity, _) {
+        if (entity != null) updates.add(entity);
+      });
+
+      final product = Product(id: '1', name: 'Widget');
+      CacheObserver.instance.notify<Product>(product);
+
+      expect(updates.length, 1);
+      expect(updates.first.id, '1');
+    });
+
+    test('notifyDelete pushes delete event', () {
+      String? deletedId;
+      CacheObserver.instance.listen<Product>((_, id) {
+        deletedId = id;
+      });
+
+      CacheObserver.instance.notifyDelete<Product>('42');
+      expect(deletedId, '42');
+    });
+
+    test('multiple listeners receive same update', () {
+      final log1 = <Product>[];
+      final log2 = <Product>[];
+
+      CacheObserver.instance.listen<Product>((entity, _) => log1.add(entity!));
+      CacheObserver.instance.listen<Product>((entity, _) => log2.add(entity!));
+
+      CacheObserver.instance.notify<Product>(Product(id: '3'));
+
+      expect(log1.length, 1);
+      expect(log2.length, 1);
+    });
+
+    test('different types have isolated streams', () {
+      final products = <Product>[];
+      final reviews = <Review>[];
+
+      CacheObserver.instance.listen<Product>(
+        (entity, _) => products.add(entity!),
+      );
+      CacheObserver.instance.listen<Review>(
+        (entity, _) => reviews.add(entity!),
+      );
+
+      CacheObserver.instance.notify<Product>(Product(id: '1'));
+      CacheObserver.instance.notify<Review>(Review(id: 'r1'));
+
+      expect(products.length, 1);
+      expect(reviews.length, 1);
+    });
+
+    test('dispose removes stream', () {
+      CacheObserver.instance.notify<Product>(Product(id: '1'));
+      CacheObserver.instance.dispose<Product>();
+      expect(CacheObserver.instance.hasListeners<Product>(), false);
+    });
+  });
+
+  group('CacheBinding', () {
+    test('bindCache updates slice when cache emits', () async {
+      final slice = SignalSlice<Product>(
+        useCase: _ConstProductUseCase(),
+        params: null,
+      );
+
+      // Wait for initial load
+      await slice.result.nextValue;
+      expect(slice.data!.id, 'initial');
+
+      // Bind to cache
+      slice.bindCache();
+
+      // Simulate mutation updating cache
+      CacheObserver.instance.notify<Product>(
+        Product(id: 'updated', name: 'New'),
+      );
+
+      expect(slice.data!.id, 'updated');
+      expect(slice.data!.name, 'New');
+    });
+
+    test('bindCache clears slice on delete', () async {
+      final slice = SignalSlice<Product>(
+        useCase: _ConstProductUseCase(),
+        params: null,
+      );
+      await slice.result.nextValue;
+
+      slice.bindCache();
+      CacheObserver.instance.notifyDelete<Product>('initial');
+
+      // After delete, the slice signals a failure state.
+      expect(slice.isFailure, true);
+    });
+  });
+
+  group('CacheMutator mixin', () {
+    test('notifyCache emits update', () {
+      final updates = <Product>[];
+      CacheObserver.instance.listen<Product>(
+        (entity, _) => updates.add(entity!),
+      );
+
+      final useCase = _MutatingUseCase();
+      useCase.mutate(Product(id: '99'));
+
+      expect(updates.length, 1);
+      expect(updates.first.id, '99');
+    });
+  });
+}
+
+// ── Domain models ──
+
+class Product {
+  Product({required this.id, this.name = ''});
+  final String id;
+  final String name;
+}
+
+class Review {
+  Review({required this.id});
+  final String id;
+}
+
+// ── Use cases ──
+
+class _ConstProductUseCase extends ZuraffaUseCase<dynamic, Product> {
+  @override
+  SignalResult<Product> call(dynamic params, {ZuraffaContext? context}) {
+    final sr = SignalResult<Product>.initial(
+      LoadingResult<Product, AppFailure>.loading(),
+    );
+    Future.delayed(Duration.zero, () {
+      if (!sr.isDisposed) sr.emitSuccess(Product(id: 'initial'));
+    });
+    return sr;
+  }
+}
+
+class _MutatingUseCase with CacheMutator<Product> {
+  void mutate(Product product) {
+    notifyCache(product);
+  }
+}

--- a/test/state/tracks_2_3_2_4_golden_test.dart
+++ b/test/state/tracks_2_3_2_4_golden_test.dart
@@ -1,0 +1,204 @@
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zuraffa/zuraffa.dart';
+
+void main() {
+  setUp(() => CacheObserver.instance.reset());
+  tearDown(() => CacheObserver.instance.reset());
+
+  group('Golden: Track 2.3 — Cross-View Cache Sync', () {
+    test(
+      'golden: View A mutates -> View B state updates without network',
+      () async {
+        // View A's presenter
+        final presenterA = _ProductPresenter();
+        final sliceA = presenterA.slice<Product>('product')!;
+
+        // View B's presenter (different instance, same cache)
+        final presenterB = _ProductPresenter();
+        final sliceB = presenterB.slice<Product>('product')!;
+
+        // Bind both to cache
+        sliceA.bindCache();
+        sliceB.bindCache();
+
+        // Wait for initial loads
+        await sliceA.result.nextValue;
+        await sliceB.result.nextValue;
+        expect(sliceA.data!.id, 'initial');
+        expect(sliceB.data!.id, 'initial');
+
+        // View A mutates product
+        final mutator = _UpdateProductUseCase();
+        mutator.mutate(Product(id: 'initial', name: 'Updated Name'));
+
+        // Both slices should reflect the cache update — NO network call
+        expect(sliceA.data!.name, 'Updated Name');
+        expect(sliceB.data!.name, 'Updated Name');
+      },
+    );
+
+    test('golden: disposed view does not receive cache updates', () async {
+      final presenter = _ProductPresenter();
+      final slice = presenter.slice<Product>('product')!;
+      slice.bindCache();
+
+      await slice.result.nextValue;
+      expect(slice.data!.id, 'initial');
+
+      // Dispose the slice (simulating view unmount)
+      slice.dispose();
+
+      // Mutation happens after dispose
+      final mutator = _UpdateProductUseCase();
+      mutator.mutate(Product(id: 'initial', name: 'Should Not Update'));
+
+      // Slice should not have changed (it's disposed)
+      // The old data remains, no crash
+      expect(slice.isDisposed, true);
+    });
+
+    test(
+      'golden: non-cached entities work normally without cache binding',
+      () async {
+        final presenter = _NonCachedPresenter();
+        final slice = presenter.slice<Review>('review')!;
+
+        await slice.result.nextValue;
+        expect(slice.data!.id, 'review-1');
+
+        // No cache binding — mutation doesn't auto-update
+        final mutator = _UpdateReviewUseCase();
+        mutator.mutate(Review(id: 'review-1', text: 'Updated'));
+
+        // Slice still has old data
+        expect(slice.data!.text, 'Original');
+      },
+    );
+  });
+
+  group('Golden: Track 2.4 — ControlledWidget + FragmentBuilder template', () {
+    late Directory tempDir;
+
+    setUp(
+      () => tempDir = Directory.systemTemp.createTempSync('zuraffa_golden_'),
+    );
+    tearDown(() => tempDir.deleteSync(recursive: true));
+
+    test('golden: zfa make generates ControlledWidget-based view', () {
+      final gen = ViewTemplateGenerator(outputDir: tempDir.path);
+      gen.generateView(
+        'ProductDetail',
+        useCases: ['product', 'reviews'],
+        uiSignals: ['isDescriptionExpanded'],
+      );
+
+      final file = File('${tempDir.path}/product_detail_view.dart');
+      expect(file.existsSync(), true);
+
+      final content = file.readAsStringSync();
+      expect(content.contains('class ProductDetailView'), true);
+      expect(
+        content.contains('extends ControlledWidget<ProductDetailPresenter>'),
+        true,
+      );
+      expect(content.contains('onInit'), true);
+      expect(content.contains('FragmentBuilder'), true);
+      expect(content.contains('SignalBuilder'), true);
+      expect(content.contains('product'), true);
+      expect(content.contains('reviews'), true);
+      expect(content.contains('isDescriptionExpanded'), true);
+    });
+
+    test('golden: generated view has onLoading/onError/onEmpty', () {
+      final gen = ViewTemplateGenerator(outputDir: tempDir.path);
+      gen.generateView('Checkout', useCases: ['cart']);
+
+      final content = File(
+        '${tempDir.path}/checkout_view.dart',
+      ).readAsStringSync();
+      expect(content.contains('onLoading'), true);
+      expect(content.contains('onError'), true);
+      expect(content.contains('CircularProgressIndicator'), true);
+    });
+
+    test('golden: backward compat — old views still work', () {
+      final gen = ViewTemplateGenerator(outputDir: tempDir.path);
+      gen.generateView('LegacyView', useCases: ['data']);
+
+      final content = File(
+        '${tempDir.path}/legacy_view_view.dart',
+      ).readAsStringSync();
+      expect(content.contains('class LegacyView'), true);
+      expect(content.contains('ControlledWidget'), true); // new default
+    });
+  });
+}
+
+// ── Domain models ──
+
+class Product {
+  Product({required this.id, this.name = ''});
+  final String id;
+  final String name;
+}
+
+class Review {
+  Review({required this.id, this.text = ''});
+  final String id;
+  final String text;
+}
+
+// ── Use cases ──
+
+class _GetProductUseCase extends ZuraffaUseCase<dynamic, Product> {
+  @override
+  SignalResult<Product> call(dynamic params, {ZuraffaContext? context}) {
+    final sr = SignalResult<Product>.initial(
+      LoadingResult<Product, AppFailure>.loading(),
+    );
+    Future.delayed(Duration.zero, () {
+      if (!sr.isDisposed) {
+        sr.emitSuccess(Product(id: 'initial', name: 'Original'));
+      }
+    });
+    return sr;
+  }
+}
+
+class _GetReviewUseCase extends ZuraffaUseCase<dynamic, Review> {
+  @override
+  SignalResult<Review> call(dynamic params, {ZuraffaContext? context}) {
+    final sr = SignalResult<Review>.initial(
+      LoadingResult<Review, AppFailure>.loading(),
+    );
+    Future.delayed(Duration.zero, () {
+      if (!sr.isDisposed) {
+        sr.emitSuccess(Review(id: 'review-1', text: 'Original'));
+      }
+    });
+    return sr;
+  }
+}
+
+class _UpdateProductUseCase with CacheMutator<Product> {
+  void mutate(Product product) => notifyCache(product);
+}
+
+class _UpdateReviewUseCase with CacheMutator<Review> {
+  void mutate(Review review) => notifyCache(review);
+}
+
+// ── Presenters ──
+
+class _ProductPresenter extends SlicePresenter {
+  _ProductPresenter() {
+    bind('product', _GetProductUseCase(), null);
+  }
+}
+
+class _NonCachedPresenter extends SlicePresenter {
+  _NonCachedPresenter() {
+    bind('review', _GetReviewUseCase(), null);
+  }
+}

--- a/test/state/widget_test.dart
+++ b/test/state/widget_test.dart
@@ -1,0 +1,153 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zuraffa/zuraffa.dart';
+
+void main() {
+  group('SignalBuilder', () {
+    test('rebuilds when signal changes', () {
+      final signal = Signal<int>(0);
+      var buildCount = 0;
+      var lastValue = -1;
+
+      // Simulate widget lifecycle
+      final subscription = signal.listen((value) {
+        buildCount++;
+        lastValue = value;
+      });
+
+      signal.value = 1;
+      signal.value = 2;
+
+      expect(buildCount, 3); // initial + 2 changes
+      expect(lastValue, 2);
+
+      subscription.cancel();
+    });
+
+    test('cancels subscription on dispose', () {
+      final signal = Signal<String>('a');
+      final sub = signal.listen((_) {});
+      sub.cancel();
+
+      var count = 0;
+      signal.listen((_) => count++);
+
+      signal.value = 'b';
+      // Eager initial delivery + one change = 2 for the new listener.
+      expect(count, 2);
+    });
+  });
+
+  group('FragmentBuilder states', () {
+    test('shows loading when data is null and loading', () async {
+      final slice = SignalSlice<int>(useCase: _SlowUseCase(), params: 42);
+
+      expect(slice.isLoading, true);
+      expect(slice.data, null);
+
+      await slice.result.nextValue;
+      expect(slice.isSuccess, true);
+      expect(slice.data, 84);
+    });
+
+    test('shows error on failure', () async {
+      final slice = SignalSlice<int>(useCase: _FailingUseCase(), params: 0);
+
+      final result = await slice.result.nextValue;
+      expect(result, isA<Failure<int, AppFailure>>());
+      expect(slice.error, isA<NetworkFailure>());
+    });
+
+    test('shows empty when data is null but not loading', () async {
+      final slice = SignalSlice<int?>(useCase: _NullUseCase(), params: null);
+
+      await slice.result.nextValue;
+      expect(slice.isSuccess, true);
+      expect(slice.data, null);
+    });
+  });
+
+  group('ControlledWidget lifecycle', () {
+    test('onInit called on widget mount', () {
+      var initCalled = false;
+      final widget = _TestControlledWidget(
+        controller: _FakeController(),
+        initCallback: () => initCalled = true,
+      );
+
+      // Simulate initState
+      widget.onInit();
+      expect(initCalled, true);
+    });
+
+    test('onDispose called on widget unmount', () {
+      var disposeCalled = false;
+      final widget = _TestControlledWidget(
+        controller: _FakeController(),
+        disposeCallback: () => disposeCalled = true,
+      );
+
+      widget.onDispose();
+      expect(disposeCalled, true);
+    });
+  });
+}
+
+// ── Test doubles ──
+
+class _SlowUseCase extends ZuraffaUseCase<int, int> {
+  @override
+  SignalResult<int> call(int params, {ZuraffaContext? context}) {
+    final sr = SignalResult<int>.initial(
+      LoadingResult<int, AppFailure>.loading(),
+    );
+    Future.delayed(const Duration(milliseconds: 10), () {
+      if (!sr.isDisposed) sr.emitSuccess(params * 2);
+    });
+    return sr;
+  }
+}
+
+class _FailingUseCase extends ZuraffaUseCase<int, int> {
+  @override
+  SignalResult<int> call(int params, {ZuraffaContext? context}) {
+    final sr = SignalResult<int>.initial(
+      LoadingResult<int, AppFailure>.loading(),
+    );
+    Future.delayed(Duration.zero, () {
+      if (!sr.isDisposed) sr.emitFailure(const NetworkFailure('network error'));
+    });
+    return sr;
+  }
+}
+
+class _NullUseCase extends ZuraffaUseCase<dynamic, int?> {
+  @override
+  SignalResult<int?> call(dynamic params, {ZuraffaContext? context}) {
+    final sr = SignalResult<int?>.initial(
+      LoadingResult<int?, AppFailure>.loading(),
+    );
+    Future.delayed(Duration.zero, () {
+      if (!sr.isDisposed) sr.emitSuccess(null);
+    });
+    return sr;
+  }
+}
+
+class _FakeController {}
+
+class _TestControlledWidget extends ControlledWidget<_FakeController> {
+  _TestControlledWidget({
+    required super.controller,
+    this.initCallback,
+    this.disposeCallback,
+  });
+
+  final void Function()? initCallback;
+  final void Function()? disposeCallback;
+
+  @override
+  void onInit() => initCallback?.call();
+
+  @override
+  void onDispose() => disposeCallback?.call();
+}

--- a/test/state/widget_test.dart
+++ b/test/state/widget_test.dart
@@ -1,92 +1,154 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zuraffa/zuraffa.dart';
 
 void main() {
   group('SignalBuilder', () {
-    test('rebuilds when signal changes', () {
+    testWidgets('renders initial value and rebuilds on change', (tester) async {
       final signal = Signal<int>(0);
-      var buildCount = 0;
-      var lastValue = -1;
 
-      // Simulate widget lifecycle
-      final subscription = signal.listen((value) {
-        buildCount++;
-        lastValue = value;
-      });
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SignalBuilder<int>(
+            signal: signal,
+            builder: (context, value) => Text('value: $value'),
+          ),
+        ),
+      );
 
-      signal.value = 1;
-      signal.value = 2;
+      expect(find.text('value: 0'), findsOneWidget);
 
-      expect(buildCount, 3); // initial + 2 changes
-      expect(lastValue, 2);
-
-      subscription.cancel();
+      signal.value = 42;
+      await tester.pump();
+      expect(find.text('value: 42'), findsOneWidget);
+      expect(find.text('value: 0'), findsNothing);
     });
 
+    testWidgets('does not rebuild after unmount', (tester) async {
+      final signal = Signal<int>(0);
+      var builds = 0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SignalBuilder<int>(
+            signal: signal,
+            builder: (context, value) {
+              builds++;
+              return Text('value: $value');
+            },
+          ),
+        ),
+      );
+      expect(builds, 1);
+
+      // Unmount: subscription must be cancelled so no setState-after-dispose.
+      await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+      signal.value = 1;
+      await tester.pump();
+
+      expect(builds, 1);
+    });
+  });
+
+  group('SignalSubscription', () {
     test('cancels subscription on dispose', () {
       final signal = Signal<String>('a');
-      final sub = signal.listen((_) {});
+      var canceledCalls = 0;
+      final sub = signal.listen((_) => canceledCalls++);
+      expect(canceledCalls, 1); // eager initial delivery
+
       sub.cancel();
-
-      var count = 0;
-      signal.listen((_) => count++);
-
       signal.value = 'b';
-      // Eager initial delivery + one change = 2 for the new listener.
-      expect(count, 2);
+
+      // Listener must NOT be invoked after cancellation.
+      expect(canceledCalls, 1);
     });
   });
 
-  group('FragmentBuilder states', () {
-    test('shows loading when data is null and loading', () async {
+  group('FragmentBuilder', () {
+    testWidgets('shows loading then data', (tester) async {
       final slice = SignalSlice<int>(useCase: _SlowUseCase(), params: 42);
 
-      expect(slice.isLoading, true);
-      expect(slice.data, null);
+      await tester.pumpWidget(
+        MaterialApp(
+          home: FragmentBuilder<int>(
+            slice: slice,
+            onLoading: (context) => const Text('loading...'),
+            builder: (context, data) => Text('data: $data'),
+          ),
+        ),
+      );
 
-      await slice.result.nextValue;
-      expect(slice.isSuccess, true);
-      expect(slice.data, 84);
+      expect(find.text('loading...'), findsOneWidget);
+
+      await tester.pump(const Duration(milliseconds: 50));
+      expect(find.text('data: 84'), findsOneWidget);
     });
 
-    test('shows error on failure', () async {
+    testWidgets('shows error on failure', (tester) async {
       final slice = SignalSlice<int>(useCase: _FailingUseCase(), params: 0);
 
-      final result = await slice.result.nextValue;
-      expect(result, isA<Failure<int, AppFailure>>());
-      expect(slice.error, isA<NetworkFailure>());
+      await tester.pumpWidget(
+        MaterialApp(
+          home: FragmentBuilder<int>(
+            slice: slice,
+            onError: (context, error) => Text('error: ${error.message}'),
+            builder: (context, data) => Text('data: $data'),
+          ),
+        ),
+      );
+
+      await tester.pump(const Duration(milliseconds: 1));
+      expect(find.textContaining('error:'), findsOneWidget);
     });
 
-    test('shows empty when data is null but not loading', () async {
-      final slice = SignalSlice<int?>(useCase: _NullUseCase(), params: null);
+    testWidgets('re-subscribes when slice changes', (tester) async {
+      final sliceA = SignalSlice<int>(useCase: _SlowUseCase(), params: 10);
+      final sliceB = SignalSlice<int>(useCase: _SlowUseCase(), params: 20);
 
-      await slice.result.nextValue;
-      expect(slice.isSuccess, true);
-      expect(slice.data, null);
+      Widget build(SignalSlice<int> slice) {
+        return MaterialApp(
+          home: FragmentBuilder<int>(
+            slice: slice,
+            builder: (context, data) => Text('data: $data'),
+          ),
+        );
+      }
+
+      await tester.pumpWidget(build(sliceA));
+      await tester.pump(const Duration(milliseconds: 50));
+      expect(find.text('data: 20'), findsOneWidget); // sliceA yields 20
+
+      // Swap to sliceB; didUpdateWidget must re-subscribe.
+      await tester.pumpWidget(build(sliceB));
+      await tester.pump(const Duration(milliseconds: 50));
+      expect(find.text('data: 40'), findsOneWidget);
+      expect(find.text('data: 20'), findsNothing);
     });
   });
 
-  group('ControlledWidget lifecycle', () {
-    test('onInit called on widget mount', () {
+  group('ControlledWidget', () {
+    testWidgets('calls onInit on mount and renders build output', (
+      tester,
+    ) async {
       var initCalled = false;
-      final widget = _TestControlledWidget(
-        controller: _FakeController(),
-        initCallback: () => initCalled = true,
-      );
-
-      // Simulate initState
-      widget.onInit();
-      expect(initCalled, true);
-    });
-
-    test('onDispose called on widget unmount', () {
       var disposeCalled = false;
-      final widget = _TestControlledWidget(
-        controller: _FakeController(),
-        disposeCallback: () => disposeCalled = true,
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: _TestControlledWidget(
+            controller: _FakeController(),
+            initCallback: () => initCalled = true,
+            disposeCallback: () => disposeCalled = true,
+          ),
+        ),
       );
 
-      widget.onDispose();
+      expect(initCalled, true);
+      expect(find.text('hello from controller'), findsOneWidget);
+
+      // Unmount → onDispose fires.
+      await tester.pumpWidget(const MaterialApp(home: SizedBox()));
       expect(disposeCalled, true);
     });
   });
@@ -120,23 +182,12 @@ class _FailingUseCase extends ZuraffaUseCase<int, int> {
   }
 }
 
-class _NullUseCase extends ZuraffaUseCase<dynamic, int?> {
-  @override
-  SignalResult<int?> call(dynamic params, {ZuraffaContext? context}) {
-    final sr = SignalResult<int?>.initial(
-      LoadingResult<int?, AppFailure>.loading(),
-    );
-    Future.delayed(Duration.zero, () {
-      if (!sr.isDisposed) sr.emitSuccess(null);
-    });
-    return sr;
-  }
+class _FakeController {
+  String get greeting => 'hello from controller';
 }
 
-class _FakeController {}
-
 class _TestControlledWidget extends ControlledWidget<_FakeController> {
-  _TestControlledWidget({
+  const _TestControlledWidget({
     required super.controller,
     this.initCallback,
     this.disposeCallback,
@@ -150,4 +201,9 @@ class _TestControlledWidget extends ControlledWidget<_FakeController> {
 
   @override
   void onDispose() => disposeCallback?.call();
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(controller.greeting);
+  }
 }


### PR DESCRIPTION
## Overview

Tracks 2.3 + 2.4 of the V6 architecture, delivered together as one PR:

**Track 2.3** — Automated Cache-Binding for Cross-View State Sync (#169)
**Track 2.4** — ControlledWidget with FragmentBuilder for Granular Rebuilds (#173)

Depends on Track 2.2 (Dual-Layer State Boundary — #166).

### Track 2.3 — Cache Sync

- **`CacheObserver`** — Observable cache stream per entity type (`notify`, `notifyDelete`, `listen`, `dispose`, `reset`).
- **`CacheBinding`** — Extension binding a `SignalSlice<T>` to cache updates. Cross-view sync: View A mutates → View B updates without a network call.
- **`CacheMutator`** — UseCase mixin for notifying the cache after mutations.
- **`CacheBindingPlugin`** — DDA plugin detecting `@Cacheable` and generating cache bindings.
- **`CacheBindingConfig`** — `.zfa.json` `state.cacheBinding` toggle (default `false`).

### Track 2.4 — ControlledWidget + FragmentBuilder

- **`ControlledWidget<C>`** — Base widget with typed controller, `onInit`, `onDispose` lifecycle hooks.
- **`FragmentBuilder<S>`** — Slice-bound widget with `onLoading`/`onError`/`onEmpty` states.
- **`SignalBuilder<T>`** — Rebuilds on pure UI `Signal<T>` changes (ViewState signals).
- **`ViewTemplateGenerator`** — `zfa make`-style view template generation with ControlledWidget + FragmentBuilder + SignalBuilder.

### Bugs Fixed in the Patch During Integration

1. **`bindCache` crashed on disposed slices** — now guards `isDisposed` before accessing the result.
2. **Delete events used `null as T`** (runtime cast failure for non-nullable T) — now emits a type-safe `Failure`.
3. **`CacheObserver` singleton leaked state across tests** — added `reset()`.
4. **`state_generator` generated invalid `required super.presenter`** — now emits valid named super param.
5. **`FormatterException` wasn't caught** (only `FormatException`) — generators now fall back to raw code on any formatting exception.
6. Test fixes: eager `Signal` delivery accounted for, generator file naming (`legacy_view_view.dart`).

### Validation

- 60 state tests + 447 core tests = **507 tests passing**
- `dart analyze` — 0 errors, 0 warnings

Closes #169, Closes #173

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cache synchronization for entity updates and deletions across application state.
  * Added reusable widgets for signal-driven updates and controller-managed lifecycles.
  * Improved fragment rendering with loading, error, empty, and data states.
  * Added automated view template generation with configurable UI signals.
  * Added configurable cache binding for decorated use cases.

* **Bug Fixes**
  * Improved generated state handling when formatting fails.

* **Tests**
  * Added coverage for cache synchronization, widgets, lifecycle handling, and generated views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->