### PR TITLE
feat(xray): add MCP bridge for AI agent tree inspection

### DIFF
--- a/lib/src/commands/xray_bridge_command.dart
+++ b/lib/src/commands/xray_bridge_command.dart
@@ -1,0 +1,132 @@
+// X-Ray Bridge CLI command.
+//
+// Usage:
+//   zfa xray bridge              Start the X-Ray bridge (default port 8471)
+//   zfa xray bridge --port=9000  Custom port
+//   zfa xray bridge --token=secret   Require Bearer token for auth
+//   zfa xray bridge --remote     Bind to 0.0.0.0 instead of localhost
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:args/command_runner.dart';
+
+import '../presentation/xray/xray_bridge_server.dart';
+import '../presentation/xray/xray_mode.dart';
+
+/// CLI subcommand for the X-Ray bridge server.
+class XrayBridgeCommand extends Command<void> {
+  @override
+  String get name => 'bridge';
+
+  @override
+  String get description =>
+      'Start the X-Ray bridge server for AI agent inspection';
+
+  XrayBridgeCommand() {
+    argParser.addOption(
+      'port',
+      abbr: 'p',
+      help: 'Port to bind the bridge server (default: 8471)',
+      defaultsTo: '8471',
+    );
+    argParser.addOption(
+      'token',
+      abbr: 't',
+      help: 'Bearer token for remote agent authentication',
+    );
+    argParser.addFlag(
+      'remote',
+      abbr: 'r',
+      help: 'Bind to 0.0.0.0 instead of localhost (requires --token)',
+      negatable: false,
+    );
+  }
+
+  @override
+  Future<void> run() async {
+    final portStr = argResults!['port'] as String;
+    final port = int.tryParse(portStr) ?? XRayBridgeServer.defaultPort;
+    final token = argResults!['token'] as String?;
+    final remote = argResults!['remote'] as bool;
+    final localhostOnly = !remote;
+
+    if (remote && token == null) {
+      print('Error: --remote requires --token for authentication.');
+      print('Use --token=<secret> to set a Bearer token.');
+      return;
+    }
+
+    // Check if X-Ray mode is enabled
+    final configFile = File(XRayMode.configPath);
+    bool xrayEnabled = false;
+    if (configFile.existsSync()) {
+      try {
+        final content = configFile.readAsStringSync();
+        final config = jsonDecode(content) as Map<String, dynamic>;
+        xrayEnabled = config['enabled'] == true;
+      } catch (_) {
+        // Ignore malformed config
+      }
+    }
+
+    if (!xrayEnabled) {
+      print('X-Ray mode is not enabled. The bridge will still start,');
+      print('but /xray/tree will return 503 until X-Ray is activated.');
+      print('Run: zfa xray enable');
+      print('');
+    }
+
+    final server = XRayBridgeServer(
+      port: port,
+      authToken: token,
+      localhostOnly: localhostOnly,
+    );
+
+    // Handle SIGINT / SIGTERM for graceful shutdown
+    final completer = Completer<void>();
+    ProcessSignal.sigint.watch().listen((_) {
+      print('');
+      print('Shutting down X-Ray bridge...');
+      server.stop().then((_) {
+        completer.complete();
+        exit(0);
+      });
+    });
+
+    ProcessSignal.sigterm.watch().listen((_) {
+      server.stop().then((_) {
+        completer.complete();
+        exit(0);
+      });
+    });
+
+    final actualPort = await server.start();
+    if (actualPort < 0) {
+      print('X-Ray bridge cannot start in release mode.');
+      return;
+    }
+
+    final bindAddr = localhostOnly ? '127.0.0.1' : '0.0.0.0';
+    print('');
+    print('  X-Ray Bridge running');
+    print('  ─────────────────────────────');
+    print('  Endpoints:');
+    print('    GET  http://$bindAddr:$actualPort/xray/tree');
+    print('    POST http://$bindAddr:$actualPort/xray/action');
+    print('    POST http://$bindAddr:$actualPort/xray/control-deck');
+    print('    WS   ws://$bindAddr:$actualPort/xray/ws');
+    if (token != null) {
+      print('  Auth: Bearer token required');
+    } else {
+      print('  Auth: localhost-only (no token)');
+    }
+    print('');
+    print('  Press Ctrl+C to stop.');
+    print('');
+
+    // Keep alive
+    await completer.future;
+  }
+}

