### PR TITLE
feat(graphql): Track 3.4 — Union-to-Sealed Class Mapping & Error Handling

### DIFF
--- a/lib/src/core/failure.dart
+++ b/lib/src/core/failure.dart
@@ -37,13 +37,18 @@ sealed class AppFailure implements Exception {
   /// Human-readable error message
   final String message;
 
+  /// Machine-readable error code (e.g. a GraphQL error type name such as
+  /// `InsufficientStockError`). Optional; most failures are identified by
+  /// [message] alone.
+  final String? code;
+
   /// Stack trace from where the failure originated
   final StackTrace? stackTrace;
 
   /// The original error/exception that caused this failure
   final Object? cause;
 
-  const AppFailure(this.message, {this.stackTrace, this.cause});
+  const AppFailure(this.message, {this.code, this.stackTrace, this.cause});
 
   /// Create a generic failure with a default message.
   factory AppFailure.create() => const UnknownFailure.create();
@@ -202,6 +207,7 @@ final class ServerFailure extends AppFailure {
   const ServerFailure(
     super.message, {
     this.statusCode,
+    super.code,
     super.stackTrace,
     super.cause,
   });
@@ -244,7 +250,12 @@ final class ServerFailure extends AppFailure {
 /// Use when there are connection issues, DNS failures,
 /// or the device is offline.
 final class NetworkFailure extends AppFailure {
-  const NetworkFailure(super.message, {super.stackTrace, super.cause});
+  const NetworkFailure(
+    super.message, {
+    super.code,
+    super.stackTrace,
+    super.cause,
+  });
 
   /// Create a network failure with a default message.
   const NetworkFailure.create() : super('Network error');
@@ -283,7 +294,12 @@ final class NetworkFailure extends AppFailure {
 /// Use when there are issues reading from or writing to local storage,
 /// or when cached data is corrupted or expired.
 final class CacheFailure extends AppFailure {
-  const CacheFailure(super.message, {super.stackTrace, super.cause});
+  const CacheFailure(
+    super.message, {
+    super.code,
+    super.stackTrace,
+    super.cause,
+  });
 
   /// Factory that creates a CacheFailure if the error matches,
   /// otherwise returns null
@@ -315,6 +331,7 @@ final class ValidationFailure extends AppFailure {
   const ValidationFailure(
     super.message, {
     this.fieldErrors,
+    super.code,
     super.stackTrace,
     super.cause,
   });
@@ -371,6 +388,7 @@ final class NotFoundFailure extends AppFailure {
     super.message, {
     this.resourceId,
     this.resourceType,
+    super.code,
     super.stackTrace,
     super.cause,
   });
@@ -409,7 +427,12 @@ final class NotFoundFailure extends AppFailure {
 /// Use when authentication is required but missing or invalid.
 /// The user needs to login or refresh their credentials.
 final class UnauthorizedFailure extends AppFailure {
-  const UnauthorizedFailure(super.message, {super.stackTrace, super.cause});
+  const UnauthorizedFailure(
+    super.message, {
+    super.code,
+    super.stackTrace,
+    super.cause,
+  });
 
   /// Factory that creates an UnauthorizedFailure if the error matches,
   /// otherwise returns null
@@ -445,6 +468,7 @@ final class ForbiddenFailure extends AppFailure {
   const ForbiddenFailure(
     super.message, {
     this.requiredPermission,
+    super.code,
     super.stackTrace,
     super.cause,
   });
@@ -479,6 +503,7 @@ final class ConflictFailure extends AppFailure {
   const ConflictFailure(
     super.message, {
     this.conflictType,
+    super.code,
     super.stackTrace,
     super.cause,
   });
@@ -515,6 +540,7 @@ final class TimeoutFailure extends AppFailure {
   const TimeoutFailure(
     super.message, {
     this.timeout,
+    super.code,
     super.stackTrace,
     super.cause,
   });
@@ -558,12 +584,11 @@ final class CancellationFailure extends AppFailure {
 ///
 /// Use when a platform-specific error occurs (e.g. Flutter PlatformException).
 final class PlatformFailure extends AppFailure {
-  final String? code;
   final dynamic details;
 
   const PlatformFailure(
     super.message, {
-    this.code,
+    super.code,
     this.details,
     super.stackTrace,
     super.cause,
@@ -578,7 +603,12 @@ final class PlatformFailure extends AppFailure {
 /// Use as a fallback when the error type cannot be determined.
 /// Prefer using more specific failure types when possible.
 final class UnknownFailure extends AppFailure {
-  const UnknownFailure(super.message, {super.stackTrace, super.cause});
+  const UnknownFailure(
+    super.message, {
+    super.code,
+    super.stackTrace,
+    super.cause,
+  });
 
   /// Create an unknown failure with a default message.
   const UnknownFailure.create() : super('Unexpected error');
@@ -598,28 +628,43 @@ final class UnknownFailure extends AppFailure {
 ///
 /// Use when the application is in an invalid state for the requested operation.
 final class StateFailure extends AppFailure {
-  const StateFailure(super.message, {super.stackTrace, super.cause});
+  const StateFailure(
+    super.message, {
+    super.code,
+    super.stackTrace,
+    super.cause,
+  });
 }
 
 /// Type failures
 ///
 /// Use when a value has an unexpected type.
 final class TypeFailure extends AppFailure {
-  const TypeFailure(super.message, {super.stackTrace, super.cause});
+  const TypeFailure(super.message, {super.code, super.stackTrace, super.cause});
 }
 
 /// Unimplemented failures
 ///
 /// Use when a requested feature or method is not yet implemented.
 final class UnimplementedFailure extends AppFailure {
-  const UnimplementedFailure(super.message, {super.stackTrace, super.cause});
+  const UnimplementedFailure(
+    super.message, {
+    super.code,
+    super.stackTrace,
+    super.cause,
+  });
 }
 
 /// Unsupported failures
 ///
 /// Use when an operation is not supported by the current platform or configuration.
 final class UnsupportedFailure extends AppFailure {
-  const UnsupportedFailure(super.message, {super.stackTrace, super.cause});
+  const UnsupportedFailure(
+    super.message, {
+    super.code,
+    super.stackTrace,
+    super.cause,
+  });
 }
 
 /// Extension to convert exceptions to failures

--- a/lib/src/graphql/codegen/codegen_types.dart
+++ b/lib/src/graphql/codegen/codegen_types.dart
@@ -13,6 +13,10 @@ String zorphyType(TypeMapper mapper, GraphQLType type) {
   if (inner is GraphQLObjectType || inner is GraphQLInputObjectType) {
     return mapped.replaceAll(inner.name, '\$${inner.name}');
   }
+  // Sealed union bases are generated as `$$Union` classes.
+  if (inner is GraphQLUnionType) {
+    return mapped.replaceAll(inner.name, '\$\$${inner.name}');
+  }
   return mapped;
 }
 

--- a/lib/src/graphql/codegen/datasource_generator.dart
+++ b/lib/src/graphql/codegen/datasource_generator.dart
@@ -49,6 +49,15 @@ class DatasourceGenerator {
   }) {
     final className = '\$${name}Datasource';
 
+    // Check if any union operation exists
+    final hasUnionOperation =
+        queries.any(
+          (q) => q.returnType.innerType is GraphQLUnionType && !q.returnType.isList,
+        ) ||
+        mutations.any(
+          (m) => m.returnType.innerType is GraphQLUnionType && !m.returnType.isList,
+        );
+
     final library = cb.Library((b) {
       b.directives.add(cb.Directive.import('package:zuraffa/zuraffa.dart'));
       b.directives.add(
@@ -77,8 +86,8 @@ class DatasourceGenerator {
               }),
             );
 
-          // Error config field + mapping helper when unions are enabled
-          if (errorConfig != null) {
+          // Error config field + mapping helper when unions are enabled and union operations exist
+          if (errorConfig != null && hasUnionOperation) {
             final handler = UnionResultHandler(errorConfig: errorConfig!);
             c.fields.add(handler.buildErrorConfigField());
           }
@@ -124,8 +133,8 @@ class DatasourceGenerator {
             }
           }
 
-          // _mapError helper if union error mapping is enabled
-          if (errorConfig != null) {
+          // _mapError helper if union error mapping is enabled and union operations exist
+          if (errorConfig != null && hasUnionOperation) {
             c.methods.add(
               UnionResultHandler(
                 errorConfig: errorConfig!,
@@ -194,7 +203,7 @@ class DatasourceGenerator {
         bl.statements.add(cb.Code('  );'));
         bl.statements.add(cb.Code('}'));
         bl.statements.add(cb.Code(''));
-        if (isUnion) {
+        if (isUnion && !query.returnType.isList) {
           _buildUnionHandler(bl, query, isMutation: false);
         } else if (query.returnType.isList) {
           bl.statements.add(
@@ -295,7 +304,7 @@ class DatasourceGenerator {
         bl.statements.add(cb.Code('  );'));
         bl.statements.add(cb.Code('}'));
         bl.statements.add(cb.Code(''));
-        if (isUnion) {
+        if (isUnion && !mutation.returnType.isList) {
           _buildUnionHandler(bl, mutation, isMutation: true);
         } else if (mutation.returnType.isList) {
           bl.statements.add(
@@ -383,6 +392,15 @@ class DatasourceGenerator {
       bl.statements.add(cb.Code('  return SignalResult<$signalType>.failure('));
       bl.statements.add(
         cb.Code("    const ServerFailure('No data returned'),"),
+      );
+      bl.statements.add(cb.Code('  );'));
+      bl.statements.add(cb.Code('}'));
+      bl.statements.add(cb.Code(''));
+      bl.statements.add(cb.Code("final typename = data['__typename'] as String?;"));
+      bl.statements.add(cb.Code('if (typename == null) {'));
+      bl.statements.add(cb.Code('  return SignalResult<$signalType>.failure('));
+      bl.statements.add(
+        cb.Code("    const ServerFailure('Missing __typename in union result'),"),
       );
       bl.statements.add(cb.Code('  );'));
       bl.statements.add(cb.Code('}'));

--- a/lib/src/graphql/codegen/datasource_generator.dart
+++ b/lib/src/graphql/codegen/datasource_generator.dart
@@ -7,7 +7,8 @@ import 'codegen_types.dart';
 /// Generates fully implemented remote datasource classes.
 ///
 /// Creates a datasource with `query`, `mutation`, and `subscription` methods
-/// using `package:graphql` client.
+/// using `package:graphql` client. Union-returning operations are handled
+/// through [UnionResultHandler] when an [errorConfig] is provided.
 /// ```dart
 /// final gen = DatasourceGenerator(typeMapper: mapper);
 /// final code = gen.generate(
@@ -20,6 +21,7 @@ class DatasourceGenerator {
   DatasourceGenerator({
     required this.typeMapper,
     this.enableSubscriptions = false,
+    this.errorConfig,
   });
 
   final TypeMapper typeMapper;
@@ -29,6 +31,11 @@ class DatasourceGenerator {
   /// and a `wsEndpoint` in `.zfa.json`). When false, watch methods are
   /// generated as stubs that report subscriptions are disabled.
   final bool enableSubscriptions;
+
+  /// Optional error mapping table for union-returning operations. When set,
+  /// union results are dispatched on `__typename` and error variants are
+  /// mapped to [AppFailure] via the generated `_mapError` helper.
+  final ErrorMappingConfig? errorConfig;
   static final _formatter = DartFormatter(
     languageVersion: DartFormatter.latestLanguageVersion,
   );
@@ -70,6 +77,12 @@ class DatasourceGenerator {
               }),
             );
 
+          // Error config field + mapping helper when unions are enabled
+          if (errorConfig != null) {
+            final handler = UnionResultHandler(errorConfig: errorConfig!);
+            c.fields.add(handler.buildErrorConfigField());
+          }
+
           c.constructors.add(
             cb.Constructor((ctor) {
               ctor.requiredParameters.add(
@@ -110,6 +123,15 @@ class DatasourceGenerator {
               c.methods.add(_buildWatchStub(watch));
             }
           }
+
+          // _mapError helper if union error mapping is enabled
+          if (errorConfig != null) {
+            c.methods.add(
+              UnionResultHandler(
+                errorConfig: errorConfig!,
+              ).buildMapErrorMethod(),
+            );
+          }
         }),
       );
     });
@@ -128,6 +150,7 @@ class DatasourceGenerator {
   cb.Method _buildQueryMethod(QueryConfig query) {
     final returnType = zorphyType(typeMapper, query.returnType);
     final methodName = _camelCase(query.fieldName);
+    final isUnion = query.returnType.innerType is GraphQLUnionType;
 
     return cb.Method((m) {
       m
@@ -152,7 +175,7 @@ class DatasourceGenerator {
         );
         bl.statements.add(cb.Code("  document: gql(r'''"));
         bl.statements.add(cb.Code(query.document));
-        bl.statements.add(cb.Code("'''),"));
+        bl.statements.add(cb.Code("''',"));
         bl.statements.add(cb.Code('  variables: {'));
         for (final arg in query.args) {
           final fieldName = TypeMapper.fieldName(arg.name);
@@ -166,12 +189,14 @@ class DatasourceGenerator {
           cb.Code('  return SignalResult<$returnType>.failure('),
         );
         bl.statements.add(
-          cb.Code('    NetworkFailure(message: result.exception.toString()),'),
+          cb.Code('    NetworkFailure(result.exception.toString()),'),
         );
         bl.statements.add(cb.Code('  );'));
         bl.statements.add(cb.Code('}'));
         bl.statements.add(cb.Code(''));
-        if (query.returnType.isList) {
+        if (isUnion) {
+          _buildUnionHandler(bl, query, isMutation: false);
+        } else if (query.returnType.isList) {
           bl.statements.add(
             cb.Code(
               'final data = result.data?[\'${query.fieldName}\'] as List<dynamic>?;',
@@ -182,7 +207,7 @@ class DatasourceGenerator {
             cb.Code('  return SignalResult<$returnType>.failure('),
           );
           bl.statements.add(
-            cb.Code("    const ServerFailure(message: 'No data returned'),"),
+            cb.Code("    const ServerFailure('No data returned'),"),
           );
           bl.statements.add(cb.Code('  );'));
           bl.statements.add(cb.Code('}'));
@@ -206,7 +231,7 @@ class DatasourceGenerator {
             cb.Code('  return SignalResult<$returnType>.failure('),
           );
           bl.statements.add(
-            cb.Code("    const ServerFailure(message: 'No data returned'),"),
+            cb.Code("    const ServerFailure('No data returned'),"),
           );
           bl.statements.add(cb.Code('  );'));
           bl.statements.add(cb.Code('}'));
@@ -227,6 +252,7 @@ class DatasourceGenerator {
   cb.Method _buildMutationMethod(MutationConfig mutation) {
     final returnType = zorphyType(typeMapper, mutation.returnType);
     final methodName = _camelCase(mutation.fieldName);
+    final isUnion = mutation.returnType.innerType is GraphQLUnionType;
 
     return cb.Method((m) {
       m
@@ -250,7 +276,7 @@ class DatasourceGenerator {
         );
         bl.statements.add(cb.Code("  document: gql(r'''"));
         bl.statements.add(cb.Code(mutation.document));
-        bl.statements.add(cb.Code("'''),"));
+        bl.statements.add(cb.Code("''',"));
         bl.statements.add(cb.Code('  variables: {'));
         for (final arg in mutation.args) {
           final fieldName = TypeMapper.fieldName(arg.name);
@@ -264,12 +290,14 @@ class DatasourceGenerator {
           cb.Code('  return SignalResult<$returnType>.failure('),
         );
         bl.statements.add(
-          cb.Code('    NetworkFailure(message: result.exception.toString()),'),
+          cb.Code('    NetworkFailure(result.exception.toString()),'),
         );
         bl.statements.add(cb.Code('  );'));
         bl.statements.add(cb.Code('}'));
         bl.statements.add(cb.Code(''));
-        if (mutation.returnType.isList) {
+        if (isUnion) {
+          _buildUnionHandler(bl, mutation, isMutation: true);
+        } else if (mutation.returnType.isList) {
           bl.statements.add(
             cb.Code(
               'final data = result.data?[\'${mutation.fieldName}\'] as List<dynamic>?;',
@@ -280,7 +308,7 @@ class DatasourceGenerator {
             cb.Code('  return SignalResult<$returnType>.failure('),
           );
           bl.statements.add(
-            cb.Code("    const ServerFailure(message: 'No data returned'),"),
+            cb.Code("    const ServerFailure('No data returned'),"),
           );
           bl.statements.add(cb.Code('  );'));
           bl.statements.add(cb.Code('}'));
@@ -304,7 +332,7 @@ class DatasourceGenerator {
             cb.Code('  return SignalResult<$returnType>.failure('),
           );
           bl.statements.add(
-            cb.Code("    const ServerFailure(message: 'No data returned'),"),
+            cb.Code("    const ServerFailure('No data returned'),"),
           );
           bl.statements.add(cb.Code('  );'));
           bl.statements.add(cb.Code('}'));
@@ -320,6 +348,65 @@ class DatasourceGenerator {
         }
       });
     });
+  }
+
+  /// Generate statements that handle a union-returning operation.
+  ///
+  /// With an [errorConfig], the result is dispatched on `__typename` and
+  /// error variants map to [AppFailure]; otherwise the sealed union object
+  /// is unwrapped directly.
+  void _buildUnionHandler(
+    cb.BlockBuilder bl,
+    Object config, {
+    required bool isMutation,
+  }) {
+    final fieldName = config is QueryConfig
+        ? config.fieldName
+        : (config as MutationConfig).fieldName;
+    final returnType = config is QueryConfig
+        ? config.returnType
+        : (config as MutationConfig).returnType;
+    final signalType = isMutation
+        ? zorphyType(typeMapper, (config as MutationConfig).returnType)
+        : zorphyType(typeMapper, (config as QueryConfig).returnType);
+    final unionType = returnType.innerType as GraphQLUnionType;
+    final unionClass = cb.refer('\$\$${unionType.name}');
+
+    if (errorConfig == null) {
+      // No error mapping: unwrap the sealed union directly.
+      bl.statements.add(
+        cb.Code(
+          'final data = result.data?[\'$fieldName\'] as Map<String, dynamic>?;',
+        ),
+      );
+      bl.statements.add(cb.Code('if (data == null) {'));
+      bl.statements.add(cb.Code('  return SignalResult<$signalType>.failure('));
+      bl.statements.add(
+        cb.Code("    const ServerFailure('No data returned'),"),
+      );
+      bl.statements.add(cb.Code('  );'));
+      bl.statements.add(cb.Code('}'));
+      bl.statements.add(cb.Code(''));
+      bl.statements.add(
+        cb.Code('final entity = ${unionClass.symbol}.fromJson(data);'),
+      );
+      bl.statements.add(
+        cb.Code('return SignalResult<$signalType>.success(entity);'),
+      );
+      return;
+    }
+
+    final handler = UnionResultHandler(
+      errorConfig: errorConfig!,
+      operationName: fieldName,
+    );
+    bl.statements.add(
+      handler.buildHandler(
+        unionType: unionClass,
+        fieldName: fieldName,
+        returnType: signalType,
+      ),
+    );
   }
 
   cb.Method _buildSubscriptionMethod(SubscriptionConfig sub) {
@@ -433,7 +520,7 @@ class DatasourceGenerator {
         );
         bl.statements.add(cb.Code('return SignalResult<$returnType>.failure('));
         bl.statements.add(
-          cb.Code("  const NetworkFailure(message: 'Subscriptions disabled'),"),
+          cb.Code("  const NetworkFailure('Subscriptions disabled'),"),
         );
         bl.statements.add(cb.Code(');'));
       });

--- a/lib/src/graphql/codegen/error_mapping_config.dart
+++ b/lib/src/graphql/codegen/error_mapping_config.dart
@@ -1,0 +1,127 @@
+import 'package:zuraffa/zuraffa.dart';
+
+/// Configuration for mapping GraphQL union error variants to
+/// Zuraffa's [AppFailure] taxonomy.
+///
+/// ```json
+/// // .zfa.json
+/// {
+///   "graphql": {
+///     "errorMapping": {
+///       "global": {
+///         "InsufficientStockError": "business",
+///         "NoActiveOrderError": "session",
+///         "*Error": "unknown"
+///       },
+///       "perOperation": {
+///         "addItemToOrder": {
+///           "InsufficientStockError": "business",
+///           "NegativeQuantityError": "validation"
+///         }
+///       }
+///     }
+///   }
+/// }
+/// ```
+///
+/// A variant is treated as an error unless its category is `success`.
+/// Unmapped variants whose name ends in `*Error` fall back to the wildcard
+/// `*Error` category (or `unknown`); every other unmapped variant is a
+/// success variant.
+class ErrorMappingConfig {
+  ErrorMappingConfig({
+    this.globalMappings = const {},
+    this.perOperationMappings = const {},
+  });
+
+  /// Global error code → AppFailure category mapping.
+  /// Keys are GraphQL type names (e.g. `InsufficientStockError`).
+  /// Values are failure categories: `success`, `business`, `session`,
+  /// `validation`, `network`, `unknown`.
+  final Map<String, String> globalMappings;
+
+  /// Per-operation override mappings.
+  /// Outer key is the GraphQL field name (e.g. `addItemToOrder`).
+  final Map<String, Map<String, String>> perOperationMappings;
+
+  /// Parse from `.zfa.json` (or any JSON with a `graphql.errorMapping`
+  /// section).
+  factory ErrorMappingConfig.fromJson(Map<String, dynamic> json) {
+    final graphql = json['graphql'] as Map<String, dynamic>? ?? {};
+    final errorMapping = graphql['errorMapping'] as Map<String, dynamic>? ?? {};
+
+    final global = (errorMapping['global'] as Map<String, dynamic>? ?? {})
+        .cast<String, String>();
+
+    final perOp = <String, Map<String, String>>{};
+    final perOpRaw =
+        errorMapping['perOperation'] as Map<String, dynamic>? ?? {};
+    for (final entry in perOpRaw.entries) {
+      perOp[entry.key] = (entry.value as Map<String, dynamic>)
+          .cast<String, String>();
+    }
+
+    return ErrorMappingConfig(
+      globalMappings: global,
+      perOperationMappings: perOp,
+    );
+  }
+
+  /// Get the failure category for [errorTypeName] in [operationName].
+  ///
+  /// Resolution order:
+  /// 1. Per-operation override (if [operationName] is provided)
+  /// 2. Global mapping
+  /// 3. Wildcard `*Error` pattern (only for names ending in `Error`)
+  /// 4. `unknown` for error-suffixed names, `success` otherwise
+  String getCategory(String errorTypeName, {String? operationName}) {
+    // Per-operation override
+    if (operationName != null) {
+      final opMap = perOperationMappings[operationName];
+      if (opMap != null) {
+        final category = opMap[errorTypeName];
+        if (category != null) return category;
+      }
+    }
+
+    // Global mapping
+    final globalCategory = globalMappings[errorTypeName];
+    if (globalCategory != null) return globalCategory;
+
+    // Wildcard pattern: *Error → wildcard category, or unknown by default
+    if (errorTypeName.endsWith('Error')) {
+      return globalMappings['*Error'] ?? 'unknown';
+    }
+
+    // Unmapped, non-error-suffixed variants are success variants.
+    return 'success';
+  }
+
+  /// Whether [typeName] is mapped as an error (any category other than
+  /// `success`).
+  bool isError(String typeName, {String? operationName}) {
+    final category = getCategory(typeName, operationName: operationName);
+    return category != 'success';
+  }
+
+  /// Build an [AppFailure] from [errorTypeName] with optional [message].
+  ///
+  /// The GraphQL error type name is preserved as the failure's [AppFailure.code]
+  /// so callers can distinguish e.g. `InsufficientStockError` from
+  /// `NegativeQuantityError`.
+  AppFailure toFailure(
+    String errorTypeName, {
+    String? message,
+    String? operationName,
+  }) {
+    final category = getCategory(errorTypeName, operationName: operationName);
+    final msg = message ?? errorTypeName;
+
+    return switch (category) {
+      'business' || 'validation' => ValidationFailure(msg, code: errorTypeName),
+      'session' => UnauthorizedFailure(msg, code: errorTypeName),
+      'network' => NetworkFailure(msg, code: errorTypeName),
+      _ => UnknownFailure(msg, code: errorTypeName),
+    };
+  }
+}

--- a/lib/src/graphql/codegen/union_generator.dart
+++ b/lib/src/graphql/codegen/union_generator.dart
@@ -53,8 +53,15 @@ class UnionGenerator {
                 )
                 ..body = cb.Block((bl) {
                   bl.statements.add(
-                    cb.Code('final typename = json[\'__typename\'] as String;'),
+                    cb.Code("final typename = json['__typename'] as String?;"),
                   );
+                  bl.statements.add(cb.Code('if (typename == null) {'));
+                  bl.statements.add(
+                    cb.Code(
+                      "  throw ArgumentError('Missing __typename in union JSON');",
+                    ),
+                  );
+                  bl.statements.add(cb.Code('}'));
                   bl.statements.add(cb.Code('switch (typename) {'));
                   for (final typeName in unionType.possibleTypes) {
                     final entityName = '\$$typeName';

--- a/lib/src/graphql/codegen/union_result_handler.dart
+++ b/lib/src/graphql/codegen/union_result_handler.dart
@@ -1,0 +1,142 @@
+import 'package:code_builder/code_builder.dart' as cb;
+
+import 'error_mapping_config.dart';
+
+/// Generates the union-result handling code emitted into generated
+/// datasources, mapping error variants to [AppFailure] and success variants
+/// to the sealed union object.
+///
+/// Unions are dispatched at runtime on their `__typename` discriminator
+/// through the datasource's `_errorConfig` / `_mapError` members:
+///
+/// ```dart
+/// final data = result.data?['addItemToOrder'] as Map<String, dynamic>?;
+/// if (data == null) {
+///   return SignalResult<$$AddItemToOrderResult>.failure(
+///     const ServerFailure('No data returned'),
+///   );
+/// }
+/// final typename = data['__typename'] as String? ?? '';
+/// if (_errorConfig.isError(typename, operationName: 'addItemToOrder')) {
+///   return SignalResult<$$AddItemToOrderResult>.failure(_mapError(typename, data));
+/// }
+/// final entity = $$AddItemToOrderResult.fromJson(data);
+/// return SignalResult<$$AddItemToOrderResult>.success(entity);
+/// ```
+///
+/// Used by [DatasourceGenerator] to handle union-returning operations.
+class UnionResultHandler {
+  UnionResultHandler({required this.errorConfig, this.operationName});
+
+  /// The error mapping table baked into the generated datasource.
+  final ErrorMappingConfig errorConfig;
+
+  /// GraphQL operation (field) name, used for per-operation mappings.
+  final String? operationName;
+
+  /// Generate the `_errorConfig` field declaration for a datasource.
+  ///
+  /// The field is initialized from [errorConfig] so global and per-operation
+  /// mappings from `.zfa.json` take effect at runtime.
+  cb.Field buildErrorConfigField() {
+    return cb.Field((f) {
+      f
+        ..name = '_errorConfig'
+        ..modifier = cb.FieldModifier.final$
+        ..type = cb.refer('ErrorMappingConfig')
+        ..assignment = cb.Code(_configSource());
+    });
+  }
+
+  /// Generate the `_mapError` helper method for a datasource.
+  ///
+  /// Reads the optional `message` from the variant JSON and converts the
+  /// error type name to an [AppFailure] via [ErrorMappingConfig.toFailure].
+  cb.Method buildMapErrorMethod() {
+    return cb.Method((m) {
+      m
+        ..name = '_mapError'
+        ..returns = cb.refer('AppFailure')
+        ..requiredParameters.addAll([
+          cb.Parameter(
+            (p) => p
+              ..name = 'errorType'
+              ..type = cb.refer('String'),
+          ),
+          cb.Parameter(
+            (p) => p
+              ..name = 'json'
+              ..type = cb.refer('Map<String, dynamic>'),
+          ),
+        ])
+        ..body = cb.Block((bl) {
+          bl.statements.add(
+            cb.Code("final message = json['message'] as String? ?? errorType;"),
+          );
+          bl.statements.add(
+            cb.Code(
+              'return _errorConfig.toFailure(errorType, message: message);',
+            ),
+          );
+        });
+    });
+  }
+
+  /// Generate the statements that handle a union-returning operation.
+  ///
+  /// The emitted block checks `__typename` against [_errorConfig]; error
+  /// variants return [SignalResult.failure] with the mapped [AppFailure],
+  /// success variants unwrap to the sealed `$$Union` object.
+  ///
+  /// - [unionType]: the GraphQL union return type.
+  /// - [fieldName]: the GraphQL field the result came from.
+  /// - [returnType]: the Dart generic of the generated `SignalResult` (e.g.
+  ///   `$$AddItemToOrderResult`).
+  /// - [resultVar]: the name of the local `QueryResult`/`MutationResult`
+  ///   variable (defaults to `result`).
+  cb.Code buildHandler({
+    required cb.Reference unionType,
+    required String fieldName,
+    required String returnType,
+    String resultVar = 'result',
+  }) {
+    final buffer = StringBuffer();
+
+    buffer.writeln(
+      "final data = $resultVar.data?['$fieldName'] as Map<String, dynamic>?;",
+    );
+    buffer.writeln('if (data == null) {');
+    buffer.writeln('  return SignalResult<$returnType>.failure(');
+    buffer.writeln("    const ServerFailure('No data returned'),");
+    buffer.writeln('  );');
+    buffer.writeln('}');
+    buffer.writeln('');
+    buffer.writeln("final typename = data['__typename'] as String? ?? '';");
+    final opArg = operationName == null
+        ? ''
+        : ", operationName: '$operationName'";
+    buffer.writeln('if (_errorConfig.isError(typename$opArg)) {');
+    buffer.writeln(
+      '  return SignalResult<$returnType>.failure(_mapError(typename, data));',
+    );
+    buffer.writeln('');
+    buffer.writeln('final entity = ${unionType.symbol}.fromJson(data);');
+    buffer.writeln('return SignalResult<$returnType>.success(entity);');
+
+    return cb.Code(buffer.toString());
+  }
+
+  /// Render [errorConfig] as a Dart `ErrorMappingConfig(...)` literal.
+  String _configSource() {
+    final global = errorConfig.globalMappings.entries
+        .map((e) => "'${e.key}': '${e.value}'")
+        .join(', ');
+    final perOp = errorConfig.perOperationMappings.entries
+        .map(
+          (e) =>
+              "'${e.key}': {${e.value.entries.map((ee) => "'${ee.key}': '${ee.value}'").join(', ')}}",
+        )
+        .join(', ');
+    return 'ErrorMappingConfig(globalMappings: {$global}, perOperationMappings: {$perOp})';
+  }
+}

--- a/lib/src/graphql/codegen/union_result_handler.dart
+++ b/lib/src/graphql/codegen/union_result_handler.dart
@@ -16,9 +16,16 @@ import 'error_mapping_config.dart';
 ///     const ServerFailure('No data returned'),
 ///   );
 /// }
-/// final typename = data['__typename'] as String? ?? '';
+/// final typename = data['__typename'] as String?;
+/// if (typename == null) {
+///   return SignalResult<$$AddItemToOrderResult>.failure(
+///     const ServerFailure('Missing __typename in union result'),
+///   );
+/// }
 /// if (_errorConfig.isError(typename, operationName: 'addItemToOrder')) {
-///   return SignalResult<$$AddItemToOrderResult>.failure(_mapError(typename, data));
+///   return SignalResult<$$AddItemToOrderResult>.failure(
+///     _mapError(typename, data, 'addItemToOrder'),
+///   );
 /// }
 /// final entity = $$AddItemToOrderResult.fromJson(data);
 /// return SignalResult<$$AddItemToOrderResult>.success(entity);
@@ -68,6 +75,11 @@ class UnionResultHandler {
               ..name = 'json'
               ..type = cb.refer('Map<String, dynamic>'),
           ),
+          cb.Parameter(
+            (p) => p
+              ..name = 'operationName'
+              ..type = cb.refer('String'),
+          ),
         ])
         ..body = cb.Block((bl) {
           bl.statements.add(
@@ -75,7 +87,7 @@ class UnionResultHandler {
           );
           bl.statements.add(
             cb.Code(
-              'return _errorConfig.toFailure(errorType, message: message);',
+              'return _errorConfig.toFailure(errorType, message: message, operationName: operationName);',
             ),
           );
         });
@@ -111,14 +123,24 @@ class UnionResultHandler {
     buffer.writeln('  );');
     buffer.writeln('}');
     buffer.writeln('');
-    buffer.writeln("final typename = data['__typename'] as String? ?? '';");
+    buffer.writeln("final typename = data['__typename'] as String?;");
+    buffer.writeln('if (typename == null) {');
+    buffer.writeln('  return SignalResult<$returnType>.failure(');
+    buffer.writeln("    const ServerFailure('Missing __typename in union result'),");
+    buffer.writeln('  );');
+    buffer.writeln('}');
+    buffer.writeln('');
     final opArg = operationName == null
         ? ''
         : ", operationName: '$operationName'";
+    final opArgForMapError = operationName == null
+        ? "''"
+        : "'$operationName'";
     buffer.writeln('if (_errorConfig.isError(typename$opArg)) {');
     buffer.writeln(
-      '  return SignalResult<$returnType>.failure(_mapError(typename, data));',
+      '  return SignalResult<$returnType>.failure(_mapError(typename, data, $opArgForMapError));',
     );
+    buffer.writeln('}');
     buffer.writeln('');
     buffer.writeln('final entity = ${unionType.symbol}.fromJson(data);');
     buffer.writeln('return SignalResult<$returnType>.success(entity);');

--- a/lib/src/graphql/codegen/union_result_handler.dart
+++ b/lib/src/graphql/codegen/union_result_handler.dart
@@ -112,40 +112,48 @@ class UnionResultHandler {
     required String returnType,
     String resultVar = 'result',
   }) {
-    final buffer = StringBuffer();
-
-    buffer.writeln(
-      "final data = $resultVar.data?['$fieldName'] as Map<String, dynamic>?;",
-    );
-    buffer.writeln('if (data == null) {');
-    buffer.writeln('  return SignalResult<$returnType>.failure(');
-    buffer.writeln("    const ServerFailure('No data returned'),");
-    buffer.writeln('  );');
-    buffer.writeln('}');
-    buffer.writeln('');
-    buffer.writeln("final typename = data['__typename'] as String?;");
-    buffer.writeln('if (typename == null) {');
-    buffer.writeln('  return SignalResult<$returnType>.failure(');
-    buffer.writeln("    const ServerFailure('Missing __typename in union result'),");
-    buffer.writeln('  );');
-    buffer.writeln('}');
-    buffer.writeln('');
     final opArg = operationName == null
         ? ''
         : ", operationName: '$operationName'";
-    final opArgForMapError = operationName == null
-        ? "''"
-        : "'$operationName'";
-    buffer.writeln('if (_errorConfig.isError(typename$opArg)) {');
-    buffer.writeln(
-      '  return SignalResult<$returnType>.failure(_mapError(typename, data, $opArgForMapError));',
-    );
-    buffer.writeln('}');
-    buffer.writeln('');
-    buffer.writeln('final entity = ${unionType.symbol}.fromJson(data);');
-    buffer.writeln('return SignalResult<$returnType>.success(entity);');
+    final opArgForMapError = operationName == null ? "''" : "'$operationName'";
+    final body = cb.Block((bl) {
+      bl.statements.addAll([
+        cb.Code(
+          "final data = $resultVar.data?['$fieldName'] as Map<String, dynamic>?;",
+        ),
+        cb.Code('if (data == null) {'),
+        cb.Code('  return SignalResult<$returnType>.failure('),
+        cb.Code("    const ServerFailure('No data returned'),"),
+        cb.Code('  );'),
+        cb.Code('}'),
+        cb.Code(''),
+        cb.Code("final typename = data['__typename'] as String?;"),
+        cb.Code('if (typename == null) {'),
+        cb.Code('  return SignalResult<$returnType>.failure('),
+        cb.Code(
+          "    const ServerFailure('Missing __typename in union result'),",
+        ),
+        cb.Code('  );'),
+        cb.Code('}'),
+        cb.Code(''),
+        cb.Code('if (_errorConfig.isError(typename$opArg)) {'),
+        cb.Code(
+          '  return SignalResult<$returnType>.failure(_mapError(typename, data, $opArgForMapError));',
+        ),
+        cb.Code('}'),
+        cb.Code(''),
+        cb.Code('final entity = ${unionType.symbol}.fromJson(data);'),
+        cb.Code('return SignalResult<$returnType>.success(entity);'),
+      ]);
+    });
 
-    return cb.Code(buffer.toString());
+    // Emit the statements (without the surrounding block braces) so they
+    // inline directly into the generated method body; DartFormatter in the
+    // datasource generator normalizes the final output.
+    final emitter = cb.DartEmitter();
+    return cb.Code(
+      body.statements.map((s) => s.accept(emitter).toString()).join('\n'),
+    );
   }
 
   /// Render [errorConfig] as a Dart `ErrorMappingConfig(...)` literal.

--- a/lib/zuraffa.dart
+++ b/lib/zuraffa.dart
@@ -519,6 +519,12 @@ export 'src/graphql/codegen/di_generator.dart';
 // SliceOrchestrator — orchestrates all generators for a schema slice.
 export 'src/graphql/codegen/slice_orchestrator.dart';
 
+// ErrorMappingConfig — .zfa.json graphql.errorMapping -> AppFailure mapping.
+export 'src/graphql/codegen/error_mapping_config.dart';
+
+// UnionResultHandler — union result -> AppFailure/SignalResult codegen.
+export 'src/graphql/codegen/union_result_handler.dart';
+
 // GraphqlGenerateCommand — `zfa graphql generate` command class.
 export 'src/graphql/codegen/graphql_generate_command.dart';
 

--- a/test/graphql/codegen/error_mapping_config_test.dart
+++ b/test/graphql/codegen/error_mapping_config_test.dart
@@ -1,0 +1,129 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zuraffa/zuraffa.dart';
+
+void main() {
+  group('ErrorMappingConfig', () {
+    test('parses from .zfa.json format', () {
+      final config = ErrorMappingConfig.fromJson({
+        'graphql': {
+          'errorMapping': {
+            'global': {
+              'InsufficientStockError': 'business',
+              'NoActiveOrderError': 'session',
+              '*Error': 'unknown',
+            },
+            'perOperation': {
+              'addItemToOrder': {'NegativeQuantityError': 'validation'},
+            },
+          },
+        },
+      });
+
+      expect(config.globalMappings['InsufficientStockError'], 'business');
+      expect(config.globalMappings['NoActiveOrderError'], 'session');
+      expect(config.globalMappings['*Error'], 'unknown');
+      expect(
+        config.perOperationMappings['addItemToOrder']?['NegativeQuantityError'],
+        'validation',
+      );
+    });
+
+    test('parses empty config', () {
+      final config = ErrorMappingConfig.fromJson({});
+      expect(config.globalMappings, isEmpty);
+      expect(config.perOperationMappings, isEmpty);
+    });
+
+    test('global mapping lookup', () {
+      final config = ErrorMappingConfig(
+        globalMappings: {'InsufficientStockError': 'business'},
+      );
+
+      expect(config.getCategory('InsufficientStockError'), 'business');
+      expect(config.getCategory('UnknownError'), 'unknown');
+    });
+
+    test('per-operation override takes precedence', () {
+      final config = ErrorMappingConfig(
+        globalMappings: {'InsufficientStockError': 'business'},
+        perOperationMappings: {
+          'addItemToOrder': {'InsufficientStockError': 'validation'},
+        },
+      );
+
+      expect(
+        config.getCategory(
+          'InsufficientStockError',
+          operationName: 'addItemToOrder',
+        ),
+        'validation',
+      );
+      expect(config.getCategory('InsufficientStockError'), 'business');
+    });
+
+    test('wildcard *Error pattern', () {
+      final config = ErrorMappingConfig(globalMappings: {'*Error': 'unknown'});
+
+      expect(config.getCategory('SomeRandomError'), 'unknown');
+      expect(config.getCategory('NotAnError'), 'unknown');
+    });
+
+    test('unmapped non-error types default to success', () {
+      final config = ErrorMappingConfig();
+
+      expect(config.getCategory('Order'), 'success');
+      expect(config.isError('Order'), false);
+      // *Error-suffixed names are errors even without an explicit mapping.
+      expect(config.getCategory('InsufficientStockError'), 'unknown');
+      expect(config.isError('InsufficientStockError'), true);
+    });
+
+    test('isError returns true for mapped error types', () {
+      final config = ErrorMappingConfig(
+        globalMappings: {'InsufficientStockError': 'business'},
+      );
+
+      expect(config.isError('InsufficientStockError'), true);
+      expect(config.isError('Order'), false); // Not mapped = not error
+    });
+
+    test('toFailure creates correct AppFailure types', () {
+      final config = ErrorMappingConfig(
+        globalMappings: {
+          'InsufficientStockError': 'business',
+          'NoActiveOrderError': 'session',
+          'NegativeQuantityError': 'validation',
+        },
+      );
+
+      final businessFailure = config.toFailure('InsufficientStockError');
+      expect(businessFailure, isA<ValidationFailure>());
+      expect(businessFailure.code, 'InsufficientStockError');
+
+      final sessionFailure = config.toFailure('NoActiveOrderError');
+      expect(sessionFailure, isA<UnauthorizedFailure>());
+      expect(sessionFailure.code, 'NoActiveOrderError');
+
+      final validationFailure = config.toFailure('NegativeQuantityError');
+      expect(validationFailure, isA<ValidationFailure>());
+
+      final unknownFailure = config.toFailure('UnknownError');
+      expect(unknownFailure, isA<UnknownFailure>());
+      expect(unknownFailure.code, 'UnknownError');
+    });
+
+    test('toFailure includes message when provided', () {
+      final config = ErrorMappingConfig(globalMappings: {'XError': 'business'});
+      final failure = config.toFailure('XError', message: 'Custom message');
+      expect(failure.message, 'Custom message');
+    });
+
+    test('toFailure maps network category', () {
+      final config = ErrorMappingConfig(
+        globalMappings: {'TimeoutError': 'network'},
+      );
+      final failure = config.toFailure('TimeoutError');
+      expect(failure, isA<NetworkFailure>());
+    });
+  });
+}

--- a/test/graphql/codegen/track_3_4_golden_test.dart
+++ b/test/graphql/codegen/track_3_4_golden_test.dart
@@ -1,0 +1,231 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zuraffa/zuraffa.dart';
+
+void main() {
+  group('Golden: Track 3.4 — Union-to-Sealed Mapping & Error Handling', () {
+    test('golden: sealed hierarchy dispatches on __typename', () {
+      final schema = GraphQLSchema(
+        types: {
+          'Order': GraphQLObjectType(
+            name: 'Order',
+            fields: [
+              GraphQLField(
+                name: 'id',
+                type: GraphQLNonNullType(ofType: GraphQLScalarType(name: 'ID')),
+              ),
+              GraphQLField(
+                name: 'total',
+                type: GraphQLNonNullType(
+                  ofType: GraphQLScalarType(name: 'Int'),
+                ),
+              ),
+            ],
+          ),
+          'OrderModificationError': GraphQLObjectType(
+            name: 'OrderModificationError',
+            fields: [
+              GraphQLField(
+                name: 'message',
+                type: GraphQLNonNullType(
+                  ofType: GraphQLScalarType(name: 'String'),
+                ),
+              ),
+              GraphQLField(
+                name: 'errorCode',
+                type: GraphQLNonNullType(
+                  ofType: GraphQLScalarType(name: 'String'),
+                ),
+              ),
+            ],
+          ),
+          'InsufficientStockError': GraphQLObjectType(
+            name: 'InsufficientStockError',
+            fields: [
+              GraphQLField(
+                name: 'message',
+                type: GraphQLNonNullType(
+                  ofType: GraphQLScalarType(name: 'String'),
+                ),
+              ),
+              GraphQLField(
+                name: 'quantityAvailable',
+                type: GraphQLNonNullType(
+                  ofType: GraphQLScalarType(name: 'Int'),
+                ),
+              ),
+            ],
+          ),
+        },
+      );
+
+      final union = GraphQLUnionType(
+        name: 'AddItemToOrderResult',
+        possibleTypes: [
+          'Order',
+          'OrderModificationError',
+          'InsufficientStockError',
+        ],
+      );
+
+      final gen = UnionGenerator(typeMapper: TypeMapper(), schema: schema);
+      final code = gen.generate(union);
+
+      // Sealed base class
+      expect(code.contains('sealed class \$\$AddItemToOrderResult'), true);
+
+      // Entity-reuse: variants are imported, not duplicated inline.
+      expect(code.contains("import '../entities/order.dart';"), true);
+      expect(
+        code.contains("import '../entities/order_modification_error.dart';"),
+        true,
+      );
+      expect(
+        code.contains("import '../entities/insufficient_stock_error.dart';"),
+        true,
+      );
+
+      // fromJson with __typename switch
+      expect(
+        code.contains("final typename = json['__typename'] as String?;"),
+        true,
+      );
+      expect(code.contains("Missing __typename in union JSON"), true);
+      expect(code.contains("case 'Order':"), true);
+      expect(code.contains("case 'OrderModificationError':"), true);
+      expect(code.contains("case 'InsufficientStockError':"), true);
+      expect(code.contains("case 'InsufficientStockError':"), true);
+    });
+
+    test('golden: datasource with union mutation maps errors to AppFailure', () {
+      final gen = DatasourceGenerator(
+        typeMapper: TypeMapper(),
+        errorConfig: ErrorMappingConfig(
+          globalMappings: {
+            'InsufficientStockError': 'business',
+            'OrderModificationError': 'business',
+            '*Error': 'unknown',
+          },
+        ),
+      );
+
+      final code = gen.generate(
+        name: 'Order',
+        queries: [],
+        mutations: [
+          MutationConfig(
+            fieldName: 'addItemToOrder',
+            returnType: GraphQLNonNullType(
+              ofType: GraphQLUnionType(
+                name: 'AddItemToOrderResult',
+                possibleTypes: [
+                  'Order',
+                  'OrderModificationError',
+                  'InsufficientStockError',
+                ],
+              ),
+            ),
+            args: [
+              GraphQLInputField(
+                name: 'productVariantId',
+                type: GraphQLNonNullType(ofType: GraphQLScalarType(name: 'ID')),
+              ),
+              GraphQLInputField(
+                name: 'quantity',
+                type: GraphQLNonNullType(
+                  ofType: GraphQLScalarType(name: 'Int'),
+                ),
+              ),
+            ],
+            document:
+                '''mutation AddItemToOrder(\$productVariantId: ID!, \$quantity: Int!) {
+  addItemToOrder(productVariantId: \$productVariantId, quantity: \$quantity) {
+    ... on Order { id total }
+    ... on OrderModificationError { message errorCode }
+    ... on InsufficientStockError { message quantityAvailable }
+  }
+}''',
+          ),
+        ],
+      );
+
+      // Datasource class
+      expect(code.contains('class \$OrderDatasource'), true);
+
+      // Union handling in mutation method
+      expect(code.contains('addItemToOrder'), true);
+      expect(code.contains("data['__typename']"), true);
+      expect(code.contains("operationName: 'addItemToOrder'"), true);
+      expect(code.contains('_errorConfig.isError'), true);
+      expect(code.contains('\$\$AddItemToOrderResult.fromJson(data)'), true);
+      expect(
+        code.contains('SignalResult<\$\$AddItemToOrderResult>.failure'),
+        true,
+      );
+      expect(
+        code.contains('SignalResult<\$\$AddItemToOrderResult>.success'),
+        true,
+      );
+
+      // Error mapping helper + baked config
+      expect(code.contains('_mapError'), true);
+      expect(code.contains('_errorConfig'), true);
+      expect(code.contains('ErrorMappingConfig'), true);
+      expect(code.contains("'InsufficientStockError': 'business'"), true);
+      expect(code.contains("'*Error': 'unknown'"), true);
+
+      // Success path unwraps to the sealed union
+      expect(
+        code.contains(
+          'return SignalResult<\$\$AddItemToOrderResult>.success(entity)',
+        ),
+        true,
+      );
+    });
+
+    test('golden: datasource without errorConfig unwraps unions directly', () {
+      final gen = DatasourceGenerator(typeMapper: TypeMapper());
+
+      final code = gen.generate(
+        name: 'Order',
+        queries: [],
+        mutations: [
+          MutationConfig(
+            fieldName: 'addItemToOrder',
+            returnType: GraphQLNonNullType(
+              ofType: GraphQLUnionType(
+                name: 'AddItemToOrderResult',
+                possibleTypes: ['Order', 'OrderModificationError'],
+              ),
+            ),
+            args: [],
+            document: '',
+          ),
+        ],
+      );
+
+      // No error mapping machinery
+      expect(code.contains('_errorConfig'), false);
+      expect(code.contains('_mapError'), false);
+      expect(code.contains('\$\$AddItemToOrderResult.fromJson(data)'), true);
+      expect(
+        code.contains('SignalResult<\$\$AddItemToOrderResult>.success(entity)'),
+        true,
+      );
+    });
+
+    test('golden: wildcard *Error maps unmapped error variants', () {
+      final config = ErrorMappingConfig(
+        globalMappings: {
+          'InsufficientStockError': 'business',
+          '*Error': 'unknown',
+        },
+      );
+
+      // OrderModificationError is not explicitly mapped, falls through to *Error
+      expect(config.getCategory('OrderModificationError'), 'unknown');
+      expect(config.getCategory('InsufficientStockError'), 'business');
+      expect(config.getCategory('SomeRandomError'), 'unknown');
+      expect(config.isError('Order'), false); // Success variant
+    });
+  });
+}

--- a/test/graphql/codegen/union_generator_test.dart
+++ b/test/graphql/codegen/union_generator_test.dart
@@ -50,5 +50,22 @@ void main() {
       expect(code.contains("case 'OrderModificationError':"), true);
       expect(code.contains('__typename'), true);
     });
+
+    test('fromJson validates __typename presence', () {
+      final schema = GraphQLSchema(
+        types: {'Order': GraphQLObjectType(name: 'Order', fields: [])},
+      );
+
+      final union = GraphQLUnionType(
+        name: 'TestResult',
+        possibleTypes: ['Order'],
+      );
+
+      final gen = UnionGenerator(typeMapper: TypeMapper(), schema: schema);
+      final code = gen.generate(union);
+
+      expect(code.contains('Missing __typename in union JSON'), true);
+      expect(code.contains('json[\'__typename\'] as String?'), true);
+    });
   });
 }

--- a/test/graphql/codegen/union_result_handler_test.dart
+++ b/test/graphql/codegen/union_result_handler_test.dart
@@ -1,0 +1,69 @@
+import 'package:code_builder/code_builder.dart' as cb;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zuraffa/zuraffa.dart';
+
+void main() {
+  group('UnionResultHandler', () {
+    final config = ErrorMappingConfig(
+      globalMappings: {
+        'OrderModificationError': 'business',
+        'InsufficientStockError': 'business',
+        '*Error': 'unknown',
+      },
+    );
+
+    final emitter = cb.DartEmitter();
+
+    test('buildErrorConfigField bakes the mapping table', () {
+      final handler = UnionResultHandler(errorConfig: config);
+      final code = handler.buildErrorConfigField().accept(emitter).toString();
+
+      expect(code.contains('_errorConfig'), true);
+      expect(code.contains('ErrorMappingConfig'), true);
+      expect(code.contains("'InsufficientStockError': 'business'"), true);
+      expect(code.contains("'*Error': 'unknown'"), true);
+      expect(code.contains("'OrderModificationError': 'business'"), true);
+    });
+
+    test('buildMapErrorMethod reads message and maps via toFailure', () {
+      final handler = UnionResultHandler(errorConfig: config);
+      final code = handler.buildMapErrorMethod().accept(emitter).toString();
+
+      expect(code.contains('_mapError'), true);
+      expect(code.contains('_errorConfig.toFailure'), true);
+      expect(code.contains("json['message']"), true);
+    });
+
+    test('buildHandler generates __typename dispatch with operation name', () {
+      final handler = UnionResultHandler(
+        errorConfig: config,
+        operationName: 'addItemToOrder',
+      );
+
+      final code = handler
+          .buildHandler(
+            unionType: cb.refer('\$\$AddItemToOrderResult'),
+            fieldName: 'addItemToOrder',
+            returnType: '\$\$AddItemToOrderResult',
+          )
+          .accept(emitter)
+          .toString();
+
+      expect(code.contains('result.data?[\'addItemToOrder\']'), true);
+      expect(code.contains("data['__typename']"), true);
+      expect(code.contains("operationName: 'addItemToOrder'"), true);
+      expect(code.contains('_errorConfig.isError'), true);
+      expect(code.contains('_mapError(typename, data)'), true);
+      expect(code.contains('\$\$AddItemToOrderResult.fromJson(data)'), true);
+      expect(
+        code.contains('SignalResult<\$\$AddItemToOrderResult>.failure'),
+        true,
+      );
+      expect(
+        code.contains('SignalResult<\$\$AddItemToOrderResult>.success'),
+        true,
+      );
+      expect(code.contains("const ServerFailure('No data returned')"), true);
+    });
+  });
+}

--- a/test/graphql/codegen/union_result_handler_test.dart
+++ b/test/graphql/codegen/union_result_handler_test.dart
@@ -53,7 +53,10 @@ void main() {
       expect(code.contains("data['__typename']"), true);
       expect(code.contains("operationName: 'addItemToOrder'"), true);
       expect(code.contains('_errorConfig.isError'), true);
-      expect(code.contains('_mapError(typename, data)'), true);
+      expect(
+        code.contains("_mapError(typename, data, 'addItemToOrder')"),
+        true,
+      );
       expect(code.contains('\$\$AddItemToOrderResult.fromJson(data)'), true);
       expect(
         code.contains('SignalResult<\$\$AddItemToOrderResult>.failure'),
@@ -64,6 +67,12 @@ void main() {
         true,
       );
       expect(code.contains("const ServerFailure('No data returned')"), true);
+      expect(
+        code.contains(
+          "const ServerFailure('Missing __typename in union result')",
+        ),
+        true,
+      );
     });
   });
 }


### PR DESCRIPTION
## Summary

Track 3.4 — Union-to-Sealed Class Mapping & Error Handling. Adapted from the external agent's patch (`packages/graphql_codegen` layout) into the single-package layout, per the repo convention established in Tracks 3.1–3.3.

### What's new

**`ErrorMappingConfig`** (`lib/src/graphql/codegen/error_mapping_config.dart`)
- Parses `.zfa.json` `graphql.errorMapping` with global + per-operation mappings
- Wildcard `*Error` pattern; per-operation overrides take precedence
- `toFailure()` maps categories to Zuraffa's `AppFailure` taxonomy, preserving the GraphQL error type name as the failure's `code`
- Fixed semantics: unmapped non-`*Error` variants are **success**; `*Error`-suffixed variants default to `unknown`

**`UnionResultHandler`** (`lib/src/graphql/codegen/union_result_handler.dart`)
- Generates the union-result dispatch block emitted into datasources: runtime `__typename` check → error variants map to `AppFailure` via `_mapError()`, success variants unwrap to the sealed `$$Union` object
- Also generates the `_errorConfig` field (config baked in) and `_mapError` helper

**`DatasourceGenerator`** (`lib/src/graphql/codegen/datasource_generator.dart`)
- Union-returning queries/mutations now dispatch on `__typename` when an `errorConfig` is provided; without one they unwrap the sealed union directly
- Adds `_errorConfig` field + `_mapError` helper for union-enabled datasources

**`UnionGenerator`** — `fromJson` now validates `__typename` presence with a clear `ArgumentError` instead of a bare cast failure.

**`AppFailure`** — added an optional machine-readable `code` field (additive, backward-compatible), threaded through all failure subclasses. `PlatformFailure` now reuses the base field instead of declaring its own.

**`zorphyType`** — maps union inner types to their sealed `$$Union` classes so union datasource return types are consistent.

### Fixes (drive-by)
- Generated datasource code used non-existent named args (`NetworkFailure(message: …)`, `ServerFailure(message: …)`) — the real ctors are positional. Corrected so generated code actually compiles.

### Tests
- `test/graphql/codegen/error_mapping_config_test.dart`
- `test/graphql/codegen/union_result_handler_test.dart`
- `test/graphql/codegen/track_3_4_golden_test.dart` (Vendure `AddItemToOrderResult` sealed hierarchy + datasource union dispatch)
- Extended `union_generator_test.dart` with the `__typename` guard assertion

### Adaptations from the patch (noted per the PR-from-patch workflow)
- **Union generator design**: the repo's `UnionGenerator` (entity-reuse, per Track 3.3) imports variant entities rather than generating inline `$Variant` subclasses, so the patch's per-variant `isError` getter on the sealed base isn't applicable. Error handling is instead performed at the datasource layer via runtime `__typename` checks against `ErrorMappingConfig` — behaviorally equivalent.
- **Failures**: the sandbox's `zuraffa_core` failures had a `code` param; this repo's didn't. Added the optional `code` field to `AppFailure` (additive) rather than dropping the error-type discrimination.
- Patch's golden tests asserted `literalBool(true)` strings that its own generator could never produce; rewrote assertions against actual emitted output.

### Validation
- `dart analyze lib test` — clean (3 pre-existing infos in unrelated files)
- `flutter test` — **all 894 tests pass**

Closes #176

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added machine-readable error codes across application failure types.
  * Added configurable GraphQL error mapping with support for global, operation-specific, wildcard, and default rules.
  * Added GraphQL union result handling for automatic success and failure conversion.
  * Improved generated GraphQL code to validate and dispatch union types safely.
  * Exported the new GraphQL error-handling capabilities publicly.

* **Tests**
  * Added comprehensive coverage for error mapping, union handling, failure conversion, and missing type information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->