### PR TITLE
feat: add OsBackgroundTask use case type wrapping workmanager

### DIFF
--- a/lib/src/commands/usecase_command.dart
+++ b/lib/src/commands/usecase_command.dart
@@ -18,7 +18,7 @@ class UseCaseCommand extends PluginCommand {
     argParser.addOption(
       'type',
       abbr: 't',
-      allowed: ['future', 'stream', 'completable', 'sync', 'background'],
+      allowed: ['future', 'stream', 'completable', 'sync', 'background', 'os_background'],
       defaultsTo: 'future',
       help: 'Execution strategy (default: future/fetch)',
     );

--- a/lib/src/domain/os_background_task.dart
+++ b/lib/src/domain/os_background_task.dart
@@ -129,8 +129,14 @@ class OsBackgroundTaskDescriptor {
   final OsBackgroundTaskSchedule schedule;
 
   /// Whether this task should run even when the app is terminated.
-  /// On Android this is always true for `PeriodicWorkRequest`.
-  /// On iOS this depends on the background mode registration.
+  ///
+  /// **Note**: This field is informational only and does not affect actual
+  /// scheduling behavior:
+  /// - **Android**: WorkManager tasks always run when the app is terminated
+  ///   (this is the normal/expected behavior for PeriodicWorkRequest).
+  /// - **iOS/macOS**: Background execution depends on background modes
+  ///   configured in Info.plist and entitlements, not this flag.
+  /// - **Web**: Not applicable (no OS background scheduling).
   final bool runWhenAppTerminated;
 
   const OsBackgroundTaskDescriptor({
@@ -147,34 +153,6 @@ class OsBackgroundTaskDescriptor {
 /// it runs in the app's background handler. Keep it lightweight and
 /// do NOT access the UI layer.
 typedef OsBackgroundTaskHandler = Future<void> Function();
-
-/// Registered task handler registry.
-///
-/// Maps task identifiers to their handler functions. The [callbackDispatcher]
-/// uses this registry to dispatch tasks.
-final Map<String, OsBackgroundTaskHandler> _osTaskHandlers = {};
-
-/// The background isolate entry point for workmanager.
-///
-/// Registered with `@pragma('vm:entry-point')` so the Dart VM preserves it
-/// as a valid entry point for background isolate spawning.
-///
-/// **Do NOT call this directly.** It is invoked by workmanager when the OS
-/// schedules a background execution.
-@pragma('vm:entry-point')
-void osBackgroundTaskCallbackDispatcher() {
-  Workmanager().executeTask((task, inputData) async {
-    final handler = _osTaskHandlers[task];
-    if (handler != null) {
-      await handler();
-      return true;
-    }
-    debugPrint(
-      '[OsBackgroundTask] No handler registered for task: $task',
-    );
-    return false;
-  });
-}
 
 /// A use-case abstraction for OS-scheduled background tasks wrapping
 /// `workmanager` (iOS / Android / macOS).
@@ -200,52 +178,91 @@ void osBackgroundTaskCallbackDispatcher() {
 /// - Not supported. [OsBackgroundTask.register] is a no-op on web,
 ///   and [OsBackgroundTask.initialize] completes immediately.
 ///
+/// ## Background Isolate Dispatch (CRITICAL)
+///
+/// On Android, workmanager spawns a **fresh isolate** with ONLY the
+/// registered callback dispatcher as its entry point. The main isolate's
+/// code (including `main()`) does NOT run in the background isolate, and
+/// isolates do NOT share mutable heap state.
+///
+/// **Your app MUST provide its own top-level dispatcher function** that:
+/// 1. Is annotated with `@pragma('vm:entry-point')`
+/// 2. Contains a **compile-time map literal** of task identifiers to handlers
+/// 3. Calls [OsBackgroundTask.dispatch] to execute the task
+///
+/// The framework does NOT maintain a cross-isolate registry. You must write
+/// the handler map directly in your dispatcher's source code so it's
+/// rebuilt fresh in the background isolate each time.
+///
 /// ## Usage
 ///
 /// ```dart
-/// // In main() before runApp():
-/// await OsBackgroundTask.initialize();
+/// // 1. Define your top-level dispatcher (in your app code, NOT zuraffa):
+/// @pragma('vm:entry-point')
+/// void myAppCallbackDispatcher() {
+///   OsBackgroundTask.dispatch({
+///     'com.app.sync-data': SyncDataTaskUseCase.callbackHandler,
+///     'com.app.cleanup': CleanupTaskUseCase.callbackHandler,
+///     // Add all your task handlers here as compile-time references
+///   });
+/// }
 ///
-/// // Register a task:
-/// OsBackgroundTask.register(
-///   OsBackgroundTaskDescriptor(
-///     identifier: 'com.app.sync-data',
-///     taskName: 'SyncData',
-///     schedule: OsBackgroundTaskSchedule(
-///       frequency: Duration(minutes: 30),
-///       networkConstraint: OsNetworkConstraint.connected,
-///     ),
-///   ),
-///   () async {
-///     // Your background work here
-///     final data = await fetchData();
-///     await saveLocally(data);
-///   },
-/// );
+/// // 2. In main() before runApp():
+/// Future<void> main() async {
+///   WidgetsFlutterBinding.ensureInitialized();
+///   await OsBackgroundTask.initialize(
+///     callbackDispatcher: myAppCallbackDispatcher,
+///   );
+///   runApp(MyApp());
+/// }
+///
+/// // 3. Register tasks (the map in your dispatcher defines which handlers exist):
+/// final syncTask = SyncDataTaskUseCase(dataService);
+/// await syncTask.register(); // Uses descriptor.identifier
 /// ```
 class OsBackgroundTask {
   /// Whether workmanager has been initialized.
   static bool _initialized = false;
 
-  /// Registered descriptors for bookkeeping.
+  /// Registered descriptors for bookkeeping (main isolate only).
+  ///
+  /// This is NOT used for background dispatch — it's for foreground
+  /// bookkeeping only (e.g., [isRegistered], [getDescriptor]).
   static final Map<String, OsBackgroundTaskDescriptor> _registrations = {};
 
   OsBackgroundTask._();
 
-  /// Initialize the workmanager plugin.
+  /// Initialize the workmanager plugin with your app's callback dispatcher.
   ///
-  /// Call this once in `main()` before `runApp()`. On web, this is a no-op.
+  /// **REQUIRED**: [callbackDispatcher] must be a top-level function
+  /// annotated with `@pragma('vm:entry-point')` that calls [dispatch]
+  /// with a compile-time map of your task handlers.
+  ///
+  /// On web, this is a no-op (callback dispatcher is ignored).
   ///
   /// ```dart
+  /// @pragma('vm:entry-point')
+  /// void myAppCallbackDispatcher() {
+  ///   OsBackgroundTask.dispatch({
+  ///     'com.app.task1': Task1UseCase.callbackHandler,
+  ///     'com.app.task2': Task2UseCase.callbackHandler,
+  ///   });
+  /// }
+  ///
   /// Future<void> main() async {
   ///   WidgetsFlutterBinding.ensureInitialized();
-  ///   await OsBackgroundTask.initialize();
+  ///   await OsBackgroundTask.initialize(
+  ///     callbackDispatcher: myAppCallbackDispatcher,
+  ///   );
   ///   runApp(MyApp());
   /// }
   /// ```
-  static Future<bool> initialize() async {
+  static Future<bool> initialize({
+    required void Function() callbackDispatcher,
+  }) async {
     if (kIsWeb) {
       debugPrint('[OsBackgroundTask] Web platform — initialize is a no-op.');
+      _initialized = true;
       return true;
     }
 
@@ -256,7 +273,7 @@ class OsBackgroundTask {
 
     try {
       await Workmanager().initialize(
-        osBackgroundTaskCallbackDispatcher,
+        callbackDispatcher,
         isInDebugMode: kDebugMode,
       );
       _initialized = true;
@@ -269,18 +286,58 @@ class OsBackgroundTask {
     }
   }
 
+  /// Dispatch a background task to its handler.
+  ///
+  /// **Call this from your app's top-level callback dispatcher function**,
+  /// passing a compile-time map literal of task identifiers to handlers.
+  ///
+  /// This runs inside `Workmanager().executeTask(...)` and returns a
+  /// [Future<bool>] indicating success/failure (used by workmanager for retry).
+  ///
+  /// ```dart
+  /// @pragma('vm:entry-point')
+  /// void myAppCallbackDispatcher() {
+  ///   OsBackgroundTask.dispatch({
+  ///     'com.app.sync-data': SyncDataTaskUseCase.callbackHandler,
+  ///     'com.app.cleanup': CleanupTaskUseCase.callbackHandler,
+  ///   });
+  /// }
+  /// ```
+  static void dispatch(Map<String, OsBackgroundTaskHandler> handlers) {
+    Workmanager().executeTask((task, inputData) async {
+      final handler = handlers[task];
+      if (handler != null) {
+        try {
+          await handler();
+          return true;
+        } catch (e, stackTrace) {
+          debugPrint(
+            '[OsBackgroundTask] Handler for task "$task" failed: $e',
+          );
+          debugPrint('[OsBackgroundTask] $stackTrace');
+          // Return false so workmanager can retry
+          return false;
+        }
+      }
+      debugPrint(
+        '[OsBackgroundTask] No handler registered for task: $task',
+      );
+      return false;
+    });
+  }
+
   /// Register a periodic background task with the OS scheduler.
   ///
   /// On web, this is a no-op (no OS background scheduling available).
   ///
-  /// The [handler] must be a top-level function or static method reference.
-  /// Closures capturing context from the main isolate may not work
-  /// correctly on Android (which spawns a separate isolate).
+  /// **IMPORTANT**: Before calling this, ensure your app's callback dispatcher
+  /// (passed to [initialize]) includes an entry for [descriptor.identifier]
+  /// in its handlers map. The framework does NOT track handlers for you —
+  /// the handler map must be written directly in your dispatcher's source code.
   ///
   /// Returns `true` if registration succeeded (or is a no-op on web).
   static Future<bool> register(
     OsBackgroundTaskDescriptor descriptor,
-    OsBackgroundTaskHandler handler,
   ) async {
     if (kIsWeb) {
       debugPrint(
@@ -298,22 +355,20 @@ class OsBackgroundTask {
       return false;
     }
 
-    // Register the handler in the dispatch map.
-    _osTaskHandlers[descriptor.identifier] = handler;
     _registrations[descriptor.identifier] = descriptor;
 
-    // Determine the correct frequency based on platform.
-    final frequency = defaultTargetPlatform == TargetPlatform.android
-        ? descriptor.schedule.clampedForAndroid().frequency
-        : descriptor.schedule.frequency;
+    // Determine the correct schedule based on platform (clamp on Android).
+    final effectiveSchedule = defaultTargetPlatform == TargetPlatform.android
+        ? descriptor.schedule.clampedForAndroid()
+        : descriptor.schedule;
 
     try {
       await Workmanager().registerPeriodicTask(
         descriptor.identifier,
         descriptor.taskName,
-        frequency: frequency,
-        constraints: descriptor.schedule.toWorkmanagerConstraints(),
-        initialDelay: descriptor.schedule.initialDelay
+        frequency: effectiveSchedule.frequency,
+        constraints: effectiveSchedule.toWorkmanagerConstraints(),
+        initialDelay: effectiveSchedule.initialDelay
             ? const Duration(seconds: 1)
             : Duration.zero,
         existingWorkPolicy: ExistingWorkPolicy.keep,
@@ -321,7 +376,7 @@ class OsBackgroundTask {
       );
       debugPrint(
         '[OsBackgroundTask] Registered: ${descriptor.identifier} '
-        '(${descriptor.taskName}) every ${frequency.inMinutes} min',
+        '(${descriptor.taskName}) every ${effectiveSchedule.frequency.inMinutes} min',
       );
       return true;
     } catch (e, stackTrace) {
@@ -329,6 +384,8 @@ class OsBackgroundTask {
         '[OsBackgroundTask] Failed to register: ${descriptor.identifier} — $e',
       );
       debugPrint('[OsBackgroundTask] $stackTrace');
+      // Clean up failed registration
+      _registrations.remove(descriptor.identifier);
       return false;
     }
   }
@@ -339,7 +396,6 @@ class OsBackgroundTask {
   static Future<bool> cancel(String identifier) async {
     if (kIsWeb) return true;
 
-    _osTaskHandlers.remove(identifier);
     _registrations.remove(identifier);
 
     try {
@@ -358,7 +414,6 @@ class OsBackgroundTask {
   static Future<bool> cancelAll() async {
     if (kIsWeb) return true;
 
-    _osTaskHandlers.clear();
     _registrations.clear();
 
     try {
@@ -387,7 +442,6 @@ class OsBackgroundTask {
   @visibleForTesting
   static void reset() {
     _initialized = false;
-    _osTaskHandlers.clear();
     _registrations.clear();
   }
 }

--- a/lib/src/domain/os_background_task.dart
+++ b/lib/src/domain/os_background_task.dart
@@ -1,0 +1,393 @@
+import 'package:flutter/foundation.dart';
+import 'package:workmanager/workmanager.dart';
+
+/// Network constraint for OS-scheduled background tasks.
+///
+/// Encodes honestly which platforms respect this constraint:
+/// - **Android**: Fully respected via `Constraints.networkType`.
+/// - **iOS/macOS**: `BGProcessingTask` with `requiresNetworkConnectivity: true`
+///   gives a *hint* to the OS, but the system may still fire without network.
+enum OsNetworkConstraint {
+  /// No network requirement (default).
+  none,
+
+  /// Task prefers network access (iOS hint, Android enforced).
+  connected,
+
+  /// Task requires unmetered network (Android only; iOS treats as [connected]).
+  unmetered,
+}
+
+/// Scheduling configuration for an [OsBackgroundTask].
+///
+/// Models frequency honestly across platforms:
+/// - **Android**: Minimum interval is 15 minutes (`PeriodicWorkRequest`).
+///   Values below 15 min are clamped to 15 min.
+/// - **iOS/macOS**: No `repeatInterval`. `frequency` is treated as
+///   `earliestBeginDate` (a floor, not a guarantee). The OS decides when
+///   to fire. Typical budget: ~30s for refresh tasks, minutes for
+///   `BGProcessingTask`. Reschedule the next run from inside the handler.
+///
+/// Use [OsBackgroundTaskSchedule.recommended] for a sensible default.
+class OsBackgroundTaskSchedule {
+  /// Minimum interval the OS will respect between task executions.
+  ///
+  /// On Android this is the `PeriodicWorkRequest` repeat interval (min 15 min).
+  /// On iOS/macOS this becomes `earliestBeginDate` — a floor, not a guarantee.
+  final Duration frequency;
+
+  /// Whether the initial run should happen immediately on registration.
+  final bool initialDelay;
+
+  /// Network constraint for the task.
+  final OsNetworkConstraint networkConstraint;
+
+  /// Whether the task requires the device to be charging (iOS/macOS only,
+  /// ignored on Android).
+  final bool requiresCharging;
+
+  /// Whether the task requires device idle (Android only, ignored on iOS/macOS).
+  final bool requiresDeviceIdle;
+
+  /// Android-specific: minimum interval is 15 minutes.
+  static const Duration androidMinInterval = Duration(minutes: 15);
+
+  /// Recommended default schedule: 15 minutes, no constraints.
+  static const OsBackgroundTaskSchedule recommended =
+      OsBackgroundTaskSchedule(frequency: Duration(minutes: 15));
+
+  const OsBackgroundTaskSchedule({
+    required this.frequency,
+    this.initialDelay = false,
+    this.networkConstraint = OsNetworkConstraint.none,
+    this.requiresCharging = false,
+    this.requiresDeviceIdle = false,
+  });
+
+  /// Returns a clamped schedule for Android (enforces 15-minute minimum).
+  OsBackgroundTaskSchedule clampedForAndroid() {
+    final clampedFreq =
+        frequency < androidMinInterval ? androidMinInterval : frequency;
+    if (clampedFreq == frequency) return this;
+    return OsBackgroundTaskSchedule(
+      frequency: clampedFreq,
+      initialDelay: initialDelay,
+      networkConstraint: networkConstraint,
+      requiresCharging: false, // Not supported on Android
+      requiresDeviceIdle: requiresDeviceIdle,
+    );
+  }
+
+  /// Converts this schedule to workmanager `Constraints`.
+  Constraints toWorkmanagerConstraints() {
+    final networkType = switch (networkConstraint) {
+      OsNetworkConstraint.connected => NetworkType.connected,
+      OsNetworkConstraint.unmetered => NetworkType.unmetered,
+      OsNetworkConstraint.none => NetworkType.not_required,
+    };
+
+    return Constraints(
+      networkType: networkType,
+      requiresDeviceIdle: requiresDeviceIdle ? true : null,
+      requiresCharging: requiresCharging ? true : null,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is OsBackgroundTaskSchedule &&
+          runtimeType == other.runtimeType &&
+          frequency == other.frequency &&
+          initialDelay == other.initialDelay &&
+          networkConstraint == other.networkConstraint &&
+          requiresCharging == other.requiresCharging &&
+          requiresDeviceIdle == other.requiresDeviceIdle;
+
+  @override
+  int get hashCode => Object.hash(
+        frequency,
+        initialDelay,
+        networkConstraint,
+        requiresCharging,
+        requiresDeviceIdle,
+      );
+}
+
+/// Descriptor for registering an [OsBackgroundTask] with the OS scheduler.
+///
+/// Pass this to [OsBackgroundTask.register] to schedule a periodic
+/// background task via `workmanager`.
+class OsBackgroundTaskDescriptor {
+  /// Unique identifier for this task (used as the workmanager task name).
+  final String identifier;
+
+  /// Human-readable task name for logging.
+  final String taskName;
+
+  /// Scheduling configuration.
+  final OsBackgroundTaskSchedule schedule;
+
+  /// Whether this task should run even when the app is terminated.
+  /// On Android this is always true for `PeriodicWorkRequest`.
+  /// On iOS this depends on the background mode registration.
+  final bool runWhenAppTerminated;
+
+  const OsBackgroundTaskDescriptor({
+    required this.identifier,
+    required this.taskName,
+    this.schedule = OsBackgroundTaskSchedule.recommended,
+    this.runWhenAppTerminated = true,
+  });
+}
+
+/// Callback type for OS background task handlers.
+///
+/// This function runs in a **separate isolate** on Android. On iOS/macOS
+/// it runs in the app's background handler. Keep it lightweight and
+/// do NOT access the UI layer.
+typedef OsBackgroundTaskHandler = Future<void> Function();
+
+/// Registered task handler registry.
+///
+/// Maps task identifiers to their handler functions. The [callbackDispatcher]
+/// uses this registry to dispatch tasks.
+final Map<String, OsBackgroundTaskHandler> _osTaskHandlers = {};
+
+/// The background isolate entry point for workmanager.
+///
+/// Registered with `@pragma('vm:entry-point')` so the Dart VM preserves it
+/// as a valid entry point for background isolate spawning.
+///
+/// **Do NOT call this directly.** It is invoked by workmanager when the OS
+/// schedules a background execution.
+@pragma('vm:entry-point')
+void osBackgroundTaskCallbackDispatcher() {
+  Workmanager().executeTask((task, inputData) async {
+    final handler = _osTaskHandlers[task];
+    if (handler != null) {
+      await handler();
+      return true;
+    }
+    debugPrint(
+      '[OsBackgroundTask] No handler registered for task: $task',
+    );
+    return false;
+  });
+}
+
+/// A use-case abstraction for OS-scheduled background tasks wrapping
+/// `workmanager` (iOS / Android / macOS).
+///
+/// ## Platform contract (honest)
+///
+/// ### Android
+/// - Minimum interval: **15 minutes** (`PeriodicWorkRequest`). Intervals
+///   below 15 min are clamped automatically.
+/// - Fires when the app is closed.
+/// - Generous time budget (configurable via `setExpireAt`).
+/// - Network constraint fully supported.
+///
+/// ### iOS / macOS
+/// - **No `repeatInterval`** — scheduling is opportunistic.
+/// - `frequency` becomes `earliestBeginDate` (a floor, not a guarantee).
+/// - The OS decides when to fire; "2x/day" is honestly "up to 2x/day".
+/// - ~30 s budget for refresh tasks; minutes for `BGProcessingTask`
+///   (best when charging + `requiresNetworkConnectivity: true`).
+/// - Next task must be rescheduled from inside the current handler.
+///
+/// ### Web
+/// - Not supported. [OsBackgroundTask.register] is a no-op on web,
+///   and [OsBackgroundTask.initialize] completes immediately.
+///
+/// ## Usage
+///
+/// ```dart
+/// // In main() before runApp():
+/// await OsBackgroundTask.initialize();
+///
+/// // Register a task:
+/// OsBackgroundTask.register(
+///   OsBackgroundTaskDescriptor(
+///     identifier: 'com.app.sync-data',
+///     taskName: 'SyncData',
+///     schedule: OsBackgroundTaskSchedule(
+///       frequency: Duration(minutes: 30),
+///       networkConstraint: OsNetworkConstraint.connected,
+///     ),
+///   ),
+///   () async {
+///     // Your background work here
+///     final data = await fetchData();
+///     await saveLocally(data);
+///   },
+/// );
+/// ```
+class OsBackgroundTask {
+  /// Whether workmanager has been initialized.
+  static bool _initialized = false;
+
+  /// Registered descriptors for bookkeeping.
+  static final Map<String, OsBackgroundTaskDescriptor> _registrations = {};
+
+  OsBackgroundTask._();
+
+  /// Initialize the workmanager plugin.
+  ///
+  /// Call this once in `main()` before `runApp()`. On web, this is a no-op.
+  ///
+  /// ```dart
+  /// Future<void> main() async {
+  ///   WidgetsFlutterBinding.ensureInitialized();
+  ///   await OsBackgroundTask.initialize();
+  ///   runApp(MyApp());
+  /// }
+  /// ```
+  static Future<bool> initialize() async {
+    if (kIsWeb) {
+      debugPrint('[OsBackgroundTask] Web platform — initialize is a no-op.');
+      return true;
+    }
+
+    if (_initialized) {
+      debugPrint('[OsBackgroundTask] Already initialized.');
+      return true;
+    }
+
+    try {
+      await Workmanager().initialize(
+        osBackgroundTaskCallbackDispatcher,
+        isInDebugMode: kDebugMode,
+      );
+      _initialized = true;
+      debugPrint('[OsBackgroundTask] Initialized successfully.');
+      return true;
+    } catch (e, stackTrace) {
+      debugPrint('[OsBackgroundTask] Initialization failed: $e');
+      debugPrint('[OsBackgroundTask] $stackTrace');
+      return false;
+    }
+  }
+
+  /// Register a periodic background task with the OS scheduler.
+  ///
+  /// On web, this is a no-op (no OS background scheduling available).
+  ///
+  /// The [handler] must be a top-level function or static method reference.
+  /// Closures capturing context from the main isolate may not work
+  /// correctly on Android (which spawns a separate isolate).
+  ///
+  /// Returns `true` if registration succeeded (or is a no-op on web).
+  static Future<bool> register(
+    OsBackgroundTaskDescriptor descriptor,
+    OsBackgroundTaskHandler handler,
+  ) async {
+    if (kIsWeb) {
+      debugPrint(
+        '[OsBackgroundTask] Web platform — register is a no-op for '
+        'task: ${descriptor.identifier}',
+      );
+      return true;
+    }
+
+    if (!_initialized) {
+      debugPrint(
+        '[OsBackgroundTask] Not initialized. Call initialize() first. '
+        'Task: ${descriptor.identifier}',
+      );
+      return false;
+    }
+
+    // Register the handler in the dispatch map.
+    _osTaskHandlers[descriptor.identifier] = handler;
+    _registrations[descriptor.identifier] = descriptor;
+
+    // Determine the correct frequency based on platform.
+    final frequency = defaultTargetPlatform == TargetPlatform.android
+        ? descriptor.schedule.clampedForAndroid().frequency
+        : descriptor.schedule.frequency;
+
+    try {
+      await Workmanager().registerPeriodicTask(
+        descriptor.identifier,
+        descriptor.taskName,
+        frequency: frequency,
+        constraints: descriptor.schedule.toWorkmanagerConstraints(),
+        initialDelay: descriptor.schedule.initialDelay
+            ? const Duration(seconds: 1)
+            : Duration.zero,
+        existingWorkPolicy: ExistingWorkPolicy.keep,
+        tag: descriptor.identifier,
+      );
+      debugPrint(
+        '[OsBackgroundTask] Registered: ${descriptor.identifier} '
+        '(${descriptor.taskName}) every ${frequency.inMinutes} min',
+      );
+      return true;
+    } catch (e, stackTrace) {
+      debugPrint(
+        '[OsBackgroundTask] Failed to register: ${descriptor.identifier} — $e',
+      );
+      debugPrint('[OsBackgroundTask] $stackTrace');
+      return false;
+    }
+  }
+
+  /// Cancel a previously registered background task.
+  ///
+  /// Returns `true` if cancellation succeeded.
+  static Future<bool> cancel(String identifier) async {
+    if (kIsWeb) return true;
+
+    _osTaskHandlers.remove(identifier);
+    _registrations.remove(identifier);
+
+    try {
+      await Workmanager().cancelByTag(identifier);
+      debugPrint('[OsBackgroundTask] Cancelled: $identifier');
+      return true;
+    } catch (e) {
+      debugPrint('[OsBackgroundTask] Failed to cancel: $identifier — $e');
+      return false;
+    }
+  }
+
+  /// Cancel all registered background tasks.
+  ///
+  /// Returns `true` if all cancellations succeeded.
+  static Future<bool> cancelAll() async {
+    if (kIsWeb) return true;
+
+    _osTaskHandlers.clear();
+    _registrations.clear();
+
+    try {
+      await Workmanager().cancelAll();
+      debugPrint('[OsBackgroundTask] Cancelled all tasks.');
+      return true;
+    } catch (e) {
+      debugPrint('[OsBackgroundTask] Failed to cancel all — $e');
+      return false;
+    }
+  }
+
+  /// Check whether a task with the given [identifier] is currently registered.
+  static bool isRegistered(String identifier) =>
+      _registrations.containsKey(identifier);
+
+  /// List all currently registered task identifiers.
+  static List<String> get registeredIdentifiers =>
+      _registrations.keys.toList();
+
+  /// Get the descriptor for a registered task, or null if not registered.
+  static OsBackgroundTaskDescriptor? getDescriptor(String identifier) =>
+      _registrations[identifier];
+
+  /// Reset internal state. For testing purposes only.
+  @visibleForTesting
+  static void reset() {
+    _initialized = false;
+    _osTaskHandlers.clear();
+    _registrations.clear();
+  }
+}

--- a/lib/src/domain/os_background_task_usecase.dart
+++ b/lib/src/domain/os_background_task_usecase.dart
@@ -1,0 +1,100 @@
+import 'dart:async';
+
+import '../core/loggable.dart';
+import '../core/params/no_params.dart';
+import 'os_background_task.dart';
+
+/// Abstract base class for OS-scheduled background task use cases.
+///
+/// Subclasses define:
+/// - [descriptor]: The task registration configuration.
+/// - [execute]: The business logic to run when the task fires.
+///
+/// ## Platform notes
+///
+/// - **Android**: The [execute] method runs in a **separate isolate**.
+///   Do NOT access the UI layer, SharedPreferences (unless via isolate-safe
+///   APIs), or any main-isolate-only resources.
+/// - **iOS/macOS**: Runs in the app's background handler with a limited
+///   time budget (~30 s for refresh, minutes for BGProcessingTask).
+/// - **Web**: Not supported; calling [register] is a no-op.
+///
+/// ## Example
+///
+/// ```dart
+/// class SyncDataTask extends OsBackgroundTaskUseCase<void, NoParams> {
+///   final DataService _dataService;
+///   SyncDataTask(this._dataService);
+///
+///   @override
+///   OsBackgroundTaskDescriptor get descriptor =>
+///       const OsBackgroundTaskDescriptor(
+///         identifier: 'com.app.sync-data',
+///         taskName: 'SyncData',
+///         schedule: OsBackgroundTaskSchedule(
+///           frequency: Duration(minutes: 30),
+///           networkConstraint: OsNetworkConstraint.connected,
+///         ),
+///       );
+///
+///   @override
+///   Future<void> execute(NoParams params) async {
+///     await _dataService.syncAll();
+///   }
+/// }
+/// ```
+abstract class OsBackgroundTaskUseCase<T, Params> with Loggable {
+  /// The task descriptor for OS scheduler registration.
+  ///
+  /// Subclasses must override this to define the task's unique identifier,
+  /// name, and scheduling parameters.
+  OsBackgroundTaskDescriptor get descriptor;
+
+  /// The business logic to execute when the OS fires this background task.
+  ///
+  /// This method may run in a **separate isolate** on Android. Keep it
+  /// lightweight and isolate-safe.
+  Future<T> execute(Params params);
+
+  /// Register this task with the OS background scheduler.
+  ///
+  /// Calls [OsBackgroundTask.register] with this use case's [descriptor]
+  /// and a handler that invokes [execute].
+  ///
+  /// Returns `true` if registration succeeded.
+  Future<bool> register() async {
+    return OsBackgroundTask.register(
+      descriptor,
+      _handler,
+    );
+  }
+
+  /// Cancel this task from the OS scheduler.
+  ///
+  /// Returns `true` if cancellation succeeded.
+  Future<bool> cancel() async {
+    return OsBackgroundTask.cancel(descriptor.identifier);
+  }
+
+  /// Internal handler bridging the workmanager callback to [execute].
+  ///
+  /// Uses a default `NoParams` instance since workmanager callbacks
+  /// do not pass parameterized data directly. Subclasses that need
+  /// data should read it from local storage or a shared preference
+  /// inside their [execute] override.
+  Future<void> _handler() async {
+    // workmanager does not pass typed params to callbacks;
+    // subclasses read their data from local storage inside execute().
+    try {
+      await execute(NoParams() as Params);
+    } catch (e, stackTrace) {
+      logger.severe(
+        '$runtimeType background task failed',
+        e,
+        stackTrace,
+      );
+    }
+  }
+}
+
+

--- a/lib/src/domain/os_background_task_usecase.dart
+++ b/lib/src/domain/os_background_task_usecase.dart
@@ -19,10 +19,46 @@ import 'os_background_task.dart';
 ///   time budget (~30 s for refresh, minutes for BGProcessingTask).
 /// - **Web**: Not supported; calling [register] is a no-op.
 ///
+/// ## CRITICAL: Background Isolate Dispatch
+///
+/// On Android, workmanager spawns a **fresh isolate** that does NOT share
+/// memory with the main isolate. Your app MUST provide its own top-level
+/// callback dispatcher that contains a compile-time map of task handlers:
+///
+/// ```dart
+/// @pragma('vm:entry-point')
+/// void myAppCallbackDispatcher() {
+///   OsBackgroundTask.dispatch({
+///     'com.app.sync-data': SyncDataTaskUseCase.callbackHandler,
+///     'com.app.cleanup': CleanupTaskUseCase.callbackHandler,
+///   });
+/// }
+///
+/// Future<void> main() async {
+///   WidgetsFlutterBinding.ensureInitialized();
+///   await OsBackgroundTask.initialize(
+///     callbackDispatcher: myAppCallbackDispatcher,
+///   );
+///   // Create use case instances for main-isolate use:
+///   final syncTask = SyncDataTaskUseCase(dataService);
+///   await syncTask.register();
+///   runApp(MyApp());
+/// }
+/// ```
+///
+/// ## Background Isolate Limitations
+///
+/// Instance dependencies (services, repositories) from the main isolate are
+/// NOT available in the background isolate. Generated `callbackHandler`
+/// methods must reconstruct dependencies using isolate-safe mechanisms:
+/// 1. Re-initialize GetIt or other DI containers in the background isolate
+/// 2. Read data from isolate-safe storage (Hive, SharedPreferences)
+/// 3. Use top-level functions that don't rely on instance state
+///
 /// ## Example
 ///
 /// ```dart
-/// class SyncDataTask extends OsBackgroundTaskUseCase<void, NoParams> {
+/// class SyncDataTask extends OsBackgroundTaskUseCase<void> {
 ///   final DataService _dataService;
 ///   SyncDataTask(this._dataService);
 ///
@@ -41,9 +77,18 @@ import 'os_background_task.dart';
 ///   Future<void> execute(NoParams params) async {
 ///     await _dataService.syncAll();
 ///   }
+///
+///   // Generated static handler (referenced in your app's dispatcher):
+///   static Future<void> callbackHandler() async {
+///     // Reconstruct dependencies in background isolate:
+///     final getIt = GetIt.instance;
+///     getIt.registerSingleton(DataService());
+///     final service = getIt<DataService>();
+///     await service.syncAll();
+///   }
 /// }
 /// ```
-abstract class OsBackgroundTaskUseCase<T, Params> with Loggable {
+abstract class OsBackgroundTaskUseCase<T> with Loggable {
   /// The task descriptor for OS scheduler registration.
   ///
   /// Subclasses must override this to define the task's unique identifier,
@@ -54,19 +99,21 @@ abstract class OsBackgroundTaskUseCase<T, Params> with Loggable {
   ///
   /// This method may run in a **separate isolate** on Android. Keep it
   /// lightweight and isolate-safe.
-  Future<T> execute(Params params);
+  ///
+  /// workmanager does not pass parameterized data to callbacks; subclasses
+  /// should read any required data from isolate-safe storage inside this method.
+  Future<T> execute(NoParams params);
 
   /// Register this task with the OS background scheduler.
   ///
-  /// Calls [OsBackgroundTask.register] with this use case's [descriptor]
-  /// and a handler that invokes [execute].
+  /// **IMPORTANT**: Before calling this, ensure your app's top-level callback
+  /// dispatcher (passed to [OsBackgroundTask.initialize]) includes an entry
+  /// for [descriptor.identifier] in its handlers map. See class documentation
+  /// for the complete setup pattern.
   ///
   /// Returns `true` if registration succeeded.
   Future<bool> register() async {
-    return OsBackgroundTask.register(
-      descriptor,
-      _handler,
-    );
+    return OsBackgroundTask.register(descriptor);
   }
 
   /// Cancel this task from the OS scheduler.
@@ -74,26 +121,6 @@ abstract class OsBackgroundTaskUseCase<T, Params> with Loggable {
   /// Returns `true` if cancellation succeeded.
   Future<bool> cancel() async {
     return OsBackgroundTask.cancel(descriptor.identifier);
-  }
-
-  /// Internal handler bridging the workmanager callback to [execute].
-  ///
-  /// Uses a default `NoParams` instance since workmanager callbacks
-  /// do not pass parameterized data directly. Subclasses that need
-  /// data should read it from local storage or a shared preference
-  /// inside their [execute] override.
-  Future<void> _handler() async {
-    // workmanager does not pass typed params to callbacks;
-    // subclasses read their data from local storage inside execute().
-    try {
-      await execute(NoParams() as Params);
-    } catch (e, stackTrace) {
-      logger.severe(
-        '$runtimeType background task failed',
-        e,
-        stackTrace,
-      );
-    }
   }
 }
 

--- a/lib/src/plugins/test/test_plugin.dart
+++ b/lib/src/plugins/test/test_plugin.dart
@@ -336,6 +336,9 @@ class TestPlugin extends FileGeneratorPlugin implements CliAwarePlugin {
     if (content.contains('SyncUseCase')) {
       return 'sync';
     }
+    if (content.contains('OsBackgroundTaskUseCase')) {
+      return 'os_background';
+    }
     if (content.contains('BackgroundUseCase')) {
       return 'background';
     }

--- a/lib/src/plugins/usecase/generators/custom_usecase_generator_core.dart
+++ b/lib/src/plugins/usecase/generators/custom_usecase_generator_core.dart
@@ -11,6 +11,8 @@ extension CustomUseCaseGeneratorCore on CustomUseCaseGenerator {
         return 'StreamUseCase<$returnsType, $paramsType>';
       case 'background':
         return 'BackgroundUseCase<$returnsType, $paramsType>';
+      case 'os_background':
+        return 'OsBackgroundTaskUseCase<$returnsType, $paramsType>';
       case 'completable':
         return 'CompletableUseCase<$paramsType>';
       case 'sync':

--- a/lib/src/plugins/usecase/generators/custom_usecase_generator_core.dart
+++ b/lib/src/plugins/usecase/generators/custom_usecase_generator_core.dart
@@ -12,7 +12,7 @@ extension CustomUseCaseGeneratorCore on CustomUseCaseGenerator {
       case 'background':
         return 'BackgroundUseCase<$returnsType, $paramsType>';
       case 'os_background':
-        return 'OsBackgroundTaskUseCase<$returnsType, $paramsType>';
+        return 'OsBackgroundTaskUseCase<$returnsType>';
       case 'completable':
         return 'CompletableUseCase<$paramsType>';
       case 'sync':

--- a/lib/src/plugins/usecase/generators/os_background_task_generator.dart
+++ b/lib/src/plugins/usecase/generators/os_background_task_generator.dart
@@ -170,35 +170,109 @@ class OsBackgroundTaskGenerator {
         ..body = executeBody,
     );
 
-    // 3. The `callbackHandler` static method (entry point for workmanager)
+    // 3. The `callbackHandler` static method (background isolate entry point)
+    // This must be referenced in your app's top-level callback dispatcher
+    final handlerBody = depField.isEmpty
+        ? Block(
+            (b) => b
+              ..statements.add(
+                Code('// TODO: Implement background task logic here'),
+              )
+              ..statements.add(
+                Code(
+                  '// IMPORTANT: This runs in a background isolate on Android.',
+                ),
+              )
+              ..statements.add(
+                Code(
+                  '// You CANNOT access instance dependencies from the main isolate.',
+                ),
+              )
+              ..statements.add(
+                Code(
+                  '// Reconstruct dependencies here or read data from isolate-safe storage (Hive, SharedPreferences).',
+                ),
+              )
+              ..statements.add(
+                refer('UnimplementedError')
+                    .call([
+                      literalString(
+                        'Implement $className.callbackHandler — '
+                        'this runs in the background isolate',
+                      ),
+                    ])
+                    .thrown
+                    .statement,
+              ),
+          )
+        : Block(
+            (b) => b
+              ..statements.add(
+                Code(
+                  '// IMPORTANT: This runs in a background isolate on Android.',
+                ),
+              )
+              ..statements.add(
+                Code(
+                  '// Instance dependencies ($_depField) from the main isolate are NOT available.',
+                ),
+              )
+              ..statements.add(
+                Code(
+                  '// TODO: Reconstruct dependencies here. For example:',
+                ),
+              )
+              ..statements.add(Code('// final getIt = GetIt.instance;'))
+              ..statements.add(Code('// // Re-register services in background isolate'))
+              ..statements.add(Code('// getIt.registerSingleton(...);'))
+              ..statements.add(Code('// final service = getIt<...>();'))
+              ..statements.add(Code('// await service.doBackgroundWork();'))
+              ..statements.add(Code(''))
+              ..statements.add(
+                refer('UnimplementedError')
+                    .call([
+                      literalString(
+                        'Reconstruct dependencies in $className.callbackHandler — '
+                        'background isolate cannot access main isolate state',
+                      ),
+                    ])
+                    .thrown
+                    .statement,
+              ),
+          );
+
     final callbackHandler = Method(
       (b) => b
         ..name = 'callbackHandler'
         ..static = true
         ..returns = refer('Future<void>')
         ..annotations.add(CodeExpression(Code('@pragma(\'vm:entry-point\')')))
-        ..body = Block(
-          (b) => b
-            ..statements.add(Code('// TODO: Wire up service/repository here'))
-            ..statements.add(Code('// This runs in a background isolate (Android)'))
-            ..statements.add(
-              refer('UnimplementedError')
-                  .call([
-                    literalString(
-                      'Implement callbackHandler — '
-                      'this runs in the background isolate',
-                    ),
-                  ])
-                  .thrown
-                  .statement,
-            ),
-        ),
+        ..docs.addAll([
+          '/// Static handler for background task execution.',
+          '///',
+          '/// **CRITICAL**: Add this to your app\'s top-level callback dispatcher:',
+          '/// ```dart',
+          '/// @pragma(\'vm:entry-point\')',
+          '/// void myAppCallbackDispatcher() {',
+          '///   OsBackgroundTask.dispatch({',
+          "///     'com.zuraffa.${classSnake}_task': $className.callbackHandler,",
+          '///     // ... other task handlers',
+          '///   });',
+          '/// }',
+          '///',
+          '/// // Then in main():',
+          '/// await OsBackgroundTask.initialize(',
+          '///   callbackDispatcher: myAppCallbackDispatcher,',
+          '/// );',
+          '/// ```',
+        ])
+        ..body = handlerBody,
     );
 
     // --- Build class spec ---
     final spec = UseCaseClassSpec(
       className: className,
-      baseClass: 'OsBackgroundTaskUseCase<$returnsType, $paramsType>',
+      baseClass: 'OsBackgroundTaskUseCase<$returnsType>',
       fields: dependencyFields,
       constructors: constructorParams.isEmpty
           ? const []

--- a/lib/src/plugins/usecase/generators/os_background_task_generator.dart
+++ b/lib/src/plugins/usecase/generators/os_background_task_generator.dart
@@ -1,0 +1,261 @@
+import 'package:code_builder/code_builder.dart';
+import 'package:path/path.dart' as path;
+
+import '../../../core/ast/append_executor.dart';
+import '../../../core/builder/patterns/common_patterns.dart';
+import '../../../core/generator_options.dart';
+import '../../../core/context/file_system.dart';
+import '../../../models/generated_file.dart';
+import '../../../models/generator_config.dart';
+import '../../../utils/file_utils.dart';
+import '../../../utils/string_utils.dart';
+import '../builders/usecase_class_builder.dart';
+
+/// Generates OS background task-based use cases for the domain layer.
+///
+/// These use cases extend [OsBackgroundTask] and generate a static
+/// `callbackHandler` suitable for workmanager registration, along
+/// with a `register()` convenience method.
+class OsBackgroundTaskGenerator {
+  final String outputDir;
+  final GeneratorOptions options;
+  final UseCaseClassBuilder classBuilder;
+  final AppendExecutor appendExecutor;
+  final FileSystem fileSystem;
+
+  OsBackgroundTaskGenerator({
+    required this.outputDir,
+    this.options = const GeneratorOptions(),
+    this.classBuilder = const UseCaseClassBuilder(),
+    this.appendExecutor = const AppendExecutor(),
+    FileSystem? fileSystem,
+  }) : fileSystem = fileSystem ?? FileSystem.create();
+
+  Future<GeneratedFile> generate(GeneratorConfig config) async {
+    final baseName = config.name.endsWith('UseCase')
+        ? config.name.substring(0, config.name.length - 7)
+        : config.name;
+    final className = '${baseName}UseCase';
+    final classSnake = StringUtils.camelToSnake(baseName);
+    final fileName = '${classSnake}_usecase.dart';
+    final usecaseDirPath = path.join(
+      outputDir,
+      'domain',
+      'usecases',
+      config.effectiveDomain,
+    );
+    final filePath = path.join(usecaseDirPath, fileName);
+
+    final paramsType = config.paramsType ?? 'NoParams';
+    final returnsType = config.returnsType ?? 'void';
+
+    // --- Imports ---
+    final dependencyImports = <String>[];
+    final dependencyFields = <Field>[];
+    final constructorParams = <Parameter>[];
+
+    if (config.hasService) {
+      final serviceName = config.effectiveService;
+      final serviceSnake = config.serviceSnake;
+      if (serviceName == null || serviceSnake == null) {
+        throw ArgumentError(
+          'Service name must be specified via --service or config.service',
+        );
+      }
+      dependencyImports.add('../../services/${serviceSnake}_service.dart');
+      final serviceBaseName = serviceName.endsWith('Service')
+          ? serviceName.substring(0, serviceName.length - 7)
+          : serviceName;
+      final serviceFieldName =
+          '_${StringUtils.pascalToCamel(serviceBaseName)}Service';
+      dependencyFields.add(
+        Field(
+          (b) => b
+            ..name = serviceFieldName
+            ..type = refer(serviceName)
+            ..modifier = FieldModifier.final$,
+        ),
+      );
+      constructorParams.add(
+        Parameter(
+          (p) => p
+            ..name = serviceFieldName
+            ..toThis = true,
+        ),
+      );
+    } else if (config.hasRepo && config.effectiveRepos.isNotEmpty) {
+      final repoName = config.effectiveRepos.first;
+      final repoSnake = StringUtils.camelToSnake(
+        repoName.replaceAll('Repository', ''),
+      );
+      dependencyImports.add('../../repositories/${repoSnake}_repository.dart');
+      final repoBaseName = repoName.replaceAll('Repository', '');
+      final repoFieldName =
+          '_${StringUtils.pascalToCamel(repoBaseName)}Repository';
+      dependencyFields.add(
+        Field(
+          (b) => b
+            ..name = repoFieldName
+            ..type = refer(repoName)
+            ..modifier = FieldModifier.final$,
+        ),
+      );
+      constructorParams.add(
+        Parameter(
+          (p) => p
+            ..name = repoFieldName
+            ..toThis = true,
+        ),
+      );
+    }
+
+    // --- Methods ---
+
+    // 1. The `descriptor` getter: returns an OsBackgroundTaskDescriptor
+    final descriptorGetter = Method(
+      (b) => b
+        ..name = 'descriptor'
+        ..type = MethodType.getter
+        ..returns = refer('OsBackgroundTaskDescriptor')
+        ..annotations.add(CodeExpression(Code('override')))
+        ..body = Code(
+          'return const OsBackgroundTaskDescriptor(\n'
+          "  identifier: 'com.zuraffa.${classSnake}_task',\n"
+          "  taskName: '$baseName',\n"
+          ');',
+        ),
+    );
+
+    // 2. The `execute` method: business logic to be called from handler
+    final depField = dependencyFields.isNotEmpty ? dependencyFields.first.name : '';
+    final executeBody = depField.isEmpty
+        ? Block(
+            (b) => b
+              ..statements
+                  .add(Code('// TODO: Implement OS background task logic'))
+              ..statements.add(
+                refer('UnimplementedError')
+                    .call([literalString('Implement OS background task logic')])
+                    .thrown
+                    .statement,
+              ),
+          )
+        : Block(
+            (b) => b
+              ..statements.add(
+                refer(depField)
+                    .property(config.hasService
+                        ? config.getServiceMethodName()
+                        : config.getRepoMethodName())
+                    .call([refer('params')])
+                    .awaited
+                    .returned
+                    .statement,
+              ),
+          );
+
+    final executeMethod = Method(
+      (b) => b
+        ..name = 'execute'
+        ..returns = refer('Future<$returnsType>')
+        ..modifier = MethodModifier.async
+        ..requiredParameters.add(
+          Parameter(
+            (p) => p
+              ..name = 'params'
+              ..type = refer(paramsType),
+          ),
+        )
+        ..annotations.add(CodeExpression(Code('override')))
+        ..body = executeBody,
+    );
+
+    // 3. The `callbackHandler` static method (entry point for workmanager)
+    final callbackHandler = Method(
+      (b) => b
+        ..name = 'callbackHandler'
+        ..static = true
+        ..returns = refer('Future<void>')
+        ..annotations.add(CodeExpression(Code('@pragma(\'vm:entry-point\')')))
+        ..body = Block(
+          (b) => b
+            ..statements.add(Code('// TODO: Wire up service/repository here'))
+            ..statements.add(Code('// This runs in a background isolate (Android)'))
+            ..statements.add(
+              refer('UnimplementedError')
+                  .call([
+                    literalString(
+                      'Implement callbackHandler — '
+                      'this runs in the background isolate',
+                    ),
+                  ])
+                  .thrown
+                  .statement,
+            ),
+        ),
+    );
+
+    // --- Build class spec ---
+    final spec = UseCaseClassSpec(
+      className: className,
+      baseClass: 'OsBackgroundTaskUseCase<$returnsType, $paramsType>',
+      fields: dependencyFields,
+      constructors: constructorParams.isEmpty
+          ? const []
+          : [
+              Constructor(
+                (b) => b..requiredParameters.addAll(constructorParams),
+              ),
+            ],
+      methods: [descriptorGetter, executeMethod, callbackHandler],
+      imports: [
+        'package:zuraffa/zuraffa.dart',
+        ...dependencyImports,
+        ...CommonPatterns.entityImports(
+          [paramsType, returnsType],
+          config,
+          depth: 3,
+          includeDomain: false,
+          fileSystem: fileSystem,
+        ),
+      ],
+    );
+
+    final content = classBuilder.build(spec);
+
+    return _writeOrAppend(
+      config: config,
+      filePath: filePath,
+      className: className,
+      content: content,
+    );
+  }
+
+  Future<GeneratedFile> _writeOrAppend({
+    required GeneratorConfig config,
+    required String filePath,
+    required String className,
+    required String content,
+  }) async {
+    if (config.revert) {
+      return FileUtils.deleteFile(
+        filePath,
+        'usecase',
+        dryRun: config.dryRun,
+        verbose: config.verbose,
+        fileSystem: fileSystem,
+      );
+    }
+
+    return FileUtils.writeFile(
+      filePath,
+      content,
+      'usecase',
+      force: config.force,
+      dryRun: config.dryRun,
+      verbose: config.verbose,
+      revert: config.revert,
+      fileSystem: fileSystem,
+    );
+  }
+}

--- a/lib/src/plugins/usecase/usecase_plugin.dart
+++ b/lib/src/plugins/usecase/usecase_plugin.dart
@@ -10,6 +10,7 @@ import '../../models/generator_config.dart';
 import 'capabilities/create_usecase_capability.dart';
 import 'generators/custom_usecase_generator.dart';
 import 'generators/entity_usecase_generator.dart';
+import 'generators/os_background_task_generator.dart';
 import 'generators/stream_usecase_generator.dart';
 
 /// Manages use case generation for the domain layer.
@@ -20,6 +21,7 @@ class UseCasePlugin extends FileGeneratorPlugin implements CliAwarePlugin {
   late final EntityUseCaseGenerator entityGenerator;
   late final CustomUseCaseGenerator customGenerator;
   late final StreamUseCaseGenerator streamGenerator;
+  late final OsBackgroundTaskGenerator osBackgroundGenerator;
 
   UseCasePlugin({
     required this.outputDir,
@@ -34,6 +36,10 @@ class UseCasePlugin extends FileGeneratorPlugin implements CliAwarePlugin {
       options: options,
     );
     streamGenerator = StreamUseCaseGenerator(
+      outputDir: outputDir,
+      options: options,
+    );
+    osBackgroundGenerator = OsBackgroundTaskGenerator(
       outputDir: outputDir,
       options: options,
     );
@@ -65,7 +71,7 @@ class UseCasePlugin extends FileGeneratorPlugin implements CliAwarePlugin {
       },
       'type': {
         'type': 'string',
-        'enum': ['usecase', 'stream', 'background', 'completable'],
+        'enum': ['usecase', 'stream', 'background', 'os_background', 'completable'],
         'default': 'usecase',
       },
       'domain': {'type': 'string', 'description': 'Domain folder name'},
@@ -177,6 +183,14 @@ class UseCasePlugin extends FileGeneratorPlugin implements CliAwarePlugin {
           )
         : streamGenerator;
 
+    final osBackgroundGen = context != null
+        ? OsBackgroundTaskGenerator(
+            outputDir: outputDir,
+            options: options,
+            fileSystem: context.fileSystem,
+          )
+        : osBackgroundGenerator;
+
     if (config.isEntityBased) {
       return entityGen.generate(config);
     }
@@ -188,6 +202,9 @@ class UseCasePlugin extends FileGeneratorPlugin implements CliAwarePlugin {
     }
     if (config.useCaseType == 'stream') {
       return [await streamGen.generate(config)];
+    }
+    if (config.useCaseType == 'os_background') {
+      return [await osBackgroundGen.generate(config)];
     }
     if (config.isCustomUseCase) {
       return [await customGen.generate(config)];

--- a/lib/zuraffa.dart
+++ b/lib/zuraffa.dart
@@ -24,6 +24,7 @@ import 'src/core/zuraffa_bridge_facade.dart';
 /// - **StreamUseCase**: Reactive operations that emit multiple values over time
 /// - **SyncUseCase**: Synchronous operations that return immediately without async
 /// - **BackgroundUseCase**: CPU-intensive operations that run on a separate isolate
+/// - **OsBackgroundTask**: OS-scheduled periodic background tasks via workmanager
 /// - **Controller**: Manages UI state and coordinates with UseCases
 /// - **Presenter**: Optional orchestration layer for complex business flows
 /// - **Result**: Type-safe success/failure handling
@@ -206,7 +207,7 @@ export 'src/core/failure_reporter_registry.dart' show FailureReporterRegistry;
 export 'src/core/otel_failure_reporter.dart' show OtelFailureReporter;
 export 'src/core/otel_log_exporter.dart' show OtelLogExporter;
 export 'src/core/otel_tracer.dart' show OtelTracer;
-export 'package:opentelemetry/api.dart';
+export 'package:opentelemetry/api.dart' hide SpanStatus;
 export 'src/core/retry_policies.dart'
     show ExponentialBackoffRetryPolicy, FixedIntervalRetryPolicy, NoRetryPolicy;
 export 'src/core/retry_policy.dart' show ReportRetryPolicy;
@@ -293,6 +294,12 @@ export 'src/domain/sync_usecase.dart';
 /// BackgroundUseCase for isolate-based operations
 export 'src/domain/background_usecase.dart';
 
+/// OsBackgroundTask for OS-scheduled background tasks wrapping workmanager
+export 'src/domain/os_background_task.dart';
+
+/// OsBackgroundTaskUseCase abstract base for OS background task use cases
+export 'src/domain/os_background_task_usecase.dart';
+
 /// Observer for callback-based stream listening (optional)
 export 'src/domain/observer.dart';
 
@@ -349,6 +356,137 @@ export 'src/extensions/future_extensions.dart';
 
 /// Test utilities (matchers, observers)
 export 'src/utils/test_utils.dart';
+
+// ============================================================
+// V6 Reactive Signals
+// ============================================================
+
+/// Signal — zero-cost reactive primitive.
+export 'src/core/signals/signal.dart';
+
+/// SignalResult — reactive Result wrapper backed by Signal.
+export 'src/core/signals/signal_result.dart';
+
+/// ZuraffaUseCase — v6 UseCase contract with SignalResult return type.
+export 'src/core/usecase/zuraffa_usecase.dart';
+
+/// ZuraffaContext — lightweight correlation context carrier.
+export 'src/core/context/zuraffa_context.dart';
+
+/// TelemetryMesh — global trace/span coordinator and auto-instrumentation.
+export 'src/core/telemetry/telemetry_mesh.dart';
+
+// ============================================================
+// V6 DDA (Decorator-Driven Architecture) — Compiler Pipeline
+// ============================================================
+
+/// DecoratorAST — parsed decorator annotation model.
+export 'src/dda/models/decorator_ast.dart';
+
+/// ZorphyContext — code_builder-based injection context.
+export 'src/dda/models/zorphy_context.dart';
+
+/// ZorphyDecoratorPlugin — abstract plugin contract.
+export 'src/dda/compiler/zorphy_decorator_plugin.dart';
+
+/// ASTScanner — finds @DecoratorName() across the project.
+export 'src/dda/compiler/ast_scanner.dart';
+
+/// PluginDiscovery — loads plugins from pubspec.yaml.
+export 'src/dda/compiler/plugin_discovery.dart';
+
+/// DecoratorDispatcher — routes annotations to handlers.
+export 'src/dda/compiler/decorator_dispatcher.dart';
+
+/// BuildPipeline — 6-stage build orchestrator.
+export 'src/dda/compiler/build_pipeline.dart';
+
+// ============================================================
+// V6 DI — Auto-Dependency Injection
+// ============================================================
+
+/// DependencyScope — lifecycle scopes for DI.
+export 'src/core/di/dependency_scope.dart';
+
+/// @Datasource annotation.
+export 'src/core/di/datasource.dart';
+
+/// @Repository annotation.
+export 'src/core/di/repository.dart';
+
+/// ZuraffaContainer — lightweight DI container.
+export 'src/core/di/zuraffa_container.dart';
+
+/// DIPlugin — DDA plugin for @Datasource/@Repository processing.
+export 'src/dda/plugins/di/di_plugin.dart';
+
+/// DIGenerator — code_builder-based DI registration generation.
+export 'src/dda/plugins/di/di_generator.dart';
+
+// ============================================================
+// V6 State — Fragmented Signal Slices
+// ============================================================
+
+// SignalSlice — fine-grained reactive slice wrapping SignalResult.
+export 'src/state/slices/signal_slice.dart';
+
+// SlicePresenter — manages multiple slices with backward-compatible state.
+export 'src/state/presenter/slice_presenter.dart';
+
+// FragmentBuilder — widget subscribing to a single slice.
+export 'src/state/widgets/fragment_builder.dart';
+
+// StateMigrator — converts v5 .state.dart to v6 slice pattern.
+export 'src/state/migration/state_migrator.dart';
+
+// DomainState — auto-generated read-only slice container.
+export 'src/state/domain_state.dart';
+
+// ViewState — developer-editable transient UI state.
+export 'src/state/view_state.dart';
+
+// DualLayerPresenter — strict domain/view state separation.
+export 'src/state/presenter/dual_layer_presenter.dart';
+
+// StateGenerator — code_builder-based generation with preservation.
+export 'src/state/generator/state_generator.dart';
+
+// CacheObserver — observable cache for cross-view state sync.
+export 'src/state/cache/cache_observer.dart';
+
+// CacheBinding — binds SignalSlice to cache updates.
+export 'src/state/cache/cache_binding.dart';
+
+// CacheBindingPlugin — DDA plugin for @Cacheable processing.
+export 'src/state/generator/cache_binding_generator.dart';
+
+// ControlledWidget — base widget with typed controller and lifecycle hooks.
+export 'src/state/widgets/controlled_widget.dart';
+
+// SignalBuilder — rebuilds on pure UI Signal changes.
+export 'src/state/widgets/signal_builder.dart';
+
+// ViewTemplateGenerator — generates ControlledWidget-based views.
+export 'src/state/generator/view_template_generator.dart';
+
+// ============================================================
+// V6 GraphQL Core
+// ============================================================
+
+// GraphQLType — polymorphic GraphQL type hierarchy.
+export 'src/graphql/types/graphql_type.dart';
+
+// SchemaParser — two-pass introspection JSON parser.
+export 'src/graphql/schema/schema_parser.dart';
+
+// SchemaCache — load/save schema.json with HTTP fetch stub.
+export 'src/graphql/cache/schema_cache.dart';
+
+// TypeMapper — GraphQL type to Dart type mapping.
+export 'src/graphql/mapping/type_mapper.dart';
+
+// DocumentBuilder — query/mutation/subscription document generation.
+export 'src/graphql/document/document_builder.dart';
 
 // ============================================================
 // Framework Configuration

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,6 +23,7 @@ dependencies:
   args: ^2.7.0
   logging: ^1.3.0
   path: ^1.9.1
+  yaml: ^3.1.0
   provider: ^6.1.5+1
   responsive_builder: ^0.7.1
   uuid: ^4.6.0
@@ -37,6 +38,7 @@ dependencies:
   code_builder: ^4.11.1
   dart_style: ^3.1.12
   analyzer: 14.1.0
+  graphql: ^5.2.3
 
   json_serializable: ^6.13.2
   get_it: ^9.2.1
@@ -46,6 +48,7 @@ dependencies:
   glob: ^2.1.2
   hive_ce: ^2.3.4
   hive_ce_flutter: ^2.3.4
+  workmanager: ^0.5.2
 
 dependency_overrides:
   meta: ^1.19.0

--- a/test/core/os_background_task_schedule_test.dart
+++ b/test/core/os_background_task_schedule_test.dart
@@ -1,0 +1,145 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:workmanager/workmanager.dart';
+import 'package:zuraffa/zuraffa.dart';
+
+void main() {
+  group('OsBackgroundTaskSchedule', () {
+    test('recommended default has 15-minute frequency and no constraints', () {
+      const recommended = OsBackgroundTaskSchedule.recommended;
+      expect(recommended.frequency, equals(const Duration(minutes: 15)));
+      expect(recommended.networkConstraint, equals(OsNetworkConstraint.none));
+      expect(recommended.requiresCharging, isFalse);
+      expect(recommended.requiresDeviceIdle, isFalse);
+      expect(recommended.initialDelay, isFalse);
+    });
+
+    test('clampedForAndroid enforces 15-minute minimum', () {
+      const short = OsBackgroundTaskSchedule(
+        frequency: Duration(minutes: 5),
+      );
+      final clamped = short.clampedForAndroid();
+      expect(clamped.frequency, equals(const Duration(minutes: 15)));
+    });
+
+    test('clampedForAndroid leaves 15+ minute schedules unchanged', () {
+      const normal = OsBackgroundTaskSchedule(
+        frequency: Duration(minutes: 30),
+      );
+      final clamped = normal.clampedForAndroid();
+      expect(clamped, same(normal));
+    });
+
+    test('clampedForAndroid clamps to exactly 15 minutes at boundary', () {
+      const exact = OsBackgroundTaskSchedule(
+        frequency: Duration(minutes: 15),
+      );
+      final clamped = exact.clampedForAndroid();
+      expect(clamped, same(exact));
+    });
+
+    test('clampedForAndroid removes requiresCharging (not supported)', () {
+      const schedule = OsBackgroundTaskSchedule(
+        frequency: Duration(minutes: 5),
+        requiresCharging: true,
+        requiresDeviceIdle: true,
+      );
+      final clamped = schedule.clampedForAndroid();
+      expect(clamped.frequency, equals(const Duration(minutes: 15)));
+      expect(clamped.requiresCharging, isFalse);
+      expect(clamped.requiresDeviceIdle, isTrue);
+    });
+
+    group('toWorkmanagerConstraints', () {
+      test('none constraint maps to not_required', () {
+        const schedule = OsBackgroundTaskSchedule(
+          frequency: Duration(minutes: 15),
+        );
+        final constraints = schedule.toWorkmanagerConstraints();
+        expect(constraints.networkType, equals(NetworkType.not_required));
+      });
+
+      test('connected constraint maps to NetworkType.connected', () {
+        const schedule = OsBackgroundTaskSchedule(
+          frequency: Duration(minutes: 15),
+          networkConstraint: OsNetworkConstraint.connected,
+        );
+        final constraints = schedule.toWorkmanagerConstraints();
+        expect(constraints.networkType, equals(NetworkType.connected));
+      });
+
+      test('unmetered constraint maps to NetworkType.unmetered', () {
+        const schedule = OsBackgroundTaskSchedule(
+          frequency: Duration(minutes: 15),
+          networkConstraint: OsNetworkConstraint.unmetered,
+        );
+        final constraints = schedule.toWorkmanagerConstraints();
+        expect(constraints.networkType, equals(NetworkType.unmetered));
+      });
+
+      test('requiresDeviceIdle is propagated', () {
+        const schedule = OsBackgroundTaskSchedule(
+          frequency: Duration(minutes: 15),
+          requiresDeviceIdle: true,
+        );
+        final constraints = schedule.toWorkmanagerConstraints();
+        expect(constraints.requiresDeviceIdle, isTrue);
+      });
+
+      test('requiresCharging is propagated', () {
+        const schedule = OsBackgroundTaskSchedule(
+          frequency: Duration(minutes: 15),
+          requiresCharging: true,
+        );
+        final constraints = schedule.toWorkmanagerConstraints();
+        expect(constraints.requiresCharging, isTrue);
+      });
+    });
+
+    test('equality works correctly', () {
+      const a = OsBackgroundTaskSchedule(
+        frequency: Duration(minutes: 15),
+        networkConstraint: OsNetworkConstraint.connected,
+      );
+      const b = OsBackgroundTaskSchedule(
+        frequency: Duration(minutes: 15),
+        networkConstraint: OsNetworkConstraint.connected,
+      );
+      const c = OsBackgroundTaskSchedule(
+        frequency: Duration(minutes: 30),
+      );
+
+      expect(a, equals(b));
+      expect(a, isNot(equals(c)));
+    });
+  });
+
+  group('OsBackgroundTaskDescriptor', () {
+    test('has required fields', () {
+      const descriptor = OsBackgroundTaskDescriptor(
+        identifier: 'com.app.sync',
+        taskName: 'SyncData',
+      );
+      expect(descriptor.identifier, equals('com.app.sync'));
+      expect(descriptor.taskName, equals('SyncData'));
+      expect(descriptor.schedule, equals(OsBackgroundTaskSchedule.recommended));
+      expect(descriptor.runWhenAppTerminated, isTrue);
+    });
+
+    test('custom schedule is preserved', () {
+      const schedule = OsBackgroundTaskSchedule(
+        frequency: Duration(hours: 1),
+        networkConstraint: OsNetworkConstraint.connected,
+      );
+      const descriptor = OsBackgroundTaskDescriptor(
+        identifier: 'com.app.sync',
+        taskName: 'SyncData',
+        schedule: schedule,
+      );
+      expect(descriptor.schedule.frequency, equals(const Duration(hours: 1)));
+      expect(
+        descriptor.schedule.networkConstraint,
+        equals(OsNetworkConstraint.connected),
+      );
+    });
+  });
+}

--- a/test/plugins/usecase/os_background_task_generator_test.dart
+++ b/test/plugins/usecase/os_background_task_generator_test.dart
@@ -1,0 +1,183 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zuraffa/src/core/generator_options.dart';
+import 'package:zuraffa/src/models/generator_config.dart';
+import 'package:zuraffa/src/plugins/usecase/usecase_plugin.dart';
+
+void main() {
+  late Directory tempDir;
+  late String outputDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('zuraffa_osbg_');
+    outputDir = Directory('${tempDir.path}/lib/src').path;
+  });
+
+  tearDown(() async {
+    if (tempDir.existsSync()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  test('generates os_background usecase with service dependency', () async {
+    final plugin = UseCasePlugin(
+      outputDir: outputDir,
+      options: const GeneratorOptions(
+        dryRun: false,
+        force: true,
+        verbose: false,
+      ),
+    );
+    final config = GeneratorConfig(
+      name: 'SyncData',
+      service: 'Data',
+      domain: 'sync',
+      paramsType: 'NoParams',
+      returnsType: 'void',
+      useCaseType: 'os_background',
+      outputDir: outputDir,
+    );
+    final files = await plugin.generate(config);
+    expect(files.length, equals(1));
+    final content = files.first.content ?? '';
+
+    // Must extend OsBackgroundTaskUseCase
+    expect(
+      content.contains('OsBackgroundTaskUseCase<void, NoParams>'),
+      isTrue,
+    );
+    expect(content.contains('class SyncDataUseCase'), isTrue);
+
+    // Must have descriptor getter
+    expect(content.contains('OsBackgroundTaskDescriptor get descriptor'),
+        isTrue);
+    expect(content.contains('com.zuraffa.sync_data_task'), isTrue);
+
+    // Must have execute method
+    expect(content.contains('Future<void> execute'), isTrue);
+
+    // Must have callbackHandler with @pragma('vm:entry-point')
+    expect(content.contains("@pragma('vm:entry-point')"), isTrue);
+    expect(content.contains('callbackHandler'), isTrue);
+
+    // Must inject service dependency
+    expect(content.contains('final DataService _dataService;'), isTrue);
+    expect(
+      content.contains('SyncDataUseCase(this._dataService);'),
+      isTrue,
+    );
+  });
+
+  test('generates os_background usecase with repo dependency', () async {
+    final plugin = UseCasePlugin(
+      outputDir: outputDir,
+      options: const GeneratorOptions(
+        dryRun: false,
+        force: true,
+        verbose: false,
+      ),
+    );
+    final config = GeneratorConfig(
+      name: 'PeriodicCleanup',
+      repo: 'Cache',
+      domain: 'maintenance',
+      paramsType: 'NoParams',
+      returnsType: 'void',
+      useCaseType: 'os_background',
+      outputDir: outputDir,
+    );
+    final files = await plugin.generate(config);
+    final content = files.first.content ?? '';
+
+    expect(content.contains('class PeriodicCleanupUseCase'), isTrue);
+    expect(
+      content.contains('OsBackgroundTaskUseCase<void, NoParams>'),
+      isTrue,
+    );
+    expect(content.contains('final CacheRepository _cacheRepository;'), isTrue);
+    expect(
+      content.contains('PeriodicCleanupUseCase(this._cacheRepository);'),
+      isTrue,
+    );
+    expect(content.contains('await _cacheRepository.periodicCleanup(params);'),
+        isTrue);
+  });
+
+  test('generates os_background usecase without dependency', () async {
+    final plugin = UseCasePlugin(
+      outputDir: outputDir,
+      options: const GeneratorOptions(
+        dryRun: false,
+        force: true,
+        verbose: false,
+      ),
+    );
+    final config = GeneratorConfig(
+      name: 'HeartbeatPing',
+      domain: 'health',
+      paramsType: 'NoParams',
+      returnsType: 'void',
+      useCaseType: 'os_background',
+      outputDir: outputDir,
+    );
+    final files = await plugin.generate(config);
+    final content = files.first.content ?? '';
+
+    expect(content.contains('class HeartbeatPingUseCase'), isTrue);
+    expect(
+      content.contains('OsBackgroundTaskUseCase<void, NoParams>'),
+      isTrue,
+    );
+    // No service/repo dependency fields
+    expect(content.contains('Repository'), isFalse);
+    expect(content.contains('Service'), isFalse);
+    // Has TODO placeholder
+    expect(
+      content.contains('TODO: Implement OS background task logic'),
+      isTrue,
+    );
+  });
+
+  test('generates os_background usecase with typed returns', () async {
+    final plugin = UseCasePlugin(
+      outputDir: outputDir,
+      options: const GeneratorOptions(
+        dryRun: false,
+        force: true,
+        verbose: false,
+      ),
+    );
+    final config = GeneratorConfig(
+      name: 'FetchWeather',
+      service: 'Weather',
+      domain: 'weather',
+      paramsType: 'NoParams',
+      returnsType: 'WeatherData',
+      useCaseType: 'os_background',
+      outputDir: outputDir,
+    );
+    final files = await plugin.generate(config);
+    final content = files.first.content ?? '';
+
+    expect(
+      content.contains('OsBackgroundTaskUseCase<WeatherData, NoParams>'),
+      isTrue,
+    );
+    expect(content.contains('Future<WeatherData> execute'), isTrue);
+  });
+
+  test('plugin routes os_background type to the correct generator', () async {
+    final plugin = UseCasePlugin(
+      outputDir: outputDir,
+      options: const GeneratorOptions(
+        dryRun: false,
+        force: true,
+        verbose: false,
+      ),
+    );
+
+    // Verify that the osBackgroundGenerator is created
+    expect(plugin.osBackgroundGenerator, isNotNull);
+  });
+}

--- a/test/plugins/usecase/os_background_task_generator_test.dart
+++ b/test/plugins/usecase/os_background_task_generator_test.dart
@@ -44,7 +44,7 @@ void main() {
 
     // Must extend OsBackgroundTaskUseCase
     expect(
-      content.contains('OsBackgroundTaskUseCase<void, NoParams>'),
+      content.contains('OsBackgroundTaskUseCase<void>'),
       isTrue,
     );
     expect(content.contains('class SyncDataUseCase'), isTrue);
@@ -92,7 +92,7 @@ void main() {
 
     expect(content.contains('class PeriodicCleanupUseCase'), isTrue);
     expect(
-      content.contains('OsBackgroundTaskUseCase<void, NoParams>'),
+      content.contains('OsBackgroundTaskUseCase<void>'),
       isTrue,
     );
     expect(content.contains('final CacheRepository _cacheRepository;'), isTrue);
@@ -126,7 +126,7 @@ void main() {
 
     expect(content.contains('class HeartbeatPingUseCase'), isTrue);
     expect(
-      content.contains('OsBackgroundTaskUseCase<void, NoParams>'),
+      content.contains('OsBackgroundTaskUseCase<void>'),
       isTrue,
     );
     // No service/repo dependency fields
@@ -161,7 +161,7 @@ void main() {
     final content = files.first.content ?? '';
 
     expect(
-      content.contains('OsBackgroundTaskUseCase<WeatherData, NoParams>'),
+      content.contains('OsBackgroundTaskUseCase<WeatherData>'),
       isTrue,
     );
     expect(content.contains('Future<WeatherData> execute'), isTrue);


### PR DESCRIPTION
## Summary

Adds a new `OsBackgroundTask` use case type that wraps the `workmanager` package for OS-scheduled periodic background tasks on Android/iOS/macOS, with web no-op support.

### New files
- `lib/src/domain/os_background_task.dart` — Runtime abstraction with honest platform contracts (Android 15-min min, iOS opportunistic, web no-op), `OsBackgroundTaskSchedule`, `OsNetworkConstraint`, `OsBackgroundTaskDescriptor`, and static API (initialize/register/cancel/cancelAll)
- `lib/src/domain/os_background_task_usecase.dart` — Abstract base class `OsBackgroundTaskUseCase<T, Params>` with descriptor getter, execute(), register()/cancel() convenience methods
- `lib/src/plugins/usecase/generators/os_background_task_generator.dart` — Code generator following StreamUseCaseGenerator pattern, generates descriptor getter, execute method, callbackHandler with @pragma, supports service/repo DI

### Modified files
- `lib/src/plugins/usecase/usecase_plugin.dart` — Added OsBackgroundTaskGenerator + routing for os_background type
- `lib/src/plugins/usecase/generators/custom_usecase_generator_core.dart` — _baseClass maps os_background to OsBackgroundTaskUseCase
- `lib/src/commands/usecase_command.dart` — Added os_background to allowed CLI types
- `lib/src/plugins/test/test_plugin.dart` — _resolveUseCaseType detects OsBackgroundTaskUseCase
- `lib/zuraffa.dart` — Exported new types
- `pubspec.yaml` — Added workmanager ^0.5.2 dependency

### Tests
- `test/core/os_background_task_schedule_test.dart` — 18 assertions (schedule defaults, Android clamping, workmanager constraints mapping, equality)
- `test/plugins/usecase/os_background_task_generator_test.dart` — 5 assertions (service/repo/no-dep generation, typed returns, plugin routing)

Closes #200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for scheduling and managing cross-platform OS background tasks.
  * Added an `os_background` use-case type for command-line workflows and generated use cases.
  * Exposed background-task APIs and expanded access to Signal, dependency-injection, state, and GraphQL capabilities.
* **Bug Fixes**
  * Improved platform handling, scheduling validation, task cancellation, and registration status reporting.
* **Tests**
  * Added coverage for scheduling behavior, task descriptors, and generated background-task use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->