--- a/lib/src/commands/xray_bridge_command.dart
+++ b/lib/src/commands/xray_bridge_command.dart
@@ -28,8 +28,9 @@ class XrayBridgeCommand extends Command<void> {
     argParser.addOption(
       'port',
       abbr: 'p',
-      help: 'Port to bind the bridge server (default: 8471)',
-      defaultsTo: '8471',
+      help:
+          'Port to bind the bridge server (default: ${XRayBridgeServer.defaultPort})',
+      defaultsTo: '${XRayBridgeServer.defaultPort}',
     );
     argParser.addOption(
       'token',
@@ -47,15 +48,31 @@ class XrayBridgeCommand extends Command<void> {
   @override
   Future<void> run() async {
     final portStr = argResults!['port'] as String;
-    final port = int.tryParse(portStr) ?? XRayBridgeServer.defaultPort;
+    final port = int.tryParse(portStr);
+
+    if (port == null) {
+      throw UsageException(
+        'Invalid port: "$portStr" is not a valid integer.',
+        usage,
+      );
+    }
+
+    if (port < 1 || port > 65535) {
+      throw UsageException(
+        'Port must be between 1 and 65535, got: $port',
+        usage,
+      );
+    }
+
     final token = argResults!['token'] as String?;
     final remote = argResults!['remote'] as bool;
     final localhostOnly = !remote;
 
     if (remote && token == null) {
-      print('Error: --remote requires --token for authentication.');
-      print('Use --token=<secret> to set a Bearer token.');
-      return;
+      throw UsageException(
+        '--remote requires --token for authentication.',
+        usage,
+      );
     }
 
     // Check if X-Ray mode is enabled
@@ -90,19 +107,33 @@ class XrayBridgeCommand extends Command<void> {
       print('');
       print('Shutting down X-Ray bridge...');
       server.stop().then((_) {
-        completer.complete();
+        if (!completer.isCompleted) {
+          completer.complete();
+        }
         exit(0);
       });
     });
 
-    ProcessSignal.sigterm.watch().listen((_) {
-      server.stop().then((_) {
-        completer.complete();
-        exit(0);
+    if (!Platform.isWindows) {
+      ProcessSignal.sigterm.watch().listen((_) {
+        server.stop().then((_) {
+          if (!completer.isCompleted) {
+            completer.complete();
+          }
+          exit(0);
+        });
       });
-    });
+    }
 
-    final actualPort = await server.start();
+    int actualPort;
+    try {
+      actualPort = await server.start();
+    } on SocketException catch (e) {
+      print('Failed to start X-Ray bridge: ${e.message}');
+      print('Port $port may already be in use or unavailable.');
+      return;
+    }
+
     if (actualPort < 0) {
       print('X-Ray bridge cannot start in release mode.');
       return;

--- a/lib/src/commands/xray_command.dart
+++ b/lib/src/commands/xray_command.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:args/command_runner.dart';
 
 import '../presentation/xray/xray_mode.dart';
+import 'xray_bridge_command.dart';
 import 'xray_deck_command.dart';
 
 /// CLI command for X-Ray mode management.
@@ -12,6 +13,7 @@ import 'xray_deck_command.dart';
 /// ```
 /// zfa xray enable   # activate X-Ray overlay on next app launch
 /// zfa xray disable  # deactivate X-Ray overlay
+/// zfa xray bridge   # start the AI agent bridge server
 /// zfa xray deck     # generate Control Deck registration
 /// ```
 class XrayCommand extends Command<void> {
@@ -19,22 +21,24 @@ class XrayCommand extends Command<void> {
   String get name => 'xray';
 
   @override
-  String get description => 'X-Ray debug tools (overlay, control deck)';
+  String get description => 'X-Ray debug tools (overlay, control deck, bridge)';
 
   XrayCommand() {
     addSubcommand(_XrayEnableCommand());
     addSubcommand(_XrayDisableCommand());
     addSubcommand(_XrayStatusCommand());
     addSubcommand(XrayDeckCommand());
+    addSubcommand(XrayBridgeCommand());
   }
 
   @override
   Future<void> run() async {
-    print('Usage: zfa xray <enable|disable|status|deck>');
+    print('Usage: zfa xray <enable|disable|status|deck|bridge>');
     print('  enable   Activate X-Ray overlay (debug/profile mode)');
     print('  disable  Deactivate X-Ray overlay');
     print('  status   Show current X-Ray configuration status');
     print('  deck     Generate Control Deck from annotations/YAML');
+    print('  bridge   Start the AI agent bridge server');
     print('');
     print('Activation methods:');
     print('  · Two-finger long press in the running app');

--- a/lib/src/presentation/xray/xray.dart
+++ b/lib/src/presentation/xray/xray.dart
@@ -19,3 +19,5 @@ export 'xray_mock_annotation.dart';
 export 'xray_mock_entry.dart';
 export 'xray_mock_parser.dart';
 export 'xray_control_deck.dart';
+export 'xray_bridge.dart';
+export 'xray_bridge_server.dart';

--- a/lib/src/presentation/xray/xray.dart
+++ b/lib/src/presentation/xray/xray.dart
@@ -4,6 +4,10 @@
 /// in generated views. Foundation for visual X-Ray overlay (Track 4.2),
 /// Control Deck synthetic payload injection (Track 4.3), and
 /// AI agent bridge (Track 4.4).
+///
+/// NOTE: [xray_bridge_server.dart] is not exported from this barrel because
+/// it depends on dart:io and is not compatible with Flutter web. Import it
+/// directly when needed: `import 'package:zuraffa/src/presentation/xray/xray_bridge_server.dart';`
 library;
 
 export 'xray_mode.dart';
@@ -20,4 +24,6 @@ export 'xray_mock_entry.dart';
 export 'xray_mock_parser.dart';
 export 'xray_control_deck.dart';
 export 'xray_bridge.dart';
-export 'xray_bridge_server.dart';
+// NOTE: xray_bridge_server.dart is NOT exported (dart:io dependency, web-incompatible)
+// Import directly if needed on native platforms:
+// import 'package:zuraffa/src/presentation/xray/xray_bridge_server.dart';

--- a/lib/src/presentation/xray/xray_bridge.dart
+++ b/lib/src/presentation/xray/xray_bridge.dart
@@ -1,0 +1,254 @@
+// X-Ray Bridge — connects external AI agents to the live X-Ray tree.
+//
+// Provides JSON tree serialization, bound-action invocation, and
+// Control Deck mock injection for MCP / HTTP bridge endpoints.
+//
+// Security: every public method is a no-op in release mode.
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+import 'xray_node_metadata.dart';
+import 'xray_scope.dart';
+
+// ------------------------------------------------------------------
+// Types
+// ------------------------------------------------------------------
+
+/// A serializable snapshot of a single X-Ray node.
+class XRayTreeNodeJson {
+  /// Deterministic node ID, e.g. "ProductView.actionButton".
+  final String id;
+
+  /// The enum value name (e.g. "actionButton").
+  final String enumName;
+
+  /// Bound action name from [XRayMetadataRegistry], if any.
+  final String? actionName;
+
+  /// Whether the node's action is enabled.
+  final bool isEnabled;
+
+  /// Snapshot of associated state (e.g. loading, data, error).
+  final Map<String, dynamic>? state;
+
+  const XRayTreeNodeJson({
+    required this.id,
+    required this.enumName,
+    this.actionName,
+    this.isEnabled = true,
+    this.state,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'type': enumName,
+        if (actionName != null) 'boundAction': actionName,
+        'enabled': isEnabled,
+        if (state != null) 'state': state,
+      };
+}
+
+/// Full JSON response for `GET /xray/tree`.
+class XRayTreeJson {
+  /// The active view's scope ID.
+  final String activeView;
+
+  /// All registered nodes in registration order.
+  final List<XRayTreeNodeJson> nodes;
+
+  const XRayTreeJson({
+    required this.activeView,
+    required this.nodes,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'activeView': activeView,
+        'nodes': nodes.map((n) => n.toJson()).toList(),
+      };
+}
+
+// ------------------------------------------------------------------
+// Action registry
+// ------------------------------------------------------------------
+
+/// Callback signature for a bound action.
+typedef XRayBoundAction = void Function(Map<String, dynamic> payload);
+
+/// Global registry that maps node IDs to their bound-action callbacks.
+///
+/// Controllers call [register] during initialization so the bridge
+/// can invoke actions by node ID.
+class XRayActionRegistry {
+  XRayActionRegistry._();
+
+  static final Map<String, XRayBoundAction> _actions = {};
+
+  /// Register a bound action for the node identified by [nodeId].
+  static void register(String nodeId, XRayBoundAction action) {
+    assert(
+      !kReleaseMode,
+      'XRayActionRegistry is only available in debug/profile mode',
+    );
+    if (kReleaseMode) return;
+    _actions[nodeId] = action;
+  }
+
+  /// Unregister a bound action.
+  static void unregister(String nodeId) {
+    if (kReleaseMode) return;
+    _actions.remove(nodeId);
+  }
+
+  /// Invoke the action for [nodeId] with an optional [payload].
+  ///
+  /// Returns `true` if the action was found and invoked, `false` otherwise.
+  static bool invoke(String nodeId, [Map<String, dynamic>? payload]) {
+    if (kReleaseMode) return false;
+    final action = _actions[nodeId];
+    if (action == null) return false;
+    action(payload ?? const {});
+    return true;
+  }
+
+  /// List all registered node IDs (useful for 404 error messages).
+  static List<String> get registeredIds {
+    if (kReleaseMode) return const [];
+    return List.unmodifiable(_actions.keys);
+  }
+
+  /// Clear all registered actions (for testing).
+  @visibleForTesting
+  static void clear() {
+    _actions.clear();
+  }
+}
+
+// ------------------------------------------------------------------
+// Mock injector registry (Control Deck bridge target)
+// ------------------------------------------------------------------
+
+/// Callback invoked when an external agent triggers a mock by name.
+typedef XRayMockInjectorCallback = void Function(dynamic payload);
+
+/// Global registry that maps mock names to their injector callbacks.
+class XRayMockInjectorRegistry {
+  XRayMockInjectorRegistry._();
+
+  static final Map<String, XRayMockInjectorCallback> _injectors = {};
+
+  /// Register an injector for a given mock name.
+  static void register(String mockName, XRayMockInjectorCallback injector) {
+    if (kReleaseMode) return;
+    _injectors[mockName] = injector;
+  }
+
+  /// Unregister an injector.
+  static void unregister(String mockName) {
+    if (kReleaseMode) return;
+    _injectors.remove(mockName);
+  }
+
+  /// Invoke the injector for [mockName] with [payload].
+  ///
+  /// Returns `true` if the mock was found and triggered.
+  static bool trigger(String mockName, [dynamic payload]) {
+    if (kReleaseMode) return false;
+    final injector = _injectors[mockName];
+    if (injector == null) return false;
+    injector(payload);
+    return true;
+  }
+
+  /// List all registered mock names.
+  static List<String> get registeredNames {
+    if (kReleaseMode) return const [];
+    return List.unmodifiable(_injectors.keys);
+  }
+
+  /// Clear all registered injectors (for testing).
+  @visibleForTesting
+  static void clear() {
+    _injectors.clear();
+  }
+}
+
+// ------------------------------------------------------------------
+// Bridge controller — orchestrates tree snapshot + diff stream
+// ------------------------------------------------------------------
+
+/// Events emitted by the X-Ray bridge when the tree changes.
+enum XRayBridgeEventType { added, removed, updated }
+
+/// A single tree diff event pushed over WebSocket.
+class XRayTreeDiff {
+  final XRayBridgeEventType type;
+  final String nodeId;
+  final XRayTreeNodeJson? node;
+
+  const XRayTreeDiff({
+    required this.type,
+    required this.nodeId,
+    this.node,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'type': type.name,
+        'nodeId': nodeId,
+        if (node != null) 'node': node!.toJson(),
+      };
+}
+
+/// Stream controller that broadcasts tree change events.
+///
+/// The [XRayScope] integration calls [notifyTreeChanged] when
+/// nodes are registered or unregistered, and the bridge server
+/// pushes these diffs to connected WebSocket clients.
+class XRayBridgeStream {
+  XRayBridgeStream._();
+
+  static final StreamController<XRayTreeDiff> _controller =
+      StreamController<XRayTreeDiff>.broadcast();
+
+  /// Subscribe to tree change events.
+  static Stream<XRayTreeDiff> get stream => _controller.stream;
+
+  /// Whether any listeners are subscribed.
+  static bool get hasListeners => _controller.hasListener;
+
+  /// Emit a diff event. Called by [XRayScopeState] when nodes change.
+  static void emit(XRayTreeDiff diff) {
+    if (kReleaseMode) return;
+    if (_controller.hasListener) {
+      _controller.add(diff);
+    }
+  }
+
+  /// Close the stream (for testing).
+  @visibleForTesting
+  static Future<void> close() => _controller.close();
+}
+
+// ------------------------------------------------------------------
+// Tree serialization
+// ------------------------------------------------------------------
+
+/// Serializes an [XRayScopeState] tree into a JSON-ready structure.
+///
+/// Enriches each node with metadata from [XRayMetadataRegistry]
+/// (action name, enabled state, state snapshot).
+XRayTreeJson serializeXRayTree(XRayScopeState scope) {
+  final nodes = scope.tree.map((info) {
+    final meta = XRayMetadataRegistry.forNode(info.id);
+    return XRayTreeNodeJson(
+      id: info.id,
+      enumName: info.enumName,
+      actionName: meta?.actionName,
+      isEnabled: meta?.isEnabled ?? true,
+      state: meta?.stateJson,
+    );
+  }).toList();
+
+  return XRayTreeJson(activeView: scope.viewId, nodes: nodes);
+}

--- a/lib/src/presentation/xray/xray_bridge.dart
+++ b/lib/src/presentation/xray/xray_bridge.dart
@@ -33,12 +33,16 @@ class XRayTreeNodeJson {
   /// Snapshot of associated state (e.g. loading, data, error).
   final Map<String, dynamic>? state;
 
+  /// Parent node ID determined from BuildContext hierarchy, if any.
+  final String? parentId;
+
   const XRayTreeNodeJson({
     required this.id,
     required this.enumName,
     this.actionName,
     this.isEnabled = true,
     this.state,
+    this.parentId,
   });
 
   Map<String, dynamic> toJson() => {
@@ -47,6 +51,7 @@ class XRayTreeNodeJson {
         if (actionName != null) 'boundAction': actionName,
         'enabled': isEnabled,
         if (state != null) 'state': state,
+        if (parentId != null) 'parentId': parentId,
       };
 }
 
@@ -208,7 +213,7 @@ class XRayTreeDiff {
 class XRayBridgeStream {
   XRayBridgeStream._();
 
-  static final StreamController<XRayTreeDiff> _controller =
+  static StreamController<XRayTreeDiff> _controller =
       StreamController<XRayTreeDiff>.broadcast();
 
   /// Subscribe to tree change events.
@@ -225,9 +230,15 @@ class XRayBridgeStream {
     }
   }
 
-  /// Close the stream (for testing).
+  /// Close the current stream and create a fresh controller (for testing).
+  ///
+  /// This allows multiple tests to subscribe without encountering
+  /// a closed controller from previous tests.
   @visibleForTesting
-  static Future<void> close() => _controller.close();
+  static Future<void> close() async {
+    await _controller.close();
+    _controller = StreamController<XRayTreeDiff>.broadcast();
+  }
 }
 
 // ------------------------------------------------------------------
@@ -237,9 +248,43 @@ class XRayBridgeStream {
 /// Serializes an [XRayScopeState] tree into a JSON-ready structure.
 ///
 /// Enriches each node with metadata from [XRayMetadataRegistry]
-/// (action name, enabled state, state snapshot).
+/// (action name, enabled state, state snapshot). Computes parent-child
+/// relationships based on BuildContext hierarchy: each node's parentId
+/// contains the ID of its closest XRayNode ancestor in the widget tree.
+///
+/// In release mode, returns an empty tree without serializing scope data.
 XRayTreeJson serializeXRayTree(XRayScopeState scope) {
-  final nodes = scope.tree.map((info) {
+  if (kReleaseMode) {
+    return const XRayTreeJson(activeView: '', nodes: []);
+  }
+
+  final allNodes = scope.tree;
+  final contextToId = <BuildContext, String>{
+    for (final node in allNodes) node.context: node.id,
+  };
+
+  // For each node, find its parent by walking up the BuildContext tree
+  final parentMap = <String, String?>{};
+
+  for (final node in allNodes) {
+    String? foundParentId;
+    try {
+      // Walk up the tree to find the first ancestor that is also an XRayNode
+      node.context.visitAncestorElements((element) {
+        // Check if this ancestor's context belongs to another XRayNode
+        if (contextToId.containsKey(element)) {
+          foundParentId = contextToId[element];
+          return false; // Stop visiting, we found the parent
+        }
+        return true; // Continue visiting further ancestors
+      });
+    } catch (_) {
+      // BuildContext may be invalid, skip
+    }
+    parentMap[node.id] = foundParentId;
+  }
+
+  final nodes = allNodes.map((info) {
     final meta = XRayMetadataRegistry.forNode(info.id);
     return XRayTreeNodeJson(
       id: info.id,
@@ -247,6 +292,7 @@ XRayTreeJson serializeXRayTree(XRayScopeState scope) {
       actionName: meta?.actionName,
       isEnabled: meta?.isEnabled ?? true,
       state: meta?.stateJson,
+      parentId: parentMap[info.id],
     );
   }).toList();
 

--- a/lib/src/presentation/xray/xray_bridge_server.dart
+++ b/lib/src/presentation/xray/xray_bridge_server.dart
@@ -1,0 +1,338 @@
+// X-Ray Bridge HTTP/WebSocket server.
+//
+// Exposes three REST endpoints and a WebSocket for real-time tree diffs.
+// Only starts in debug/profile mode. In release mode, every method is a no-op.
+//
+// Endpoints:
+//   GET  /xray/tree           → JSON tree snapshot
+//   POST /xray/action         → invoke a bound action by nodeId
+//   POST /xray/control-deck   → trigger a synthetic mock by name
+//   WS   /xray/ws             → real-time tree diff stream
+//
+// Auth:
+//   - Localhost binding in dev mode (default).
+//   - Configurable bearer token for remote agent access.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+
+import 'xray_bridge.dart';
+import 'xray_scope.dart';
+
+// ------------------------------------------------------------------
+// Scope holder — allows registering the active scope with the bridge.
+// ------------------------------------------------------------------
+
+/// Holds a reference to the currently active [XRayScopeState].
+///
+/// Set this in your app's widget tree (e.g. in a State's initState)
+/// so the bridge can serialize the tree.
+class XRayBridgeScopeHolder {
+  XRayBridgeScopeHolder._();
+
+  static XRayScopeState? _activeScope;
+
+  /// Register the active scope.
+  static void setScope(XRayScopeState scope) {
+    if (kReleaseMode) return;
+    _activeScope = scope;
+  }
+
+  /// Clear the active scope (e.g. on dispose).
+  static void clearScope() {
+    _activeScope = null;
+  }
+
+  /// Get the current active scope, if any.
+  static XRayScopeState? get activeScope {
+    if (kReleaseMode) return null;
+    return _activeScope;
+  }
+
+  /// Clear for testing.
+  @visibleForTesting
+  static void reset() {
+    _activeScope = null;
+  }
+}
+
+// ------------------------------------------------------------------
+// Bridge server
+// ------------------------------------------------------------------
+
+/// X-Ray Bridge HTTP + WebSocket server.
+///
+/// Call [start] to begin listening. The server binds to
+/// [InternetAddress.loopbackIPv4] by default (localhost-only).
+/// Set [authToken] to require a Bearer token for remote access.
+///
+/// In release mode, [start] is a no-op and [isRunning] is always false.
+class XRayBridgeServer {
+  /// Default port for the X-Ray bridge.
+  static const int defaultPort = 8471;
+
+  HttpServer? _server;
+  final String? _authToken;
+  final bool _localhostOnly;
+  int _port;
+
+  /// Whether the server is currently running.
+  bool get isRunning => _server != null;
+
+  /// The actual port the server is listening on.
+  int get port => _port;
+
+  XRayBridgeServer({
+    int port = defaultPort,
+    String? authToken,
+    bool localhostOnly = true,
+  })  : _port = port,
+        _authToken = authToken,
+        _localhostOnly = localhostOnly;
+
+  /// Start the bridge server.
+  ///
+  /// Returns the actual port the server bound to.
+  /// In release mode, returns -1 and does nothing.
+  Future<int> start() async {
+    if (kReleaseMode) return -1;
+    if (_server != null) return _port;
+
+    final address = _localhostOnly
+        ? InternetAddress.loopbackIPv4
+        : InternetAddress.anyIPv4;
+
+    _server = await HttpServer.bind(address, _port);
+    _port = _server!.port;
+    _server!.listen(_handleRequest);
+    return _port;
+  }
+
+  /// Stop the bridge server.
+  Future<void> stop() async {
+    final server = _server;
+    if (server == null) return;
+    await server.close(force: true);
+    _server = null;
+  }
+
+  // ----------------------------------------------------------------
+  // Request routing
+  // ----------------------------------------------------------------
+
+  void _handleRequest(HttpRequest request) {
+    // Auth check
+    if (_authToken != null) {
+      final authHeader = request.headers.value('authorization');
+      final expected = 'Bearer $_authToken';
+      if (authHeader != expected) {
+        _jsonResponse(request, 401, {
+          'error': 'Unauthorized',
+          'message': 'Missing or invalid Bearer token',
+        });
+        return;
+      }
+    }
+
+    // Release mode guard
+    if (kReleaseMode) {
+      _jsonResponse(request, 404, {
+        'error': 'Not available',
+        'message': 'X-Ray bridge is disabled in release mode',
+      });
+      return;
+    }
+
+    // WebSocket upgrade
+    if (request.headers.value('upgrade')?.toLowerCase() == 'websocket') {
+      _handleWebSocket(request);
+      return;
+    }
+
+    // REST routing
+    final path = request.uri.path;
+    final method = request.method;
+
+    if (method == 'GET' && path == '/xray/tree') {
+      _handleGetTree(request);
+    } else if (method == 'POST' && path == '/xray/action') {
+      _handlePostAction(request);
+    } else if (method == 'POST' && path == '/xray/control-deck') {
+      _handlePostControlDeck(request);
+    } else {
+      _jsonResponse(request, 404, {
+        'error': 'Not found',
+        'message':
+            'Available endpoints: /xray/tree, /xray/action, /xray/control-deck, /xray/ws',
+      });
+    }
+  }
+
+  // ----------------------------------------------------------------
+  // GET /xray/tree
+  // ----------------------------------------------------------------
+
+  Future<void> _handleGetTree(HttpRequest request) async {
+    final scope = XRayBridgeScopeHolder.activeScope;
+    if (scope == null) {
+      _jsonResponse(request, 503, {
+        'error': 'No active scope',
+        'message':
+            'No XRayScope is currently registered. Ensure X-Ray mode is enabled and a view is mounted.',
+      });
+      return;
+    }
+
+    final tree = serializeXRayTree(scope);
+    _jsonResponse(request, 200, tree.toJson());
+  }
+
+  // ----------------------------------------------------------------
+  // POST /xray/action
+  // ----------------------------------------------------------------
+
+  Future<void> _handlePostAction(HttpRequest request) async {
+    try {
+      final body = await _readJsonBody(request);
+      final targetNode = body['targetNode'] as String?;
+      final payload = body['payload'] as Map<String, dynamic>?;
+
+      if (targetNode == null || targetNode.isEmpty) {
+        _jsonResponse(request, 400, {
+          'error': 'Bad request',
+          'message': 'Field "targetNode" is required',
+        });
+        return;
+      }
+
+      final invoked = XRayActionRegistry.invoke(targetNode, payload ?? {});
+      if (invoked) {
+        _jsonResponse(request, 200, {
+          'success': true,
+          'targetNode': targetNode,
+          'message': 'Action invoked',
+        });
+      } else {
+        _jsonResponse(request, 404, {
+          'error': 'Node not found',
+          'message': 'No registered action for "$targetNode"',
+          'availableNodes': XRayActionRegistry.registeredIds,
+        });
+      }
+    } catch (e) {
+      _jsonResponse(request, 400, {
+        'error': 'Bad request',
+        'message': 'Invalid JSON body: $e',
+      });
+    }
+  }
+
+  // ----------------------------------------------------------------
+  // POST /xray/control-deck
+  // ----------------------------------------------------------------
+
+  Future<void> _handlePostControlDeck(HttpRequest request) async {
+    try {
+      final body = await _readJsonBody(request);
+      final mockName = body['mockName'] as String?;
+      final payload = body['payload'];
+
+      if (mockName == null || mockName.isEmpty) {
+        _jsonResponse(request, 400, {
+          'error': 'Bad request',
+          'message': 'Field "mockName" is required',
+        });
+        return;
+      }
+
+      final triggered = XRayMockInjectorRegistry.trigger(mockName, payload);
+      if (triggered) {
+        _jsonResponse(request, 200, {
+          'success': true,
+          'mockName': mockName,
+          'message': 'Mock injected',
+        });
+      } else {
+        _jsonResponse(request, 404, {
+          'error': 'Mock not found',
+          'message': 'No registered mock named "$mockName"',
+          'availableMocks': XRayMockInjectorRegistry.registeredNames,
+        });
+      }
+    } catch (e) {
+      _jsonResponse(request, 400, {
+        'error': 'Bad request',
+        'message': 'Invalid JSON body: $e',
+      });
+    }
+  }
+
+  // ----------------------------------------------------------------
+  // WebSocket /xray/ws — tree diff stream
+  // ----------------------------------------------------------------
+
+  void _handleWebSocket(HttpRequest request) {
+    final scope = XRayBridgeScopeHolder.activeScope;
+    if (scope == null) {
+      // Reject upgrade — no scope to stream
+      request.response.statusCode = 503;
+      request.response.write(jsonEncode({
+        'error': 'No active scope',
+      }));
+      request.response.close();
+      return;
+    }
+
+    // Accept the WebSocket upgrade
+    final wsFuture = WebSocketTransformer.upgrade(request);
+    wsFuture.then((webSocket) {
+      // Send initial tree snapshot
+      final tree = serializeXRayTree(scope);
+      webSocket.add(jsonEncode({
+        'type': 'snapshot',
+        'data': tree.toJson(),
+      }));
+
+      // Subscribe to tree diffs
+      StreamSubscription<XRayTreeDiff>? subscription;
+      subscription = XRayBridgeStream.stream.listen((diff) {
+        if (webSocket.readyState == WebSocket.open) {
+          webSocket.add(jsonEncode({
+            'type': 'diff',
+            'data': diff.toJson(),
+          }));
+        }
+      });
+
+      // Clean up on close
+      webSocket.done.whenComplete(() {
+        subscription?.cancel();
+      });
+    }).catchError((e) {
+      stderr.writeln('[xray-bridge] WebSocket upgrade error: $e');
+    });
+  }
+
+  // ----------------------------------------------------------------
+  // Helpers
+  // ----------------------------------------------------------------
+
+  Future<void> _jsonResponse(
+    HttpRequest request,
+    int statusCode,
+    Map<String, dynamic> body,
+  ) async {
+    request.response.statusCode = statusCode;
+    request.response.headers.set('Content-Type', 'application/json');
+    request.response.write(jsonEncode(body));
+    await request.response.close();
+  }
+
+  Future<Map<String, dynamic>> _readJsonBody(HttpRequest request) async {
+    final body = await utf8.decoder.bind(request).join();
+    return jsonDecode(body) as Map<String, dynamic>;
+  }
+}

--- a/lib/src/presentation/xray/xray_bridge_server.dart
+++ b/lib/src/presentation/xray/xray_bridge_server.dart
@@ -124,6 +124,26 @@ class XRayBridgeServer {
   // ----------------------------------------------------------------
 
   void _handleRequest(HttpRequest request) {
+    // Reject any request with an Origin header (CSRF protection)
+    if (request.headers.value('origin') != null) {
+      _jsonResponse(request, 403, {
+        'error': 'Forbidden',
+        'message': 'Cross-origin requests are not allowed',
+      });
+      return;
+    }
+
+    // Validate Host header matches expected loopback address
+    final hostHeader = request.headers.value('host');
+    final expectedHost = '127.0.0.1:$_port';
+    if (hostHeader != expectedHost && hostHeader != 'localhost:$_port') {
+      _jsonResponse(request, 400, {
+        'error': 'Bad request',
+        'message': 'Invalid Host header',
+      });
+      return;
+    }
+
     // Auth check
     if (_authToken != null) {
       final authHeader = request.headers.value('authorization');
@@ -195,19 +215,29 @@ class XRayBridgeServer {
   // ----------------------------------------------------------------
 
   Future<void> _handlePostAction(HttpRequest request) async {
+    final Map<String, dynamic> body;
     try {
-      final body = await _readJsonBody(request);
-      final targetNode = body['targetNode'] as String?;
-      final payload = body['payload'] as Map<String, dynamic>?;
+      body = await _readJsonBody(request);
+    } catch (e) {
+      _jsonResponse(request, 400, {
+        'error': 'Bad request',
+        'message': 'Invalid JSON body: $e',
+      });
+      return;
+    }
 
-      if (targetNode == null || targetNode.isEmpty) {
-        _jsonResponse(request, 400, {
-          'error': 'Bad request',
-          'message': 'Field "targetNode" is required',
-        });
-        return;
-      }
+    final targetNode = body['targetNode'] as String?;
+    final payload = body['payload'] as Map<String, dynamic>?;
 
+    if (targetNode == null || targetNode.isEmpty) {
+      _jsonResponse(request, 400, {
+        'error': 'Bad request',
+        'message': 'Field "targetNode" is required',
+      });
+      return;
+    }
+
+    try {
       final invoked = XRayActionRegistry.invoke(targetNode, payload ?? {});
       if (invoked) {
         _jsonResponse(request, 200, {
@@ -223,9 +253,9 @@ class XRayBridgeServer {
         });
       }
     } catch (e) {
-      _jsonResponse(request, 400, {
-        'error': 'Bad request',
-        'message': 'Invalid JSON body: $e',
+      _jsonResponse(request, 500, {
+        'error': 'Action callback failed',
+        'message': 'Error executing action: $e',
       });
     }
   }
@@ -235,19 +265,29 @@ class XRayBridgeServer {
   // ----------------------------------------------------------------
 
   Future<void> _handlePostControlDeck(HttpRequest request) async {
+    final Map<String, dynamic> body;
     try {
-      final body = await _readJsonBody(request);
-      final mockName = body['mockName'] as String?;
-      final payload = body['payload'];
+      body = await _readJsonBody(request);
+    } catch (e) {
+      _jsonResponse(request, 400, {
+        'error': 'Bad request',
+        'message': 'Invalid JSON body: $e',
+      });
+      return;
+    }
 
-      if (mockName == null || mockName.isEmpty) {
-        _jsonResponse(request, 400, {
-          'error': 'Bad request',
-          'message': 'Field "mockName" is required',
-        });
-        return;
-      }
+    final mockName = body['mockName'] as String?;
+    final payload = body['payload'];
 
+    if (mockName == null || mockName.isEmpty) {
+      _jsonResponse(request, 400, {
+        'error': 'Bad request',
+        'message': 'Field "mockName" is required',
+      });
+      return;
+    }
+
+    try {
       final triggered = XRayMockInjectorRegistry.trigger(mockName, payload);
       if (triggered) {
         _jsonResponse(request, 200, {
@@ -263,9 +303,9 @@ class XRayBridgeServer {
         });
       }
     } catch (e) {
-      _jsonResponse(request, 400, {
-        'error': 'Bad request',
-        'message': 'Invalid JSON body: $e',
+      _jsonResponse(request, 500, {
+        'error': 'Mock callback failed',
+        'message': 'Error triggering mock: $e',
       });
     }
   }
@@ -300,10 +340,15 @@ class XRayBridgeServer {
       StreamSubscription<XRayTreeDiff>? subscription;
       subscription = XRayBridgeStream.stream.listen((diff) {
         if (webSocket.readyState == WebSocket.open) {
-          webSocket.add(jsonEncode({
-            'type': 'diff',
-            'data': diff.toJson(),
-          }));
+          try {
+            webSocket.add(jsonEncode({
+              'type': 'diff',
+              'data': diff.toJson(),
+            }));
+          } catch (e) {
+            // WebSocket write failed, cancel subscription
+            subscription?.cancel();
+          }
         }
       });
 

--- a/test/presentation/xray/xray_bridge_test.dart
+++ b/test/presentation/xray/xray_bridge_test.dart
@@ -87,6 +87,17 @@ void main() {
       expect(json.containsKey('boundAction'), false);
       expect(json['enabled'], true);
       expect(json.containsKey('state'), false);
+      expect(json.containsKey('parentId'), false);
+    });
+
+    test('toJson includes parentId when present', () {
+      const node = XRayTreeNodeJson(
+        id: 'ProductView.childButton',
+        enumName: 'childButton',
+        parentId: 'ProductView.parentContainer',
+      );
+      final json = node.toJson();
+      expect(json['parentId'], 'ProductView.parentContainer');
     });
   });
 
@@ -284,14 +295,14 @@ void main() {
       client.close();
     });
 
-    test('GET /xray/tree returns tree when scope is registered', () async {
-      // We can't create a real XRayScopeState without a widget tree,
-      // so we test the server's 503 path. The 200 path is verified
-      // through the XRayTreeJson serialization tests above.
+    test('GET /xray/tree returns 503 when scope is unregistered (duplicate check)', () async {
+      // This test verifies the same 503 path as the previous test.
+      // We can't create a real XRayScopeState without a widget tree.
+      // The 200 path is verified through the XRayTreeJson serialization tests above.
       // The bridge server calls serializeXRayTree which calls
       // scope.tree and scope.viewId — this is a pure data pass-through.
       //
-      // For a full integration test, see the widget test directory.
+      // For a full integration test with a mounted XRayScope, see the widget test directory.
       XRayBridgeScopeHolder.reset();
       final client = HttpClient();
       final request =
@@ -495,7 +506,12 @@ void main() {
       await server.stop();
     });
 
-    test('full agent flow: inspect, action, verify', () async {
+    test('action invocation without mounted scope (partial flow)', () async {
+      // NOTE: This test does NOT perform tree inspection because no XRayScope
+      // is mounted in this unit test environment. It verifies action invocation
+      // and state changes only. For a complete inspect -> action -> verify flow
+      // with actual tree traversal, see widget tests with mounted XRayScope.
+
       bool buttonPressed = false;
       XRayActionRegistry.register('ProfileView.editProfileButton', (_) {
         buttonPressed = true;
@@ -503,13 +519,13 @@ void main() {
 
       final client = HttpClient();
 
-      // Step 1: Inspect tree (503 since no scope in unit test)
+      // Step 1: Attempt tree inspection (returns 503 since no scope is mounted)
       final treeRequest = await client
           .getUrl(Uri.parse('http://127.0.0.1:$port/xray/tree'));
       final treeResponse = await treeRequest.close();
       expect(treeResponse.statusCode, 503);
 
-      // Step 2: Tap button via action endpoint
+      // Step 2: Invoke registered action directly (works without scope)
       final actionRequest = await client
           .postUrl(Uri.parse('http://127.0.0.1:$port/xray/action'));
       actionRequest.headers.set('Content-Type', 'application/json');
@@ -520,7 +536,7 @@ void main() {
       final actionResponse = await actionRequest.close();
       expect(actionResponse.statusCode, 200);
 
-      // Step 3: Verify state changed
+      // Step 3: Verify action callback was executed
       expect(buttonPressed, true);
 
       client.close();

--- a/test/presentation/xray/xray_bridge_test.dart
+++ b/test/presentation/xray/xray_bridge_test.dart
@@ -1,0 +1,534 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:zuraffa/src/presentation/xray/xray_bridge.dart';
+import 'package:zuraffa/src/presentation/xray/xray_bridge_server.dart';
+import 'package:zuraffa/src/presentation/xray/xray_node_metadata.dart';
+import 'package:zuraffa/src/presentation/xray/xray_scope.dart';
+
+// ------------------------------------------------------------------
+// Test helper — creates a Fake scope with the minimal interface
+// needed by the bridge server.
+// ------------------------------------------------------------------
+
+/// Creates an [XRayScopeState] fake by leveraging [Fake] only on
+/// the non-conflicting methods.
+///
+/// Because [XRayScopeState] extends [State] → [Diagnosticable],
+/// `extends Fake implements XRayScopeState` causes a `toString`
+/// override conflict. We work around this by not implementing the
+/// full interface — the bridge server only accesses `viewId` and
+/// `tree`, so we create a lightweight wrapper.
+class TestScopeWrapper {
+  final String viewId;
+  final List<XRayNodeInfo> nodes;
+
+  const TestScopeWrapper({
+    required this.viewId,
+    this.nodes = const [],
+  });
+
+  /// Serialize through [XRayTreeJson] directly (same path as
+  /// [serializeXRayTree] but without requiring a real scope).
+  XRayTreeJson toTreeJson() {
+    return XRayTreeJson(
+      activeView: viewId,
+      nodes: nodes.map((info) {
+        final meta = XRayMetadataRegistry.forNode(info.id);
+        return XRayTreeNodeJson(
+          id: info.id,
+          enumName: info.enumName,
+          actionName: meta?.actionName,
+          isEnabled: meta?.isEnabled ?? true,
+          state: meta?.stateJson,
+        );
+      }).toList(),
+    );
+  }
+}
+
+// ------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------
+
+void main() {
+  tearDown(() {
+    XRayActionRegistry.clear();
+    XRayMockInjectorRegistry.clear();
+    XRayMetadataRegistry.clear();
+    XRayBridgeScopeHolder.reset();
+  });
+
+  group('XRayTreeNodeJson', () {
+    test('toJson includes all fields', () {
+      const node = XRayTreeNodeJson(
+        id: 'ProductView.saveButton',
+        enumName: 'saveButton',
+        actionName: 'onSaveTapped',
+        isEnabled: false,
+        state: {'loading': true},
+      );
+      final json = node.toJson();
+      expect(json['id'], 'ProductView.saveButton');
+      expect(json['type'], 'saveButton');
+      expect(json['boundAction'], 'onSaveTapped');
+      expect(json['enabled'], false);
+      expect(json['state'], {'loading': true});
+    });
+
+    test('toJson omits optional fields when null', () {
+      const node = XRayTreeNodeJson(
+        id: 'ProfileView.avatar',
+        enumName: 'avatar',
+      );
+      final json = node.toJson();
+      expect(json.containsKey('boundAction'), false);
+      expect(json['enabled'], true);
+      expect(json.containsKey('state'), false);
+    });
+  });
+
+  group('XRayTreeJson', () {
+    test('toJson returns activeView and nodes list', () {
+      final tree = XRayTreeJson(
+        activeView: 'ProductView',
+        nodes: const [
+          XRayTreeNodeJson(id: 'ProductView.title', enumName: 'title'),
+          XRayTreeNodeJson(
+            id: 'ProductView.saveButton',
+            enumName: 'saveButton',
+            actionName: 'onSave',
+          ),
+        ],
+      );
+
+      final json = tree.toJson();
+      expect(json['activeView'], 'ProductView');
+      expect((json['nodes'] as List).length, 2);
+      expect((json['nodes'] as List)[0]['id'], 'ProductView.title');
+      expect((json['nodes'] as List)[1]['boundAction'], 'onSave');
+    });
+
+    test('toJson with empty nodes', () {
+      final tree = XRayTreeJson(activeView: 'EmptyView', nodes: const []);
+      final json = tree.toJson();
+      expect(json['activeView'], 'EmptyView');
+      expect(json['nodes'], []);
+    });
+  });
+
+  group('XRayActionRegistry', () {
+    test('register and invoke action', () {
+      Map<String, dynamic>? receivedPayload;
+      XRayActionRegistry.register('TestView.tapButton', (payload) {
+        receivedPayload = payload;
+      });
+
+      final result = XRayActionRegistry.invoke(
+          'TestView.tapButton', {'key': 'value'});
+      expect(result, true);
+      expect(receivedPayload, {'key': 'value'});
+    });
+
+    test('invoke with missing nodeId returns false', () {
+      final result = XRayActionRegistry.invoke('NonExistent.node');
+      expect(result, false);
+    });
+
+    test('invoke without payload uses empty map', () {
+      Map<String, dynamic>? receivedPayload;
+      XRayActionRegistry.register('TestView.node', (payload) {
+        receivedPayload = payload;
+      });
+
+      XRayActionRegistry.invoke('TestView.node');
+      expect(receivedPayload, isNotNull);
+      expect(receivedPayload, {});
+    });
+
+    test('registeredIds returns all registered node IDs', () {
+      XRayActionRegistry.register('A.b', (_) {});
+      XRayActionRegistry.register('C.d', (_) {});
+
+      final ids = XRayActionRegistry.registeredIds;
+      expect(ids, containsAll(['A.b', 'C.d']));
+    });
+
+    test('unregister removes the action', () {
+      XRayActionRegistry.register('TestView.node', (_) {});
+      XRayActionRegistry.unregister('TestView.node');
+      expect(XRayActionRegistry.invoke('TestView.node'), false);
+    });
+  });
+
+  group('XRayMockInjectorRegistry', () {
+    test('register and trigger mock', () {
+      dynamic receivedPayload;
+      XRayMockInjectorRegistry.register('Valid Product', (payload) {
+        receivedPayload = payload;
+      });
+
+      final result =
+          XRayMockInjectorRegistry.trigger('Valid Product', 'barcode123');
+      expect(result, true);
+      expect(receivedPayload, 'barcode123');
+    });
+
+    test('trigger with missing name returns false', () {
+      final result = XRayMockInjectorRegistry.trigger('NonExistent');
+      expect(result, false);
+    });
+
+    test('registeredNames returns all mock names', () {
+      XRayMockInjectorRegistry.register('Mock A', (_) {});
+      XRayMockInjectorRegistry.register('Mock B', (_) {});
+
+      final names = XRayMockInjectorRegistry.registeredNames;
+      expect(names, containsAll(['Mock A', 'Mock B']));
+    });
+
+    test('unregister removes the mock', () {
+      XRayMockInjectorRegistry.register('Mock X', (_) {});
+      XRayMockInjectorRegistry.unregister('Mock X');
+      expect(XRayMockInjectorRegistry.trigger('Mock X'), false);
+    });
+  });
+
+  group('XRayBridgeStream', () {
+    test('emits diff events to listeners', () async {
+      final events = <XRayTreeDiff>[];
+      final sub = XRayBridgeStream.stream.listen(events.add);
+
+      const diff = XRayTreeDiff(
+        type: XRayBridgeEventType.added,
+        nodeId: 'TestView.newNode',
+      );
+
+      XRayBridgeStream.emit(diff);
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      expect(events.length, 1);
+      expect(events[0].type, XRayBridgeEventType.added);
+      expect(events[0].nodeId, 'TestView.newNode');
+
+      await sub.cancel();
+    });
+
+    test('multiple listeners receive events', () async {
+      final events1 = <XRayTreeDiff>[];
+      final events2 = <XRayTreeDiff>[];
+      final sub1 = XRayBridgeStream.stream.listen(events1.add);
+      final sub2 = XRayBridgeStream.stream.listen(events2.add);
+
+      XRayBridgeStream.emit(const XRayTreeDiff(
+        type: XRayBridgeEventType.removed,
+        nodeId: 'A.b',
+      ));
+
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      expect(events1.length, 1);
+      expect(events2.length, 1);
+
+      await sub1.cancel();
+      await sub2.cancel();
+    });
+
+    test('diff toJson includes type and nodeId', () {
+      const diff = XRayTreeDiff(
+        type: XRayBridgeEventType.updated,
+        nodeId: 'View.node',
+        node: XRayTreeNodeJson(id: 'View.node', enumName: 'node'),
+      );
+
+      final json = diff.toJson();
+      expect(json['type'], 'updated');
+      expect(json['nodeId'], 'View.node');
+      expect(json['node'], isNotNull);
+      expect(json['node']['id'], 'View.node');
+    });
+  });
+
+  // ----------------------------------------------------------------
+  // Integration: server endpoints
+  // ----------------------------------------------------------------
+
+  group('XRayBridgeServer', () {
+    late XRayBridgeServer server;
+    late int port;
+
+    setUp(() async {
+      server = XRayBridgeServer(port: 0, localhostOnly: true);
+      port = await server.start();
+      expect(port, greaterThan(0));
+    });
+
+    tearDown(() async {
+      await server.stop();
+    });
+
+    test('GET /xray/tree returns 503 when no scope is registered', () async {
+      XRayBridgeScopeHolder.reset();
+
+      final client = HttpClient();
+      final request =
+          await client.getUrl(Uri.parse('http://127.0.0.1:$port/xray/tree'));
+      final response = await request.close();
+
+      expect(response.statusCode, 503);
+      final body = await _jsonBody(response);
+      expect(body['error'], 'No active scope');
+
+      client.close();
+    });
+
+    test('GET /xray/tree returns tree when scope is registered', () async {
+      // We can't create a real XRayScopeState without a widget tree,
+      // so we test the server's 503 path. The 200 path is verified
+      // through the XRayTreeJson serialization tests above.
+      // The bridge server calls serializeXRayTree which calls
+      // scope.tree and scope.viewId — this is a pure data pass-through.
+      //
+      // For a full integration test, see the widget test directory.
+      XRayBridgeScopeHolder.reset();
+      final client = HttpClient();
+      final request =
+          await client.getUrl(Uri.parse('http://127.0.0.1:$port/xray/tree'));
+      final response = await request.close();
+      expect(response.statusCode, 503);
+      client.close();
+    });
+
+    test('POST /xray/action invokes registered action', () async {
+      Map<String, dynamic>? received;
+      XRayActionRegistry.register('TestView.tapMe', (payload) {
+        received = payload;
+      });
+
+      final client = HttpClient();
+      final request = await client
+          .postUrl(Uri.parse('http://127.0.0.1:$port/xray/action'));
+      request.headers.set('Content-Type', 'application/json');
+      request.write(jsonEncode({
+        'targetNode': 'TestView.tapMe',
+        'payload': {'key': 'val'},
+      }));
+      final response = await request.close();
+
+      expect(response.statusCode, 200);
+      final body = await _jsonBody(response);
+      expect(body['success'], true);
+      expect(body['targetNode'], 'TestView.tapMe');
+      expect(received, {'key': 'val'});
+
+      client.close();
+    });
+
+    test('POST /xray/action with invalid nodeId returns 404', () async {
+      final client = HttpClient();
+      final request = await client
+          .postUrl(Uri.parse('http://127.0.0.1:$port/xray/action'));
+      request.headers.set('Content-Type', 'application/json');
+      request.write(jsonEncode({
+        'targetNode': 'NonExistent.node',
+        'payload': {},
+      }));
+      final response = await request.close();
+
+      expect(response.statusCode, 404);
+      final body = await _jsonBody(response);
+      expect(body['error'], 'Node not found');
+      expect(body['availableNodes'], isA<List>());
+
+      client.close();
+    });
+
+    test('POST /xray/action without targetNode returns 400', () async {
+      final client = HttpClient();
+      final request = await client
+          .postUrl(Uri.parse('http://127.0.0.1:$port/xray/action'));
+      request.headers.set('Content-Type', 'application/json');
+      request.write(jsonEncode({'payload': {}}));
+      final response = await request.close();
+
+      expect(response.statusCode, 400);
+
+      client.close();
+    });
+
+    test('POST /xray/control-deck triggers mock', () async {
+      dynamic received;
+      XRayMockInjectorRegistry.register('Expired Product', (payload) {
+        received = payload;
+      });
+
+      final client = HttpClient();
+      final request = await client.postUrl(
+          Uri.parse('http://127.0.0.1:$port/xray/control-deck'));
+      request.headers.set('Content-Type', 'application/json');
+      request.write(jsonEncode({
+        'mockName': 'Expired Product',
+        'payload': 'expired_data',
+      }));
+      final response = await request.close();
+
+      expect(response.statusCode, 200);
+      final body = await _jsonBody(response);
+      expect(body['success'], true);
+      expect(body['mockName'], 'Expired Product');
+      expect(received, 'expired_data');
+
+      client.close();
+    });
+
+    test('POST /xray/control-deck with invalid name returns 404', () async {
+      final client = HttpClient();
+      final request = await client.postUrl(
+          Uri.parse('http://127.0.0.1:$port/xray/control-deck'));
+      request.headers.set('Content-Type', 'application/json');
+      request.write(jsonEncode({'mockName': 'NonExistent'}));
+      final response = await request.close();
+
+      expect(response.statusCode, 404);
+      final body = await _jsonBody(response);
+      expect(body['error'], 'Mock not found');
+      expect(body['availableMocks'], isA<List>());
+
+      client.close();
+    });
+
+    test('POST /xray/control-deck without mockName returns 400', () async {
+      final client = HttpClient();
+      final request = await client.postUrl(
+          Uri.parse('http://127.0.0.1:$port/xray/control-deck'));
+      request.headers.set('Content-Type', 'application/json');
+      request.write(jsonEncode({}));
+      final response = await request.close();
+
+      expect(response.statusCode, 400);
+
+      client.close();
+    });
+
+    test('unknown endpoint returns 404', () async {
+      final client = HttpClient();
+      final request = await client
+          .getUrl(Uri.parse('http://127.0.0.1:$port/xray/nonexistent'));
+      final response = await request.close();
+
+      expect(response.statusCode, 404);
+
+      client.close();
+    });
+
+    test('auth token rejects unauthenticated requests', () async {
+      await server.stop();
+      server = XRayBridgeServer(
+          port: 0, authToken: 'secret123', localhostOnly: true);
+      port = await server.start();
+
+      final client = HttpClient();
+      final request =
+          await client.getUrl(Uri.parse('http://127.0.0.1:$port/xray/tree'));
+      final response = await request.close();
+
+      expect(response.statusCode, 401);
+
+      client.close();
+    });
+
+    test('server stop and restart works', () async {
+      await server.stop();
+      expect(server.isRunning, false);
+
+      server = XRayBridgeServer(port: 0, localhostOnly: true);
+      port = await server.start();
+      expect(server.isRunning, true);
+      expect(port, greaterThan(0));
+    });
+  });
+
+  group('XRayBridgeServer WebSocket', () {
+    late XRayBridgeServer server;
+    late int port;
+
+    setUp(() async {
+      server = XRayBridgeServer(port: 0, localhostOnly: true);
+      port = await server.start();
+    });
+
+    tearDown(() async {
+      await server.stop();
+    });
+
+    test('WS returns 503 when no scope is registered', () async {
+      XRayBridgeScopeHolder.reset();
+
+      try {
+        await WebSocket.connect('ws://127.0.0.1:$port/xray/ws')
+            .timeout(const Duration(seconds: 2));
+        fail('Should have thrown');
+      } catch (e) {
+        // The server rejects the upgrade with 503.
+        // WebSocket.connect throws on non-101 responses.
+        expect(e, isA<WebSocketException>());
+      }
+    });
+  });
+
+  // ----------------------------------------------------------------
+  // E2E flow
+  // ----------------------------------------------------------------
+
+  group('E2E: inspect tree -> tap button -> verify state change', () {
+    late XRayBridgeServer server;
+    late int port;
+
+    setUp(() async {
+      server = XRayBridgeServer(port: 0, localhostOnly: true);
+      port = await server.start();
+    });
+
+    tearDown(() async {
+      await server.stop();
+    });
+
+    test('full agent flow: inspect, action, verify', () async {
+      bool buttonPressed = false;
+      XRayActionRegistry.register('ProfileView.editProfileButton', (_) {
+        buttonPressed = true;
+      });
+
+      final client = HttpClient();
+
+      // Step 1: Inspect tree (503 since no scope in unit test)
+      final treeRequest = await client
+          .getUrl(Uri.parse('http://127.0.0.1:$port/xray/tree'));
+      final treeResponse = await treeRequest.close();
+      expect(treeResponse.statusCode, 503);
+
+      // Step 2: Tap button via action endpoint
+      final actionRequest = await client
+          .postUrl(Uri.parse('http://127.0.0.1:$port/xray/action'));
+      actionRequest.headers.set('Content-Type', 'application/json');
+      actionRequest.write(jsonEncode({
+        'targetNode': 'ProfileView.editProfileButton',
+        'payload': {},
+      }));
+      final actionResponse = await actionRequest.close();
+      expect(actionResponse.statusCode, 200);
+
+      // Step 3: Verify state changed
+      expect(buttonPressed, true);
+
+      client.close();
+    });
+  });
+}
+
+Future<Map<String, dynamic>> _jsonBody(HttpClientResponse response) async {
+  final body = await utf8.decoder.bind(response).join();
+  return jsonDecode(body) as Map<String, dynamic>;
+}


### PR DESCRIPTION
Closes #184 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an X-Ray Bridge CLI command with configurable ports, remote access, and optional bearer-token authentication.
  - Added an HTTP/WebSocket bridge for inspecting X-Ray trees, invoking actions, triggering mock controls, and receiving live updates.
  - Added debug/profile-only bridge support; release builds safely disable bridge functionality.
- **Documentation**
  - Updated X-Ray command descriptions, usage guidance, and bridge help text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->