### PR TITLE
[v6] Track 5.3 — Migration Tooling: v5 to v6 Upgrade Path

### DIFF
--- a/lib/src/cli/cli_runner.dart
+++ b/lib/src/cli/cli_runner.dart
@@ -11,6 +11,7 @@ import '../commands/entity_command.dart';
 import '../commands/plugin_command.dart' as plugincmd;
 import '../commands/make_command.dart';
 import '../commands/doctor_command.dart';
+import '../commands/migrate_command.dart';
 import '../commands/build_command.dart';
 import '../commands/manifest_command.dart';
 import '../commands/apply_command.dart';
@@ -75,6 +76,7 @@ class CliRunner {
     _runner.addCommand(_PluginCommand());
     _runner.addCommand(MakeCommand(registry));
     _runner.addCommand(DoctorCommand());
+    _runner.addCommand(MigrateCommand());
     _runner.addCommand(BuildCommand());
     _runner.addCommand(ManifestCommand(registry));
     _runner.addCommand(ApplyCommand(registry));
@@ -216,9 +218,10 @@ CORE COMMANDS:
   initialize          Initialize a test entity
   entity              Create and manage Zorphy entities
   config              Manage ZFA configuration
-  doctor              Check your environment
+  doctor              Check your environment and v5 migration readiness
   schema              Output JSON schema
   validate <file>     Validate JSON configuration
+  migrate <target>     Migrate v5 artifacts to v6 (state, gql, di)
 
 MODULAR COMMANDS:
   route <Name>        Generate route definitions

--- a/lib/src/commands/doctor_command.dart
+++ b/lib/src/commands/doctor_command.dart
@@ -178,7 +178,10 @@ class DoctorCommand extends Command<void> {
           _print('  $line');
         }
 
-        if (deadCodeLines.length < lines.where((l) => l.contains('dead_code')).length) {
+        final totalDeadCodeLines = lines
+            .where((line) => line.contains('Dead code') || line.contains('dead_code'))
+            .length;
+        if (deadCodeLines.length < totalDeadCodeLines) {
           _print('  ... and more.');
         }
       } else {

--- a/lib/src/commands/doctor_command.dart
+++ b/lib/src/commands/doctor_command.dart
@@ -1,16 +1,44 @@
 import 'dart:async';
 import 'dart:io';
 import 'package:args/command_runner.dart';
+
+import '../migration/migration.dart';
+import '../migration/migration_models.dart';
+import '../migration/detectors/gql_detector.dart';
+import '../migration/detectors/state_detector.dart';
+import '../migration/detectors/di_detector.dart';
+import '../migration/detectors/controlled_widget_detector.dart';
+import '../migration/detectors/dependency_overrides_detector.dart';
+import '../migration/fixers/state_fixer.dart';
+import '../migration/fixers/gql_fixer.dart';
 import '../version.dart';
 
-class DoctorCommand extends Command {
+class DoctorCommand extends Command<void> {
   @override
   final String name = 'doctor';
 
   @override
-  final String description = 'Show information about the installed tooling.';
+  final String description = 'Show information about the installed tooling and v5 migration readiness.';
 
   static const _timeout = Duration(seconds: 10);
+
+  DoctorCommand() {
+    argParser.addFlag(
+      'fix',
+      negatable: false,
+      help: 'Automatically fix detected v5 patterns where possible',
+    );
+    argParser.addFlag(
+      'dry-run',
+      negatable: false,
+      help: 'Show what would change without writing files (implies --fix)',
+    );
+    argParser.addFlag(
+      'migration-only',
+      negatable: false,
+      help: 'Only run v5 migration checks, skip tooling checks',
+    );
+  }
 
   void _print(String message) {
     print(message);
@@ -18,110 +46,105 @@ class DoctorCommand extends Command {
 
   @override
   Future<void> run() async {
-    _print('🩺 Zuraffa Doctor\n');
+    final shouldFix = argResults!['fix'] == true || argResults!['dry-run'] == true;
+    final dryRun = argResults!['dry-run'] == true;
+    final migrationOnly = argResults!['migration-only'] == true;
 
+    if (!migrationOnly) {
+      await _runToolingChecks();
+    }
+
+    _print('');
+    await _runMigrationChecks(shouldFix: shouldFix, dryRun: dryRun);
+  }
+
+  Future<void> _runToolingChecks() async {
+    _print('Zuraffa Doctor');
+    _print('');
     _print('Zuraffa CLI: v$version');
 
     try {
-      final dartResult = await Process.run('dart', [
-        '--version',
-      ]).timeout(_timeout);
+      final dartResult = await Process.run('dart', ['--version']).timeout(_timeout);
       final dartOutput = dartResult.stdout.toString().trim().isNotEmpty
           ? dartResult.stdout.toString().trim()
           : dartResult.stderr.toString().trim();
       _print('Dart: $dartOutput');
     } on TimeoutException {
-      _print('Dart: ⚠️ Timeout');
+      _print('Dart: Timeout');
     } catch (e) {
-      _print('Dart: ❌ Not found');
+      _print('Dart: Not found');
     }
 
     try {
-      final flutterResult = await Process.run('flutter', [
-        '--version',
-      ]).timeout(_timeout);
+      final flutterResult = await Process.run('flutter', ['--version']).timeout(_timeout);
       if (flutterResult.exitCode == 0) {
-        final flutterOutput = flutterResult.stderr
-            .toString()
-            .split('\n')
-            .first
-            .trim();
+        final flutterOutput = flutterResult.stderr.toString().split('\n').first.trim();
         if (flutterOutput.isEmpty) {
-          _print('Flutter: ✅ Installed');
+          _print('Flutter: Installed');
         } else {
           _print('Flutter: $flutterOutput');
         }
       } else {
-        _print('Flutter: ⚠️ Not found (exit code ${flutterResult.exitCode})');
+        _print('Flutter: Not found (exit code ${flutterResult.exitCode})');
       }
     } on TimeoutException {
-      _print('Flutter: ⚠️ Timeout (this is fine if you are only using Dart)');
+      _print('Flutter: Timeout (this is fine if you are only using Dart)');
     } catch (e) {
-      _print('Flutter: ⚠️ Not found (this is fine if you are only using Dart)');
+      _print('Flutter: Not found (this is fine if you are only using Dart)');
     }
 
     _print('');
 
     final configFile = File('.zfa.json');
     if (configFile.existsSync()) {
-      _print('Configuration: ✅ Found .zfa.json');
+      _print('Configuration: Found .zfa.json');
     } else {
-      _print(
-        'Configuration: ⚠️ No .zfa.json found (run "zfa config init" to create one)',
-      );
+      _print('Configuration: No .zfa.json found (run "zfa config init" to create one)');
     }
 
     final pubspecFile = File('pubspec.yaml');
     if (pubspecFile.existsSync()) {
-      _print('Project: ✅ Found pubspec.yaml');
+      _print('Project: Found pubspec.yaml');
 
       try {
         final content = await pubspecFile.readAsString();
         if (content.contains('zuraffa:')) {
-          _print('Dependencies: ✅ Zuraffa package found');
+          _print('Dependencies: Zuraffa package found');
         } else {
-          _print('Dependencies: ⚠️ Zuraffa package not found in pubspec.yaml');
+          _print('Dependencies: Zuraffa package not found in pubspec.yaml');
         }
 
         if (content.contains('zorphy_annotation:')) {
-          _print('              ✅ zorphy_annotation found');
+          _print('              zorphy_annotation found');
         } else {
-          _print(
-            '              ⚠️ zorphy_annotation not found - required for entity generation',
-          );
+          _print('              zorphy_annotation not found - required for entity generation');
           _print('                 Add: dart pub add zorphy_annotation');
         }
       } catch (e) {
-        _print('Dependencies: ❌ Could not read pubspec.yaml');
+        _print('Dependencies: Could not read pubspec.yaml');
       }
     } else {
-      _print('Project: ❌ No pubspec.yaml found');
+      _print('Project: No pubspec.yaml found');
     }
 
     _print('');
 
     try {
-      final zorphyResult = await Process.run('dart', [
-        'pub',
-        'global',
-        'list',
-      ]).timeout(_timeout);
+      final zorphyResult = await Process.run('dart', ['pub', 'global', 'list']).timeout(_timeout);
       final output = zorphyResult.stdout.toString();
       if (output.contains('zorphy')) {
         final match = RegExp(r'zorphy\s+(\S+)').firstMatch(output);
         final zorphyVersion = match?.group(1) ?? 'unknown';
-        _print('zorphy CLI: ✅ v$zorphyVersion (globally installed)');
+        _print('zorphy CLI: v$zorphyVersion (globally installed)');
       } else {
-        _print('zorphy CLI: ℹ️  Not installed globally (optional)');
+        _print('zorphy CLI: Not installed globally (optional)');
         _print('             zfa entity commands work without it (bundled)');
-        _print(
-          '             For standalone use: dart pub global activate zorphy',
-        );
+        _print('             For standalone use: dart pub global activate zorphy');
       }
     } on TimeoutException {
-      _print('zorphy CLI: ⚠️ Timeout checking global packages');
+      _print('zorphy CLI: Timeout checking global packages');
     } catch (e) {
-      _print('zorphy CLI: ❌ Could not check: $e');
+      _print('zorphy CLI: Could not check: $e');
     }
 
     _print('');
@@ -129,16 +152,12 @@ class DoctorCommand extends Command {
   }
 
   Future<void> _checkDeadCode() async {
-    _print('Dead Code Analysis: ⏳ Running dart analyze...');
+    _print('Dead Code Analysis: Running dart analyze...');
 
-    // Count entities for dynamic timeout (min 60s, max 120s)
     final entitiesDir = Directory('lib/src/domain/entities');
     int entityCount = 0;
     if (await entitiesDir.exists()) {
-      entityCount = await entitiesDir
-          .list()
-          .where((e) => e is Directory)
-          .length;
+      entityCount = await entitiesDir.list().where((e) => e is Directory).length;
     }
     final timeout = Duration(seconds: (entityCount * 5 + 60).clamp(60, 120));
 
@@ -147,14 +166,11 @@ class DoctorCommand extends Command {
       final output = result.stdout.toString();
 
       if (output.contains('Dead code') || output.contains('dead_code')) {
-        _print('Dead Code Analysis: ⚠️ Found dead code issues');
+        _print('Dead Code Analysis: Found dead code issues');
 
         final lines = output.split('\n');
         final deadCodeLines = lines
-            .where(
-              (line) =>
-                  line.contains('Dead code') || line.contains('dead_code'),
-            )
+            .where((line) => line.contains('Dead code') || line.contains('dead_code'))
             .take(5)
             .toList();
 
@@ -162,17 +178,123 @@ class DoctorCommand extends Command {
           _print('  $line');
         }
 
-        if (deadCodeLines.length <
-            lines.where((l) => l.contains('dead_code')).length) {
+        if (deadCodeLines.length < lines.where((l) => l.contains('dead_code')).length) {
           _print('  ... and more.');
         }
       } else {
-        _print('Dead Code Analysis: ✅ No dead code found');
+        _print('Dead Code Analysis: No dead code found');
       }
     } on TimeoutException {
-      _print('Dead Code Analysis: ⚠️ Timeout (skipped)');
+      _print('Dead Code Analysis: Timeout (skipped)');
     } catch (e) {
-      _print('Dead Code Analysis: ❌ Failed to run analysis: $e');
+      _print('Dead Code Analysis: Failed to run analysis: $e');
     }
+  }
+
+  Future<void> _runMigrationChecks({
+    required bool shouldFix,
+    required bool dryRun,
+  }) async {
+    _print('v5 Migration Readiness');
+    _print('=======================');
+
+    final projectDir = Directory.current.path;
+    final detectors = <MigrationDetector>[
+      DependencyOverridesDetector(),
+      GqlConstStringDetector(),
+      StateDetector(),
+      ManualDiDetector(),
+      ControlledWidgetDetector(),
+    ];
+
+    var report = MigrationReport();
+    for (final detector in detectors) {
+      final result = await detector.detect(projectDir);
+      report = MigrationReport(
+        detectorResults: [...report.detectorResults, result],
+        migrationResults: report.migrationResults,
+      );
+    }
+
+    // Print results grouped by detector
+    for (final detResult in report.detectorResults) {
+      final detector = detectors.firstWhere((d) => d.detectorId == detResult.detectorId);
+      if (!detResult.hasFindings) {
+        _print('  [PASS] ${detector.displayName}');
+        continue;
+      }
+
+      _print('  [${_severityTag(detResult)}] ${detector.displayName}');
+      for (final finding in detResult.findings.take(5)) {
+        _print('    ${finding.filePath}:${finding.line} - ${finding.message}');
+        if (finding.suggestion != null) {
+          _print('      fix: ${finding.suggestion}');
+        }
+      }
+      if (detResult.findings.length > 5) {
+        _print('    ... and ${detResult.findings.length - 5} more');
+      }
+    }
+
+    _print('');
+    _print('Summary: ${report.totalErrors} error(s), ${report.totalWarnings} warning(s), ${report.totalInfo} info');
+
+    if (report.isClean) {
+      _print('');
+      _print('This project appears to be v6-ready.');
+      return;
+    }
+
+    if (!shouldFix) {
+      _print('');
+      _print('Run `zfa doctor --fix` to apply automatic fixes where possible.');
+      _print('Run `zfa doctor --dry-run` to preview fixes without writing.');
+      _print('Run `zfa migrate <state|gql|di>` for targeted migrations.');
+    } else {
+      _print('');
+      if (dryRun) {
+        _print('Applying fixes (dry-run)...');
+      } else {
+        _print('Applying fixes...');
+      }
+
+      // Fix state migrations
+      final stateFindings = report.allFindings.where((f) => f.ruleId == 'v5_mixed_state').toList();
+      if (stateFindings.isNotEmpty) {
+        final migrator = StateMigrator();
+        final result = await migrator.migrate(
+          findings: stateFindings,
+          projectDir: projectDir,
+          dryRun: dryRun,
+        );
+        _print('  State migration: ${result.filesCreated} created, ${result.filesModified} modified');
+      }
+
+      // Fix gql migrations
+      final gqlFindings = report.allFindings.where((f) => f.ruleId == 'v5_gql_const_string').toList();
+      if (gqlFindings.isNotEmpty) {
+        final migrator = GqlMigrator();
+        final result = await migrator.migrate(
+          findings: gqlFindings,
+          projectDir: projectDir,
+          dryRun: dryRun,
+        );
+        _print('  GQL migration: ${result.filesCreated} created, ${result.filesModified} modified');
+      }
+
+      if (dryRun) {
+        _print('');
+        _print('Dry-run complete. Re-run without --dry-run to apply.');
+      } else {
+        _print('');
+        _print('Fixes applied. Run `dart analyze` to verify.');
+      }
+    }
+  }
+
+  String _severityTag(DetectorResult result) {
+    if (result.errorCount > 0) return 'FAIL';
+    if (result.warningCount > 0) return 'WARN';
+    return 'INFO';
   }
 }

--- a/lib/src/commands/migrate_command.dart
+++ b/lib/src/commands/migrate_command.dart
@@ -1,0 +1,210 @@
+import 'dart:io';
+
+import 'package:args/command_runner.dart';
+
+import '../migration/migration_models.dart';
+import '../migration/detectors/gql_detector.dart';
+import '../migration/detectors/state_detector.dart';
+import '../migration/detectors/di_detector.dart';
+import '../migration/fixers/state_fixer.dart';
+import '../migration/fixers/gql_fixer.dart';
+
+/// `zfa migrate [state|gql|di]` -- migrates v5 artifacts to v6 equivalents.
+class MigrateCommand extends Command<void> {
+  @override
+  final String name = 'migrate';
+
+  @override
+  final String description =
+      'Migrate v5 artifacts to v6 equivalents (state, gql, di).';
+
+  MigrateCommand() {
+    argParser.addFlag(
+      'dry-run',
+      negatable: false,
+      help: 'Preview changes without writing files',
+    );
+    argParser.addFlag(
+      'verbose',
+      abbr: 'v',
+      negatable: false,
+      help: 'Show detailed output',
+    );
+  }
+
+  @override
+  Future<void> run() async {
+    final dryRun = argResults!['dry-run'] == true;
+    final verbose = argResults!['verbose'] == true;
+    final subcommand = argResults!.rest.isEmpty ? null : argResults!.rest.first;
+
+    if (subcommand == null || subcommand == 'help') {
+      _printUsage();
+      return;
+    }
+
+    final projectDir = Directory.current.path;
+
+    switch (subcommand) {
+      case 'state':
+        await _migrateState(projectDir, dryRun, verbose);
+      case 'gql':
+        await _migrateGql(projectDir, dryRun, verbose);
+      case 'di':
+        await _migrateDi(projectDir, dryRun, verbose);
+      default:
+        print('Unknown migration target: $subcommand');
+        print('Available: state, gql, di');
+        print('');
+        _printUsage();
+    }
+  }
+
+  Future<void> _migrateState(String projectDir, bool dryRun, bool verbose) async {
+    print('Scanning for v5 state files...');
+
+    final detector = StateDetector();
+    final result = await detector.detect(projectDir);
+
+    if (!result.hasFindings) {
+      print('No v5 mixed state files found. Nothing to migrate.');
+      return;
+    }
+
+    print('Found ${result.findings.length} state file(s) to migrate:');
+    for (final f in result.findings) {
+      print('  - ${f.filePath}');
+    }
+    print('');
+
+    if (dryRun) {
+      print('Dry-run mode -- no files will be written.');
+      print('');
+    }
+
+    final migrator = StateMigrator();
+    final migrationResult = await migrator.migrate(
+      findings: result.findings,
+      projectDir: projectDir,
+      dryRun: dryRun,
+    );
+
+    _printMigrationResult(migrationResult, dryRun, verbose);
+  }
+
+  Future<void> _migrateGql(String projectDir, bool dryRun, bool verbose) async {
+    print('Scanning for v5 GraphQL const-string documents...');
+
+    final detector = GqlConstStringDetector();
+    final result = await detector.detect(projectDir);
+
+    if (!result.hasFindings) {
+      print('No v5 GraphQL const-string documents found. Nothing to migrate.');
+      return;
+    }
+
+    print('Found ${result.findings.length} document(s) to migrate:');
+    for (final f in result.findings) {
+      print('  - ${f.filePath}:${f.line}');
+    }
+    print('');
+
+    if (dryRun) {
+      print('Dry-run mode -- no files will be written.');
+      print('');
+    }
+
+    final migrator = GqlMigrator();
+    final migrationResult = await migrator.migrate(
+      findings: result.findings,
+      projectDir: projectDir,
+      dryRun: dryRun,
+    );
+
+    _printMigrationResult(migrationResult, dryRun, verbose);
+  }
+
+  Future<void> _migrateDi(String projectDir, bool dryRun, bool verbose) async {
+    print('Scanning for manual get_it DI registrations...');
+
+    final detector = ManualDiDetector();
+    final result = await detector.detect(projectDir);
+
+    if (!result.hasFindings) {
+      print('No manual get_it registrations found. Nothing to migrate.');
+      return;
+    }
+
+    print('Found ${result.findings.length} registration(s):');
+    for (final f in result.findings) {
+      print('  ${f.filePath}:${f.line} -- ${f.message}');
+    }
+    print('');
+
+    print('DI migration is currently detection-only.');
+    print('Manual steps required:');
+    print('  1. Add @Datasource annotation to datasource classes');
+    print('  2. Add @Repository annotation to repository implementations');
+    print('  3. Remove manual getIt.registerXXX calls');
+    print('  4. Use constructor injection in consumers');
+    if (dryRun) {
+      print('');
+      print('Dry-run mode -- no files modified.');
+    }
+  }
+
+  void _printMigrationResult(MigrationResult result, bool dryRun, bool verbose) {
+    if (result.actions.isEmpty) {
+      print('No actions taken.');
+      return;
+    }
+
+    print('Migration result:');
+    if (result.filesCreated > 0) {
+      print('  Created: ${result.filesCreated} file(s)');
+    }
+    if (result.filesModified > 0) {
+      print('  Modified: ${result.filesModified} file(s)');
+    }
+    if (result.filesDeleted > 0) {
+      print('  Deleted: ${result.filesDeleted} file(s)');
+    }
+    print('');
+
+    if (verbose || dryRun) {
+      for (final action in result.actions) {
+        final tag = action.action == 'created' ? '[created]' :
+                     action.action == 'modified' ? '[modified]' : '[deleted]';
+        print('  $tag ${action.filePath}');
+        print('    ${action.description}');
+      }
+      print('');
+    }
+
+    if (dryRun) {
+      print('Dry-run complete. Re-run without --dry-run to apply.');
+    } else {
+      print('Migration complete. Review generated files and update references.');
+      print('Run `dart analyze` to verify no regressions.');
+    }
+  }
+
+  void _printUsage() {
+    print('USAGE: zfa migrate <target> [options]');
+    print('');
+    print('TARGETS:');
+    print('  state   Migrate v5 mixed .state.dart files to v6 DomainState + ViewState');
+    print('  gql     Migrate v5 const-string GraphQL documents to .graphql files');
+    print('  di      Detect manual get_it registrations (detection-only, manual fix)');
+    print('');
+    print('OPTIONS:');
+    print('  --dry-run   Preview changes without writing files');
+    print('  -v, --verbose  Show detailed output');
+    print('');
+    print('EXAMPLES:');
+    print('  zfa migrate state              # Migrate all mixed state files');
+    print('  zfa migrate state --dry-run    # Preview state migration');
+    print('  zfa migrate gql --verbose      # Migrate GQL with details');
+    print('  zfa migrate di                 # Detect manual DI patterns');
+  }
+}

--- a/lib/src/migration/detectors/base_detector.dart
+++ b/lib/src/migration/detectors/base_detector.dart
@@ -1,0 +1,50 @@
+import 'dart:io';
+import 'package:meta/meta.dart';
+
+import '../migration_models.dart';
+
+/// Base class for all v5 pattern detectors.
+///
+/// Subclasses scan the project tree for specific v5 patterns and
+/// return a [DetectorResult] with any findings.
+abstract class MigrationDetector {
+  String get detectorId;
+
+  String get displayName;
+
+  Future<DetectorResult> detect(String projectDir);
+
+  List<String> get globs;
+
+  bool shouldScan(String relativePath) {
+    for (final pattern in globs) {
+      if (_matchesGlob(relativePath, pattern)) return true;
+    }
+    return false;
+  }
+
+  static bool _matchesGlob(String path, String pattern) {
+    final p = path.replaceAll('\\', '/');
+    final pat = pattern.replaceAll('\\', '/');
+    if (pat == '**' || pat == '*') return true;
+    if (pat.startsWith('**/')) {
+      return p.endsWith(pat.substring(3)) || p.contains(pat.substring(2));
+    }
+    if (pat.endsWith('/**')) {
+      return p.startsWith(pat.substring(0, pat.length - 3));
+    }
+    return p == pat ||
+        (p.startsWith(pat) && p.length > pat.length && p[pat.length] == '/');
+  }
+
+  @protected
+  String? readFile(String absolutePath) {
+    final file = File(absolutePath);
+    if (!file.existsSync()) return null;
+    try {
+      return file.readAsStringSync();
+    } on FileSystemException {
+      return null;
+    }
+  }
+}

--- a/lib/src/migration/detectors/base_detector.dart
+++ b/lib/src/migration/detectors/base_detector.dart
@@ -1,5 +1,7 @@
 import 'dart:io';
 import 'package:meta/meta.dart';
+import 'package:glob/glob.dart';
+import 'package:path/path.dart' as p;
 
 import '../migration_models.dart';
 
@@ -24,17 +26,10 @@ abstract class MigrationDetector {
   }
 
   static bool _matchesGlob(String path, String pattern) {
-    final p = path.replaceAll('\\', '/');
-    final pat = pattern.replaceAll('\\', '/');
-    if (pat == '**' || pat == '*') return true;
-    if (pat.startsWith('**/')) {
-      return p.endsWith(pat.substring(3)) || p.contains(pat.substring(2));
-    }
-    if (pat.endsWith('/**')) {
-      return p.startsWith(pat.substring(0, pat.length - 3));
-    }
-    return p == pat ||
-        (p.startsWith(pat) && p.length > pat.length && p[pat.length] == '/');
+    final normalizedPath = path.replaceAll('\\', '/');
+    final normalizedPattern = pattern.replaceAll('\\', '/');
+    final glob = Glob(normalizedPattern);
+    return glob.matches(normalizedPath);
   }
 
   @protected
@@ -46,5 +41,22 @@ abstract class MigrationDetector {
     } on FileSystemException {
       return null;
     }
+  }
+
+  @protected
+  String relativePathOf(String absolute, String base) {
+    final abs = absolute.replaceAll('\\', '/');
+    final b = base.replaceAll('\\', '/');
+    if (abs.startsWith(b)) {
+      var rel = abs.substring(b.length);
+      while (rel.startsWith('/')) rel = rel.substring(1);
+      return rel;
+    }
+    return absolute;
+  }
+
+  @protected
+  int lineNumberAt(String content, int offset) {
+    return '\n'.allMatches(content.substring(0, offset)).length + 1;
   }
 }

--- a/lib/src/migration/detectors/controlled_widget_detector.dart
+++ b/lib/src/migration/detectors/controlled_widget_detector.dart
@@ -1,0 +1,71 @@
+import 'dart:io';
+
+import 'base_detector.dart';
+import '../migration_models.dart';
+
+/// Detects usage of the legacy `ControlledWidget` base class.
+class ControlledWidgetDetector extends MigrationDetector {
+  @override
+  String get detectorId => 'v5_controlled_widget';
+
+  @override
+  String get displayName => 'Legacy ControlledWidget usage';
+
+  @override
+  List<String> get globs => ['lib/**/*.dart'];
+
+  static final _extendsPattern = RegExp(
+    r'extends\s+ControlledWidget\b',
+  );
+
+  @override
+  Future<DetectorResult> detect(String projectDir) async {
+    final findings = <MigrationFinding>[];
+    final libDir = Directory('$projectDir/lib');
+    if (!libDir.existsSync()) {
+      return DetectorResult(detectorId: detectorId, findings: findings);
+    }
+
+    await for (final entity in libDir.list(recursive: true, followLinks: false)) {
+      if (entity is! File || !entity.path.endsWith('.dart')) continue;
+      if (entity.path.contains('.g.dart') || entity.path.contains('.freezed.dart')) {
+        continue;
+      }
+
+      final relativePath = _relative(entity.path, projectDir);
+      if (!shouldScan(relativePath)) continue;
+
+      final content = readFile(entity.path);
+      if (content == null) continue;
+
+      for (final match in _extendsPattern.allMatches(content)) {
+        final line = _lineNumber(content, match.start);
+        findings.add(MigrationFinding(
+          message: 'Class extends legacy ControlledWidget',
+          filePath: relativePath,
+          line: line,
+          ruleId: 'v5_controlled_widget',
+          severity: MigrationSeverity.info,
+          suggestion: 'Migrate to ControlledWidgetBuilder for fine-grained rebuilds',
+        ));
+      }
+    }
+
+    return DetectorResult(detectorId: detectorId, findings: findings);
+  }
+
+  String _relative(String absolute, String base) {
+    final abs = absolute.replaceAll(r'\', '/');
+    final b = base.replaceAll(r'\', '/');
+    if (abs.startsWith(b)) {
+      var rel = abs.substring(b.length);
+      while (rel.startsWith('/')) rel = rel.substring(1);
+      return rel;
+    }
+    return absolute;
+  }
+
+  int _lineNumber(String content, int offset) {
+    return '\n'.allMatches(content.substring(0, offset)).length + 1;
+  }
+}

--- a/lib/src/migration/detectors/controlled_widget_detector.dart
+++ b/lib/src/migration/detectors/controlled_widget_detector.dart
@@ -32,14 +32,14 @@ class ControlledWidgetDetector extends MigrationDetector {
         continue;
       }
 
-      final relativePath = _relative(entity.path, projectDir);
+      final relativePath = relativePathOf(entity.path, projectDir);
       if (!shouldScan(relativePath)) continue;
 
       final content = readFile(entity.path);
       if (content == null) continue;
 
       for (final match in _extendsPattern.allMatches(content)) {
-        final line = _lineNumber(content, match.start);
+        final line = lineNumberAt(content, match.start);
         findings.add(MigrationFinding(
           message: 'Class extends legacy ControlledWidget',
           filePath: relativePath,
@@ -52,20 +52,5 @@ class ControlledWidgetDetector extends MigrationDetector {
     }
 
     return DetectorResult(detectorId: detectorId, findings: findings);
-  }
-
-  String _relative(String absolute, String base) {
-    final abs = absolute.replaceAll(r'\', '/');
-    final b = base.replaceAll(r'\', '/');
-    if (abs.startsWith(b)) {
-      var rel = abs.substring(b.length);
-      while (rel.startsWith('/')) rel = rel.substring(1);
-      return rel;
-    }
-    return absolute;
-  }
-
-  int _lineNumber(String content, int offset) {
-    return '\n'.allMatches(content.substring(0, offset)).length + 1;
   }
 }

--- a/lib/src/migration/detectors/dependency_overrides_detector.dart
+++ b/lib/src/migration/detectors/dependency_overrides_detector.dart
@@ -1,0 +1,86 @@
+import 'dart:io';
+
+import 'base_detector.dart';
+import '../migration_models.dart';
+
+/// Detects `dependency_overrides` in `pubspec.yaml` that are v5-specific.
+class DependencyOverridesDetector extends MigrationDetector {
+  @override
+  String get detectorId => 'v5_dependency_overrides';
+
+  @override
+  String get displayName => 'v5 dependency_overrides in pubspec.yaml';
+
+  @override
+  List<String> get globs => ['pubspec.yaml'];
+
+  @override
+  Future<DetectorResult> detect(String projectDir) async {
+    final findings = <MigrationFinding>[];
+    final pubspecFile = File('$projectDir/pubspec.yaml');
+    if (!pubspecFile.existsSync()) {
+      return DetectorResult(detectorId: detectorId, findings: findings);
+    }
+
+    final content = readFile(pubspecFile.path);
+    if (content == null) {
+      return DetectorResult(detectorId: detectorId, findings: findings);
+    }
+
+    final inDepOverrides = _findDependencyOverridesSection(content);
+    if (inDepOverrides == null) {
+      return DetectorResult(detectorId: detectorId, findings: findings);
+    }
+
+    final sectionStart = content.indexOf(inDepOverrides);
+    final sectionLines = inDepOverrides.split('\n');
+    for (int i = 0; i < sectionLines.length; i++) {
+      final line = sectionLines[i].trim();
+      if (line.isEmpty || line.startsWith('#')) continue;
+
+      final overrideMatch = RegExp(r'^(\w[\w-]*):\s*(.+)').firstMatch(line);
+      if (overrideMatch != null) {
+        final package = overrideMatch.group(1)!;
+        final version = overrideMatch.group(2)!.trim();
+
+        if (package == 'analyzer') {
+          findings.add(MigrationFinding(
+            message: 'dependency_overrides: analyzer: $version is a v5 zorphy 1.x workaround',
+            filePath: 'pubspec.yaml',
+            line: _lineNumber(content, sectionStart) + i + 1,
+            ruleId: 'v5_dependency_overrides',
+            severity: MigrationSeverity.warning,
+            suggestion: 'Remove if zorphy 2.0 is in use',
+          ));
+        } else {
+          findings.add(MigrationFinding(
+            message: 'dependency_overrides: $package: $version',
+            filePath: 'pubspec.yaml',
+            line: _lineNumber(content, sectionStart) + i + 1,
+            ruleId: 'v5_dependency_overrides',
+            severity: MigrationSeverity.info,
+          ));
+        }
+      }
+    }
+
+    return DetectorResult(detectorId: detectorId, findings: findings);
+  }
+
+  String? _findDependencyOverridesSection(String content) {
+    final match = RegExp(
+      r'^dependency_overrides:\s*$',
+      multiLine: true,
+    ).firstMatch(content);
+    if (match == null) return null;
+
+    final after = content.substring(match.end);
+    final endMatch = RegExp(r'^\S', multiLine: true).firstMatch(after);
+    if (endMatch == null) return after.trimRight();
+    return after.substring(0, endMatch.start).trimRight();
+  }
+
+  int _lineNumber(String content, int offset) {
+    return '\n'.allMatches(content.substring(0, offset)).length + 1;
+  }
+}

--- a/lib/src/migration/detectors/dependency_overrides_detector.dart
+++ b/lib/src/migration/detectors/dependency_overrides_detector.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'package:yaml/yaml.dart';
 
 import 'base_detector.dart';
 import '../migration_models.dart';
@@ -27,47 +28,73 @@ class DependencyOverridesDetector extends MigrationDetector {
       return DetectorResult(detectorId: detectorId, findings: findings);
     }
 
-    final inDepOverrides = _findDependencyOverridesSection(content);
-    if (inDepOverrides == null) {
+    final sectionInfo = _findDependencyOverridesSection(content);
+    if (sectionInfo == null) {
       return DetectorResult(detectorId: detectorId, findings: findings);
     }
 
-    final sectionStart = content.indexOf(inDepOverrides);
-    final sectionLines = inDepOverrides.split('\n');
-    for (int i = 0; i < sectionLines.length; i++) {
-      final line = sectionLines[i].trim();
-      if (line.isEmpty || line.startsWith('#')) continue;
+    try {
+      final yaml = loadYaml(content) as YamlMap;
+      final depOverrides = yaml['dependency_overrides'];
+      if (depOverrides is! YamlMap) {
+        return DetectorResult(detectorId: detectorId, findings: findings);
+      }
 
-      final overrideMatch = RegExp(r'^(\w[\w-]*):\s*(.+)').firstMatch(line);
-      if (overrideMatch != null) {
-        final package = overrideMatch.group(1)!;
-        final version = overrideMatch.group(2)!.trim();
+      for (final entry in depOverrides.entries) {
+        final package = entry.key.toString();
+        final value = entry.value;
+
+        // Determine display value
+        String displayValue;
+        if (value is String) {
+          displayValue = value;
+        } else if (value is YamlMap) {
+          if (value.containsKey('path')) {
+            displayValue = 'path: ${value['path']}';
+          } else if (value.containsKey('git')) {
+            displayValue = 'git: ${value['git']}';
+          } else {
+            displayValue = value.toString();
+          }
+        } else {
+          displayValue = value.toString();
+        }
+
+        // Find the line number for this package key
+        final packagePattern = RegExp('^\\s*${RegExp.escape(package)}:\\s*', multiLine: true);
+        final packageMatch = packagePattern.firstMatch(content.substring(sectionInfo.offset));
+        final line = packageMatch != null
+            ? lineNumberAt(content, sectionInfo.offset + packageMatch.start)
+            : lineNumberAt(content, sectionInfo.offset);
 
         if (package == 'analyzer') {
           findings.add(MigrationFinding(
-            message: 'dependency_overrides: analyzer: $version is a v5 zorphy 1.x workaround',
+            message: 'dependency_overrides: analyzer: $displayValue is a v5 zorphy 1.x workaround',
             filePath: 'pubspec.yaml',
-            line: _lineNumber(content, sectionStart) + i + 1,
+            line: line,
             ruleId: 'v5_dependency_overrides',
             severity: MigrationSeverity.warning,
             suggestion: 'Remove if zorphy 2.0 is in use',
           ));
         } else {
           findings.add(MigrationFinding(
-            message: 'dependency_overrides: $package: $version',
+            message: 'dependency_overrides: $package: $displayValue',
             filePath: 'pubspec.yaml',
-            line: _lineNumber(content, sectionStart) + i + 1,
+            line: line,
             ruleId: 'v5_dependency_overrides',
             severity: MigrationSeverity.info,
           ));
         }
       }
+    } catch (e) {
+      // If YAML parsing fails, return empty findings
+      return DetectorResult(detectorId: detectorId, findings: findings);
     }
 
     return DetectorResult(detectorId: detectorId, findings: findings);
   }
 
-  String? _findDependencyOverridesSection(String content) {
+  _Section? _findDependencyOverridesSection(String content) {
     final match = RegExp(
       r'^dependency_overrides:\s*$',
       multiLine: true,
@@ -76,11 +103,17 @@ class DependencyOverridesDetector extends MigrationDetector {
 
     final after = content.substring(match.end);
     final endMatch = RegExp(r'^\S', multiLine: true).firstMatch(after);
-    if (endMatch == null) return after.trimRight();
-    return after.substring(0, endMatch.start).trimRight();
-  }
 
-  int _lineNumber(String content, int offset) {
-    return '\n'.allMatches(content.substring(0, offset)).length + 1;
+    final sectionText = endMatch == null
+        ? after.trimRight()
+        : after.substring(0, endMatch.start).trimRight();
+
+    return _Section(text: sectionText, offset: match.end);
   }
+}
+
+class _Section {
+  final String text;
+  final int offset;
+  const _Section({required this.text, required this.offset});
 }

--- a/lib/src/migration/detectors/di_detector.dart
+++ b/lib/src/migration/detectors/di_detector.dart
@@ -1,0 +1,104 @@
+import 'dart:io';
+
+import 'base_detector.dart';
+import '../migration_models.dart';
+
+/// Detects manual `get_it` registration patterns that should use
+/// `@Datasource` / `@Repository` annotations in v6.
+class ManualDiDetector extends MigrationDetector {
+  @override
+  String get detectorId => 'v5_manual_di';
+
+  @override
+  String get displayName => 'Manual get_it DI registrations';
+
+  @override
+  List<String> get globs => ['lib/**/*.dart'];
+
+  static final _getItRegisterPattern = RegExp(
+    r'getIt\.(registerLazySingleton|registerSingleton|registerFactory|registerLazyFactory)\s*<',
+  );
+
+  static final _locatorRegisterPattern = RegExp(
+    r'locator\.(registerLazySingleton|registerSingleton|registerFactory|registerLazyFactory)\s*<',
+  );
+
+  static final _getItInstancePattern = RegExp(
+    r'GetIt\.instance(?:<[^>]+>)?',
+  );
+
+  @override
+  Future<DetectorResult> detect(String projectDir) async {
+    final findings = <MigrationFinding>[];
+    final libDir = Directory('$projectDir/lib');
+    if (!libDir.existsSync()) {
+      return DetectorResult(detectorId: detectorId, findings: findings);
+    }
+
+    await for (final entity in libDir.list(recursive: true, followLinks: false)) {
+      if (entity is! File || !entity.path.endsWith('.dart')) continue;
+      if (entity.path.contains('.g.dart') || entity.path.contains('.freezed.dart')) {
+        continue;
+      }
+
+      final relativePath = _relative(entity.path, projectDir);
+      if (!shouldScan(relativePath)) continue;
+
+      final content = readFile(entity.path);
+      if (content == null) continue;
+
+      for (final match in _getItRegisterPattern.allMatches(content)) {
+        final line = _lineNumber(content, match.start);
+        findings.add(MigrationFinding(
+          message: 'Manual getIt registration found',
+          filePath: relativePath,
+          line: line,
+          ruleId: 'v5_manual_di',
+          severity: MigrationSeverity.info,
+          suggestion: 'Consider using @Datasource/@Repository annotations',
+        ));
+      }
+
+      for (final match in _locatorRegisterPattern.allMatches(content)) {
+        final line = _lineNumber(content, match.start);
+        findings.add(MigrationFinding(
+          message: 'Manual locator registration found',
+          filePath: relativePath,
+          line: line,
+          ruleId: 'v5_manual_di',
+          severity: MigrationSeverity.info,
+          suggestion: 'Consider using @Datasource/@Repository annotations',
+        ));
+      }
+
+      for (final match in _getItInstancePattern.allMatches(content)) {
+        final line = _lineNumber(content, match.start);
+        findings.add(MigrationFinding(
+          message: 'GetIt.instance service location call found',
+          filePath: relativePath,
+          line: line,
+          ruleId: 'v5_manual_di',
+          severity: MigrationSeverity.info,
+          suggestion: 'In v6, prefer constructor injection over service location',
+        ));
+      }
+    }
+
+    return DetectorResult(detectorId: detectorId, findings: findings);
+  }
+
+  String _relative(String absolute, String base) {
+    final abs = absolute.replaceAll(r'\', '/');
+    final b = base.replaceAll(r'\', '/');
+    if (abs.startsWith(b)) {
+      var rel = abs.substring(b.length);
+      while (rel.startsWith('/')) rel = rel.substring(1);
+      return rel;
+    }
+    return absolute;
+  }
+
+  int _lineNumber(String content, int offset) {
+    return '\n'.allMatches(content.substring(0, offset)).length + 1;
+  }
+}

--- a/lib/src/migration/detectors/di_detector.dart
+++ b/lib/src/migration/detectors/di_detector.dart
@@ -41,14 +41,14 @@ class ManualDiDetector extends MigrationDetector {
         continue;
       }
 
-      final relativePath = _relative(entity.path, projectDir);
+      final relativePath = relativePathOf(entity.path, projectDir);
       if (!shouldScan(relativePath)) continue;
 
       final content = readFile(entity.path);
       if (content == null) continue;
 
       for (final match in _getItRegisterPattern.allMatches(content)) {
-        final line = _lineNumber(content, match.start);
+        final line = lineNumberAt(content, match.start);
         findings.add(MigrationFinding(
           message: 'Manual getIt registration found',
           filePath: relativePath,
@@ -60,7 +60,7 @@ class ManualDiDetector extends MigrationDetector {
       }
 
       for (final match in _locatorRegisterPattern.allMatches(content)) {
-        final line = _lineNumber(content, match.start);
+        final line = lineNumberAt(content, match.start);
         findings.add(MigrationFinding(
           message: 'Manual locator registration found',
           filePath: relativePath,
@@ -72,7 +72,7 @@ class ManualDiDetector extends MigrationDetector {
       }
 
       for (final match in _getItInstancePattern.allMatches(content)) {
-        final line = _lineNumber(content, match.start);
+        final line = lineNumberAt(content, match.start);
         findings.add(MigrationFinding(
           message: 'GetIt.instance service location call found',
           filePath: relativePath,
@@ -85,20 +85,5 @@ class ManualDiDetector extends MigrationDetector {
     }
 
     return DetectorResult(detectorId: detectorId, findings: findings);
-  }
-
-  String _relative(String absolute, String base) {
-    final abs = absolute.replaceAll(r'\', '/');
-    final b = base.replaceAll(r'\', '/');
-    if (abs.startsWith(b)) {
-      var rel = abs.substring(b.length);
-      while (rel.startsWith('/')) rel = rel.substring(1);
-      return rel;
-    }
-    return absolute;
-  }
-
-  int _lineNumber(String content, int offset) {
-    return '\n'.allMatches(content.substring(0, offset)).length + 1;
   }
 }

--- a/lib/src/migration/detectors/gql_detector.dart
+++ b/lib/src/migration/detectors/gql_detector.dart
@@ -1,0 +1,70 @@
+import 'dart:io';
+
+import 'base_detector.dart';
+import '../migration_models.dart';
+
+/// Detects v5-style const-string GraphQL documents in Dart source files.
+class GqlConstStringDetector extends MigrationDetector {
+  @override
+  String get detectorId => 'v5_gql_const_string';
+
+  @override
+  String get displayName => 'GraphQL const-string documents';
+
+  @override
+  List<String> get globs => ['lib/**/*.dart'];
+
+  /// Pattern: gql() function calls.
+  static final _gqlCallPattern = RegExp(r'gql\s*\(');
+
+  @override
+  Future<DetectorResult> detect(String projectDir) async {
+    final findings = <MigrationFinding>[];
+    final libDir = Directory('projectDir' + '/lib');
+    if (!libDir.existsSync()) {
+      return DetectorResult(detectorId: detectorId, findings: findings);
+    }
+
+    await for (final entity in libDir.list(recursive: true, followLinks: false)) {
+      if (entity is! File || !entity.path.endsWith('.dart')) continue;
+      if (entity.path.contains('.g.dart') || entity.path.contains('.freezed.dart')) {
+        continue;
+      }
+
+      final relativePath = _relative(entity.path, projectDir);
+      if (!shouldScan(relativePath)) continue;
+
+      final content = readFile(entity.path);
+      if (content == null) continue;
+
+      for (final match in _gqlCallPattern.allMatches(content)) {
+        final line = _lineNumber(content, match.start);
+        findings.add(MigrationFinding(
+          message: 'GraphQL document defined as inline Dart string via gql() call',
+          filePath: relativePath,
+          line: line,
+          ruleId: 'v5_gql_const_string',
+          severity: MigrationSeverity.warning,
+          suggestion: 'Extract to a .graphql file and use zfa migrate gql',
+        ));
+      }
+    }
+
+    return DetectorResult(detectorId: detectorId, findings: findings);
+  }
+
+  String _relative(String absolute, String base) {
+    final abs = absolute.replaceAll('\\', '/');
+    final b = base.replaceAll('\\', '/');
+    if (abs.startsWith(b)) {
+      var rel = abs.substring(b.length);
+      while (rel.startsWith('/')) rel = rel.substring(1);
+      return rel;
+    }
+    return absolute;
+  }
+
+  int _lineNumber(String content, int offset) {
+    return '\n'.allMatches(content.substring(0, offset)).length + 1;
+  }
+}

--- a/lib/src/migration/detectors/gql_detector.dart
+++ b/lib/src/migration/detectors/gql_detector.dart
@@ -20,7 +20,7 @@ class GqlConstStringDetector extends MigrationDetector {
   @override
   Future<DetectorResult> detect(String projectDir) async {
     final findings = <MigrationFinding>[];
-    final libDir = Directory('projectDir' + '/lib');
+    final libDir = Directory('$projectDir/lib');
     if (!libDir.existsSync()) {
       return DetectorResult(detectorId: detectorId, findings: findings);
     }
@@ -31,14 +31,14 @@ class GqlConstStringDetector extends MigrationDetector {
         continue;
       }
 
-      final relativePath = _relative(entity.path, projectDir);
+      final relativePath = relativePathOf(entity.path, projectDir);
       if (!shouldScan(relativePath)) continue;
 
       final content = readFile(entity.path);
       if (content == null) continue;
 
       for (final match in _gqlCallPattern.allMatches(content)) {
-        final line = _lineNumber(content, match.start);
+        final line = lineNumberAt(content, match.start);
         findings.add(MigrationFinding(
           message: 'GraphQL document defined as inline Dart string via gql() call',
           filePath: relativePath,
@@ -51,20 +51,5 @@ class GqlConstStringDetector extends MigrationDetector {
     }
 
     return DetectorResult(detectorId: detectorId, findings: findings);
-  }
-
-  String _relative(String absolute, String base) {
-    final abs = absolute.replaceAll('\\', '/');
-    final b = base.replaceAll('\\', '/');
-    if (abs.startsWith(b)) {
-      var rel = abs.substring(b.length);
-      while (rel.startsWith('/')) rel = rel.substring(1);
-      return rel;
-    }
-    return absolute;
-  }
-
-  int _lineNumber(String content, int offset) {
-    return '\n'.allMatches(content.substring(0, offset)).length + 1;
   }
 }

--- a/lib/src/migration/detectors/state_detector.dart
+++ b/lib/src/migration/detectors/state_detector.dart
@@ -1,0 +1,150 @@
+import 'dart:io';
+
+import 'base_detector.dart';
+import '../migration_models.dart';
+
+/// Detects v5-style mixed state classes that lack the v6 DomainState/ViewState split.
+///
+/// v5 pattern: A single `XxxState` class with both domain data fields
+/// (entity references) and UI state fields (isLoading, error).
+/// v6 pattern: `XxxDomainState` (data only, bound to UseCase slices) +
+/// `XxxViewState` (transient UI state: tabs, scroll position).
+class StateDetector extends MigrationDetector {
+  @override
+  String get detectorId => 'v5_mixed_state';
+
+  @override
+  String get displayName => 'Mixed state (needs DomainState + ViewState split)';
+
+  @override
+  List<String> get globs => ['lib/**/*_state.dart'];
+
+  @override
+  Future<DetectorResult> detect(String projectDir) async {
+    final findings = <MigrationFinding>[];
+    final libDir = Directory('$projectDir/lib');
+    if (!libDir.existsSync()) {
+      return DetectorResult(detectorId: detectorId, findings: findings);
+    }
+
+    await for (final entity in libDir.list(recursive: true, followLinks: false)) {
+      if (entity is! File) continue;
+      if (!entity.path.endsWith('_state.dart')) continue;
+      if (entity.path.contains('domain_state') || entity.path.contains('view_state')) {
+        continue;
+      }
+      if (entity.path.contains('.g.dart') || entity.path.contains('.freezed.dart')) {
+        continue;
+      }
+
+      final relativePath = _relative(entity.path, projectDir);
+      final content = readFile(entity.path);
+      if (content == null) continue;
+
+      final analysis = _analyzeStateFile(content);
+      if (analysis.needsMigration) {
+        findings.add(MigrationFinding(
+          message: 'Mixed state class `${analysis.className}` contains both domain data '
+              '(${analysis.domainFieldCount} fields) and UI state '
+              '(${analysis.uiFieldCount} fields). Consider splitting into '
+              'DomainState + ViewState for v6.',
+          filePath: relativePath,
+          line: analysis.classLine,
+          ruleId: 'v5_mixed_state',
+          severity: MigrationSeverity.warning,
+          suggestion: 'Run `zfa migrate state` to generate DomainState + ViewState',
+        ));
+      }
+    }
+
+    return DetectorResult(detectorId: detectorId, findings: findings);
+  }
+
+  _StateAnalysis _analyzeStateFile(String content) {
+    String? className;
+    int classLine = 0;
+    int domainFieldCount = 0;
+    int uiFieldCount = 0;
+
+    final classMatch = RegExp(r'class\s+(\w+State)\b').firstMatch(content);
+    if (classMatch != null) {
+      className = classMatch.group(1);
+      classLine = _lineNumber(content, classMatch.start);
+    }
+
+    if (className == null) {
+      return _StateAnalysis(
+        className: '<unknown>',
+        classLine: 0,
+        domainFieldCount: 0,
+        uiFieldCount: 0,
+        needsMigration: false,
+      );
+    }
+
+    for (final line in content.split('\n')) {
+      final trimmed = line.trim();
+      final fieldMatch = RegExp(
+        r'^(?:final\s+)?(\w+(?:<[^>]+>)?)\s+(\w+)\s*[;=]'
+      ).firstMatch(trimmed);
+      if (fieldMatch == null) continue;
+
+      final type = fieldMatch.group(1)!;
+      final name = fieldMatch.group(2)!;
+      if (name.startsWith('_')) continue;
+
+      if (_isUiField(type, name)) {
+        uiFieldCount++;
+      } else {
+        domainFieldCount++;
+      }
+    }
+
+    return _StateAnalysis(
+      className: className,
+      classLine: classLine,
+      domainFieldCount: domainFieldCount,
+      uiFieldCount: uiFieldCount,
+      needsMigration: domainFieldCount > 0 && uiFieldCount > 0,
+    );
+  }
+
+  bool _isUiField(String type, String name) {
+    if ((type == 'bool' || type == 'bool?') && (name.startsWith('is') || name.startsWith('has'))) return true;
+    if (name == 'error' || type == 'AppFailure?' || type == 'AppFailure') return true;
+    if (name == 'isLoading' || name == 'isRefreshing') return true;
+    if (name == 'offset' || name == 'limit' || name == 'hasMore') return true;
+    return false;
+  }
+
+  String _relative(String absolute, String base) {
+    final abs = absolute.replaceAll(r'\', '/');
+    final b = base.replaceAll(r'\', '/');
+    if (abs.startsWith(b)) {
+      var rel = abs.substring(b.length);
+      while (rel.startsWith('/')) rel = rel.substring(1);
+      return rel;
+    }
+    return absolute;
+  }
+
+  int _lineNumber(String content, int offset) {
+    return '\n'.allMatches(content.substring(0, offset)).length + 1;
+  }
+}
+
+class _StateAnalysis {
+  final String className;
+  final int classLine;
+  final int domainFieldCount;
+  final int uiFieldCount;
+  final bool needsMigration;
+
+  const _StateAnalysis({
+    required this.className,
+    required this.classLine,
+    required this.domainFieldCount,
+    required this.uiFieldCount,
+    required this.needsMigration,
+  });
+}

--- a/lib/src/migration/detectors/state_detector.dart
+++ b/lib/src/migration/detectors/state_detector.dart
@@ -37,7 +37,7 @@ class StateDetector extends MigrationDetector {
         continue;
       }
 
-      final relativePath = _relative(entity.path, projectDir);
+      final relativePath = relativePathOf(entity.path, projectDir);
       final content = readFile(entity.path);
       if (content == null) continue;
 
@@ -69,7 +69,7 @@ class StateDetector extends MigrationDetector {
     final classMatch = RegExp(r'class\s+(\w+State)\b').firstMatch(content);
     if (classMatch != null) {
       className = classMatch.group(1);
-      classLine = _lineNumber(content, classMatch.start);
+      classLine = lineNumberAt(content, classMatch.start);
     }
 
     if (className == null) {
@@ -85,7 +85,7 @@ class StateDetector extends MigrationDetector {
     for (final line in content.split('\n')) {
       final trimmed = line.trim();
       final fieldMatch = RegExp(
-        r'^(?:final\s+)?(\w+(?:<[^>]+>)?)\s+(\w+)\s*[;=]'
+        r'^(?:final\s+)?([\w<>?]+)\s+(\w+)\s*[;=]'
       ).firstMatch(trimmed);
       if (fieldMatch == null) continue;
 
@@ -115,21 +115,6 @@ class StateDetector extends MigrationDetector {
     if (name == 'isLoading' || name == 'isRefreshing') return true;
     if (name == 'offset' || name == 'limit' || name == 'hasMore') return true;
     return false;
-  }
-
-  String _relative(String absolute, String base) {
-    final abs = absolute.replaceAll(r'\', '/');
-    final b = base.replaceAll(r'\', '/');
-    if (abs.startsWith(b)) {
-      var rel = abs.substring(b.length);
-      while (rel.startsWith('/')) rel = rel.substring(1);
-      return rel;
-    }
-    return absolute;
-  }
-
-  int _lineNumber(String content, int offset) {
-    return '\n'.allMatches(content.substring(0, offset)).length + 1;
   }
 }
 

--- a/lib/src/migration/fixers/base_fixer.dart
+++ b/lib/src/migration/fixers/base_fixer.dart
@@ -1,0 +1,17 @@
+import '../migration_models.dart';
+
+/// Base class for migration fixers.
+abstract class MigrationFixer {
+  /// Machine-readable ID, should match the detector ID it handles.
+  String get migratorId;
+
+  /// Human-readable name.
+  String get displayName;
+
+  /// Run the migration.
+  Future<MigrationResult> migrate({
+    required List<MigrationFinding> findings,
+    required String projectDir,
+    bool dryRun = false,
+  });
+}

--- a/lib/src/migration/fixers/gql_fixer.dart
+++ b/lib/src/migration/fixers/gql_fixer.dart
@@ -21,12 +21,17 @@ class GqlMigrator extends MigrationFixer {
     final actions = <MigrationAction>[];
     final remaining = <MigrationFinding>[];
 
+    // Deduplicate findings by filePath
+    final findingsByFile = <String, MigrationFinding>{};
     for (final finding in findings) {
       if (finding.ruleId != 'v5_gql_const_string') {
         remaining.add(finding);
         continue;
       }
+      findingsByFile[finding.filePath] = finding;
+    }
 
+    for (final finding in findingsByFile.values) {
       final filePath = p.join(projectDir, finding.filePath);
       if (!File(filePath).existsSync()) {
         remaining.add(finding);
@@ -34,6 +39,12 @@ class GqlMigrator extends MigrationFixer {
       }
 
       final content = File(filePath).readAsStringSync();
+
+      // Check if already migrated
+      if (content.startsWith('// NOTE: GraphQL documents have been migrated to .graphql files.')) {
+        continue;
+      }
+
       final extracted = _extractGqlDocuments(content);
       if (extracted.isEmpty) {
         remaining.add(finding);
@@ -43,11 +54,23 @@ class GqlMigrator extends MigrationFixer {
       final fileDir = p.dirname(filePath);
       final graphqlDir = p.join(fileDir, 'graphql');
 
+      final usedNames = <String>{};
       for (final doc in extracted) {
-        final opName = doc.operationName.toLowerCase();
-        final graphqlPath = p.join(graphqlDir, opName + '.graphql');
+        var opName = doc.operationName.toLowerCase();
+        var targetName = opName;
+        var counter = 1;
+
+        // Detect collisions and choose unique name
+        while (usedNames.contains(targetName) ||
+               File(p.join(graphqlDir, '$targetName.graphql')).existsSync()) {
+          targetName = '${opName}_$counter';
+          counter++;
+        }
+        usedNames.add(targetName);
+
+        final graphqlPath = p.join(graphqlDir, targetName + '.graphql');
         actions.add(MigrationAction(
-          description: 'Extract ' + opName + ' to .graphql file',
+          description: 'Extract ' + targetName + ' to .graphql file',
           filePath: graphqlPath,
           action: 'created',
           newContent: doc.content,
@@ -58,11 +81,13 @@ class GqlMigrator extends MigrationFixer {
         }
       }
 
+      final header =
+          '// NOTE: GraphQL documents have been migrated to .graphql files.\n'
+          '// Run zfa build to regenerate documents.dart.\n\n';
+      final newContent = header + content;
+
       if (!dryRun) {
-        final header =
-            '// NOTE: GraphQL documents have been migrated to .graphql files.\n'
-            '// Run zfa build to regenerate documents.dart.\n\n';
-        File(filePath).writeAsStringSync(header + content);
+        File(filePath).writeAsStringSync(newContent);
       }
 
       actions.add(MigrationAction(
@@ -70,6 +95,7 @@ class GqlMigrator extends MigrationFixer {
         filePath: filePath,
         action: 'modified',
         originalContent: content,
+        newContent: newContent,
       ));
     }
 
@@ -83,29 +109,22 @@ class GqlMigrator extends MigrationFixer {
   List<_GqlDoc> _extractGqlDocuments(String content) {
     final docs = <_GqlDoc>[];
     // Match gql( calls with triple-quoted string arguments
-    final startPattern = RegExp('gql\\s*\\(');
-    final singleQuote3 = RegExp("'''");
-    final doubleQuote3 = RegExp('"""');
+    final startPattern = RegExp(r'gql\s*\(');
 
     for (final startMatch in startPattern.allMatches(content)) {
       final afterStart = startMatch.end;
-      // Determine which quote style is used
+      // Look for optional whitespace and optional 'r' prefix before quotes
       final remaining = content.substring(afterStart);
-      String? quoteStr;
-      int quoteStart = -1;
-      final sq = singleQuote3.firstMatch(remaining);
-      final dq = doubleQuote3.firstMatch(remaining);
-      if (sq != null && (dq == null || sq.start <= dq.start)) {
-        quoteStr = "'''";
-        quoteStart = sq.start;
-      } else if (dq != null) {
-        quoteStr = '"""';
-        quoteStart = dq.start;
-      }
-      if (quoteStr == null) continue;
+      final quotePattern = RegExp(r'^\s*(r)?\s*(\'\'\'|""")');
+      final quoteMatch = quotePattern.firstMatch(remaining);
 
-      final bodyStart = afterStart + quoteStart + 3;
-      final endPattern = RegExp(quoteStr);
+      if (quoteMatch == null) continue;
+
+      final quoteStr = quoteMatch.group(2)!; // ''' or """
+      final bodyStart = afterStart + quoteMatch.end;
+
+      // Find closing triple quote
+      final endPattern = RegExp(RegExp.escape(quoteStr));
       final endMatch = endPattern.firstMatch(content.substring(bodyStart));
       if (endMatch == null) continue;
 

--- a/lib/src/migration/fixers/gql_fixer.dart
+++ b/lib/src/migration/fixers/gql_fixer.dart
@@ -1,0 +1,134 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+import '../migration_models.dart';
+import 'base_fixer.dart';
+
+class GqlMigrator extends MigrationFixer {
+  @override
+  String get migratorId => 'v5_gql_const_string';
+
+  @override
+  String get displayName => 'GQL: v5 const-string to .graphql files';
+
+  @override
+  Future<MigrationResult> migrate({
+    required List<MigrationFinding> findings,
+    required String projectDir,
+    bool dryRun = false,
+  }) async {
+    final actions = <MigrationAction>[];
+    final remaining = <MigrationFinding>[];
+
+    for (final finding in findings) {
+      if (finding.ruleId != 'v5_gql_const_string') {
+        remaining.add(finding);
+        continue;
+      }
+
+      final filePath = p.join(projectDir, finding.filePath);
+      if (!File(filePath).existsSync()) {
+        remaining.add(finding);
+        continue;
+      }
+
+      final content = File(filePath).readAsStringSync();
+      final extracted = _extractGqlDocuments(content);
+      if (extracted.isEmpty) {
+        remaining.add(finding);
+        continue;
+      }
+
+      final fileDir = p.dirname(filePath);
+      final graphqlDir = p.join(fileDir, 'graphql');
+
+      for (final doc in extracted) {
+        final opName = doc.operationName.toLowerCase();
+        final graphqlPath = p.join(graphqlDir, opName + '.graphql');
+        actions.add(MigrationAction(
+          description: 'Extract ' + opName + ' to .graphql file',
+          filePath: graphqlPath,
+          action: 'created',
+          newContent: doc.content,
+        ));
+        if (!dryRun) {
+          Directory(graphqlDir).createSync(recursive: true);
+          File(graphqlPath).writeAsStringSync(doc.content);
+        }
+      }
+
+      if (!dryRun) {
+        final header =
+            '// NOTE: GraphQL documents have been migrated to .graphql files.\n'
+            '// Run zfa build to regenerate documents.dart.\n\n';
+        File(filePath).writeAsStringSync(header + content);
+      }
+
+      actions.add(MigrationAction(
+        description: 'Annotate ' + finding.filePath + ' with migration notice',
+        filePath: filePath,
+        action: 'modified',
+        originalContent: content,
+      ));
+    }
+
+    return MigrationResult(
+      migratorId: migratorId,
+      actions: actions,
+      remaining: remaining,
+    );
+  }
+
+  List<_GqlDoc> _extractGqlDocuments(String content) {
+    final docs = <_GqlDoc>[];
+    // Match gql( calls with triple-quoted string arguments
+    final startPattern = RegExp('gql\\s*\\(');
+    final singleQuote3 = RegExp("'''");
+    final doubleQuote3 = RegExp('"""');
+
+    for (final startMatch in startPattern.allMatches(content)) {
+      final afterStart = startMatch.end;
+      // Determine which quote style is used
+      final remaining = content.substring(afterStart);
+      String? quoteStr;
+      int quoteStart = -1;
+      final sq = singleQuote3.firstMatch(remaining);
+      final dq = doubleQuote3.firstMatch(remaining);
+      if (sq != null && (dq == null || sq.start <= dq.start)) {
+        quoteStr = "'''";
+        quoteStart = sq.start;
+      } else if (dq != null) {
+        quoteStr = '"""';
+        quoteStart = dq.start;
+      }
+      if (quoteStr == null) continue;
+
+      final bodyStart = afterStart + quoteStart + 3;
+      final endPattern = RegExp(quoteStr);
+      final endMatch = endPattern.firstMatch(content.substring(bodyStart));
+      if (endMatch == null) continue;
+
+      final body = content.substring(bodyStart, bodyStart + endMatch.start).trim();
+      final opName = _extractOperationName(body);
+      if (opName != null) {
+        docs.add(_GqlDoc(operationName: opName, content: body));
+      }
+    }
+
+    return docs;
+  }
+
+  String? _extractOperationName(String body) {
+    final match = RegExp(
+      r'(?:query|mutation|subscription)\s+(\w+)',
+    ).firstMatch(body);
+    return match?.group(1);
+  }
+}
+
+class _GqlDoc {
+  final String operationName;
+  final String content;
+  const _GqlDoc({required this.operationName, required this.content});
+}

--- a/lib/src/migration/fixers/state_fixer.dart
+++ b/lib/src/migration/fixers/state_fixer.dart
@@ -1,0 +1,290 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+import '../migration_models.dart';
+import 'base_fixer.dart';
+
+class StateMigrator extends MigrationFixer {
+  @override
+  String get migratorId => 'v5_mixed_state';
+
+  @override
+  String get displayName => 'State: v5 to v6 DomainState + ViewState';
+
+  @override
+  Future<MigrationResult> migrate({
+    required List<MigrationFinding> findings,
+    required String projectDir,
+    bool dryRun = false,
+  }) async {
+    final actions = <MigrationAction>[];
+    final remaining = <MigrationFinding>[];
+
+    for (final finding in findings) {
+      if (finding.ruleId != 'v5_mixed_state') {
+        remaining.add(finding);
+        continue;
+      }
+
+      final filePath = p.join(projectDir, finding.filePath);
+      final file = File(filePath);
+      if (!file.existsSync()) {
+        remaining.add(finding);
+        continue;
+      }
+
+      final content = file.readAsStringSync();
+      final analysis = _analyzeStateFile(content);
+      if (!analysis.needsMigration) {
+        remaining.add(finding);
+        continue;
+      }
+
+      final fileDir = p.dirname(filePath);
+      final baseName = p.basenameWithoutExtension(filePath);
+      final entityName = _extractEntityName(baseName);
+
+      final domainStateContent = _buildDomainState(entityName, analysis.domainFields);
+      final viewStateContent = _buildViewState(entityName, analysis.uiFields);
+
+      final domainStatePath = p.join(fileDir, '${_toSnake(entityName)}_domain_state.dart');
+      final viewStatePath = p.join(fileDir, '${_toSnake(entityName)}_view_state.dart');
+
+      actions.add(MigrationAction(
+        description: 'Create ${p.basename(domainStatePath)} with domain data fields',
+        filePath: domainStatePath,
+        action: 'created',
+        newContent: domainStateContent,
+      ));
+
+      actions.add(MigrationAction(
+        description: 'Create ${p.basename(viewStatePath)} with UI state fields',
+        filePath: viewStatePath,
+        action: 'created',
+        newContent: viewStateContent,
+      ));
+
+      actions.add(MigrationAction(
+        description: 'Annotate ${finding.filePath} as superseded by dual-layer state',
+        filePath: filePath,
+        action: 'modified',
+        originalContent: content,
+        newContent: '// NOTE: This file has been migrated to v6 dual-layer state.\n'
+            '// See: ${p.basename(domainStatePath)} and ${p.basename(viewStatePath)}\n'
+            '// This file can be removed once all references are updated.\n\n'
+            + content,
+      ));
+
+      if (!dryRun) {
+        File(domainStatePath)..createSync(recursive: true)
+          ..writeAsStringSync(domainStateContent);
+        File(viewStatePath)..createSync(recursive: true)
+          ..writeAsStringSync(viewStateContent);
+        file.writeAsStringSync(
+          '// NOTE: This file has been migrated to v6 dual-layer state.\n'
+          '// See: ${p.basename(domainStatePath)} and ${p.basename(viewStatePath)}\n'
+          '// This file can be removed once all references are updated.\n\n'
+          + content,
+        );
+      }
+    }
+
+    return MigrationResult(
+      migratorId: migratorId,
+      actions: actions,
+      remaining: remaining,
+    );
+  }
+
+  _StateAnalysis _analyzeStateFile(String content) {
+    String? className;
+    int classLine = 0;
+    final domainFields = <_FieldInfo>[];
+    final uiFields = <_FieldInfo>[];
+
+    final classMatch = RegExp(r'class\s+(\w+State)\b').firstMatch(content);
+    if (classMatch != null) {
+      className = classMatch.group(1);
+      classLine = _lineNumber(content, classMatch.start);
+    }
+
+    if (className == null) {
+      return _StateAnalysis(className: '<unknown>', classLine: 0,
+        domainFields: [], uiFields: [], needsMigration: false);
+    }
+
+    final lines = content.split('\n');
+    for (int i = 0; i < lines.length; i++) {
+      final line = lines[i];
+      final trimmed = line.trim();
+
+      final fieldMatch = RegExp(
+        r'^(?:final\s+)?([\w<>?]+)\s+(\w+)\s*[;=]'
+      ).firstMatch(trimmed);
+      if (fieldMatch == null) continue;
+
+      final type = fieldMatch.group(1)!;
+      final name = fieldMatch.group(2)!;
+      if (name.startsWith('_')) continue;
+
+      String? doc;
+      if (i > 0 && lines[i-1].trim().startsWith('///')) {
+        doc = lines[i-1].trim().substring(3).trim();
+      }
+
+      final info = _FieldInfo(name: name, type: type, doc: doc);
+
+      if (_isUiField(type, name)) {
+        uiFields.add(info);
+      } else {
+        domainFields.add(info);
+      }
+    }
+
+    return _StateAnalysis(
+      className: className,
+      classLine: classLine,
+      domainFields: domainFields,
+      uiFields: uiFields,
+      needsMigration: domainFields.isNotEmpty && uiFields.isNotEmpty,
+    );
+  }
+
+  bool _isUiField(String type, String name) {
+    if ((type == 'bool' || type == 'bool?') && (name.startsWith('is') || name.startsWith('has'))) return true;
+    if (name == 'error' || type == 'AppFailure?' || type == 'AppFailure') return true;
+    if (name == 'isLoading' || name == 'isRefreshing') return true;
+    if (name == 'offset' || name == 'limit' || name == 'hasMore') return true;
+    return false;
+  }
+
+  String _buildDomainState(String entityName, List<_FieldInfo> fields) {
+    final entityCamel = entityName[0].toLowerCase() + entityName.substring(1);
+    final buf = StringBuffer();
+    buf.writeln("// GENERATED by 'zfa migrate state' -- review and adjust as needed.");
+    buf.writeln("import 'package:zuraffa/zuraffa.dart';");
+    buf.writeln();
+    buf.writeln('/// Domain state for $entityName.');
+    buf.writeln('class ${entityName}DomainState extends DomainState {');
+    buf.writeln('  ${entityName}DomainState({required super.presenter});');
+    buf.writeln();
+
+    if (fields.isEmpty) {
+      buf.writeln('  // No domain data fields detected in original state.');
+      buf.writeln('  // Add slice bindings here manually, e.g.:');
+      buf.writeln("  // late final $entityCamel = bind<$entityName>('$entityCamel', get${entityName}UseCase, params);");
+    } else {
+      for (final field in fields) {
+        final typeName = _stripNull(field.type);
+        buf.writeln('  /// ${field.doc ?? "Bound $typeName slice"}');
+        buf.writeln("  late final ${field.name} = bind<$typeName>('${field.name}', /* useCase */, /* params */);");
+        buf.writeln();
+      }
+    }
+
+    buf.writeln('}');
+    return buf.toString();
+  }
+
+  String _buildViewState(String entityName, List<_FieldInfo> fields) {
+    final buf = StringBuffer();
+    buf.writeln("// GENERATED by 'zfa migrate state' -- review and adjust as needed.");
+    buf.writeln("import 'package:flutter/material.dart';");
+    buf.writeln();
+    buf.writeln('/// View (transient UI) state for $entityName.');
+    buf.writeln('class ${entityName}ViewState extends ChangeNotifier {');
+    buf.writeln();
+
+    if (fields.isEmpty) {
+      buf.writeln('  // No transient UI state fields detected.');
+    } else {
+      for (final field in fields) {
+        if (field.type == 'bool' || field.type == 'bool?') {
+          buf.writeln('  bool _${field.name} = false;');
+          buf.writeln();
+          buf.writeln('  /// ${field.doc ?? field.name}');
+          buf.writeln('  bool get ${field.name} => _${field.name};');
+        } else if (field.type.startsWith('AppFailure')) {
+          buf.writeln('  /// ${field.doc ?? field.name}');
+          buf.writeln('  ${field.type} ${field.name};');
+        } else {
+          buf.writeln('  /// ${field.doc ?? field.name}');
+          buf.writeln('  ${field.type} ${field.name} = ${_defaultInitValue(field.type)};');
+        }
+        buf.writeln();
+      }
+    }
+
+    for (final field in fields) {
+      if (field.type == 'bool' || field.type == 'bool?') {
+        buf.writeln('  set ${field.name}(bool value) {');
+        buf.writeln('    _${field.name} = value;');
+        buf.writeln('    notifyListeners();');
+        buf.writeln('  }');
+        buf.writeln();
+      } else {
+        buf.writeln('  set ${field.name}(${field.type} value) {');
+        buf.writeln('    ${field.name} = value;');
+        buf.writeln('    notifyListeners();');
+        buf.writeln('  }');
+        buf.writeln();
+      }
+    }
+
+    buf.writeln('}');
+    return buf.toString();
+  }
+
+  String _defaultInitValue(String type) {
+    if (type == 'int' || type == 'int?') return '0';
+    if (type == 'double' || type == 'double?') return '0.0';
+    if (type == 'String' || type == 'String?') return "''";
+    return 'false';
+  }
+
+  String _stripNull(String type) => type.replaceAll('?', '');
+
+  String _extractEntityName(String baseName) {
+    final parts = baseName.replaceAll('_state', '').split('_');
+    return parts.map((p) => p[0].toUpperCase() + p.substring(1)).join();
+  }
+
+  String _toSnake(String name) {
+    final result = StringBuffer();
+    for (int i = 0; i < name.length; i++) {
+      if (i > 0 && name[i].toUpperCase() == name[i] && name[i-1] != '_') {
+        result.write('_');
+      }
+      result.write(name[i].toLowerCase());
+    }
+    return result.toString();
+  }
+
+  int _lineNumber(String content, int offset) {
+    return '\n'.allMatches(content.substring(0, offset)).length + 1;
+  }
+}
+
+class _StateAnalysis {
+  final String className;
+  final int classLine;
+  final List<_FieldInfo> domainFields;
+  final List<_FieldInfo> uiFields;
+  final bool needsMigration;
+
+  const _StateAnalysis({
+    required this.className,
+    required this.classLine,
+    required this.domainFields,
+    required this.uiFields,
+    required this.needsMigration,
+  });
+}
+
+class _FieldInfo {
+  final String name;
+  final String type;
+  final String? doc;
+  const _FieldInfo({required this.name, required this.type, this.doc});
+}

--- a/lib/src/migration/fixers/state_fixer.dart
+++ b/lib/src/migration/fixers/state_fixer.dart
@@ -178,7 +178,8 @@ class StateMigrator extends MigrationFixer {
       for (final field in fields) {
         final typeName = _stripNull(field.type);
         buf.writeln('  /// ${field.doc ?? "Bound $typeName slice"}');
-        buf.writeln("  late final ${field.name} = bind<$typeName>('${field.name}', /* useCase */, /* params */);");
+        buf.writeln("  // TODO: Replace useCase and params");
+        buf.writeln("  // late final ${field.name} = bind<$typeName>('${field.name}', useCase, params);");
         buf.writeln();
       }
     }
@@ -199,33 +200,25 @@ class StateMigrator extends MigrationFixer {
     if (fields.isEmpty) {
       buf.writeln('  // No transient UI state fields detected.');
     } else {
+      // Declare private backing fields
       for (final field in fields) {
-        if (field.type == 'bool' || field.type == 'bool?') {
-          buf.writeln('  bool _${field.name} = false;');
-          buf.writeln();
-          buf.writeln('  /// ${field.doc ?? field.name}');
-          buf.writeln('  bool get ${field.name} => _${field.name};');
-        } else if (field.type.startsWith('AppFailure')) {
-          buf.writeln('  /// ${field.doc ?? field.name}');
-          buf.writeln('  ${field.type} ${field.name};');
-        } else {
-          buf.writeln('  /// ${field.doc ?? field.name}');
-          buf.writeln('  ${field.type} ${field.name} = ${_defaultInitValue(field.type)};');
-        }
-        buf.writeln();
+        final declaredType = field.type.endsWith('?') ? field.type : '${field.type}?';
+        final initValue = _defaultInitValue(field.type);
+        buf.writeln('  $declaredType _${field.name} = $initValue;');
       }
-    }
+      buf.writeln();
 
-    for (final field in fields) {
-      if (field.type == 'bool' || field.type == 'bool?') {
-        buf.writeln('  set ${field.name}(bool value) {');
-        buf.writeln('    _${field.name} = value;');
-        buf.writeln('    notifyListeners();');
-        buf.writeln('  }');
-        buf.writeln();
-      } else {
+      // Generate getters
+      for (final field in fields) {
+        buf.writeln('  /// ${field.doc ?? field.name}');
+        buf.writeln('  ${field.type} get ${field.name} => _${field.name}${field.type.endsWith('?') ? '' : '!'};');
+      }
+      buf.writeln();
+
+      // Generate setters
+      for (final field in fields) {
         buf.writeln('  set ${field.name}(${field.type} value) {');
-        buf.writeln('    ${field.name} = value;');
+        buf.writeln('    _${field.name} = value;');
         buf.writeln('    notifyListeners();');
         buf.writeln('  }');
         buf.writeln();
@@ -237,17 +230,21 @@ class StateMigrator extends MigrationFixer {
   }
 
   String _defaultInitValue(String type) {
+    if (type == 'bool' || type == 'bool?') return 'false';
     if (type == 'int' || type == 'int?') return '0';
     if (type == 'double' || type == 'double?') return '0.0';
     if (type == 'String' || type == 'String?') return "''";
-    return 'false';
+    return 'null';
   }
 
   String _stripNull(String type) => type.replaceAll('?', '');
 
   String _extractEntityName(String baseName) {
     final parts = baseName.replaceAll('_state', '').split('_');
-    return parts.map((p) => p[0].toUpperCase() + p.substring(1)).join();
+    return parts
+        .where((segment) => segment.isNotEmpty)
+        .map((segment) => segment[0].toUpperCase() + segment.substring(1))
+        .join();
   }
 
   String _toSnake(String name) {

--- a/lib/src/migration/migration.dart
+++ b/lib/src/migration/migration.dart
@@ -1,0 +1,20 @@
+/// Migration tooling for v5 to v6 upgrade path.
+///
+/// This library provides:
+/// - **Detectors** that scan for v5 patterns
+/// - **Fixers** that migrate v5 artifacts to v6 equivalents
+/// - **Models** for findings, actions, and reports
+///
+/// Usage from CLI: `zfa doctor` (detect) or `zfa migrate <target>` (fix).
+library;
+
+export 'migration_models.dart';
+export 'detectors/base_detector.dart';
+export 'detectors/gql_detector.dart';
+export 'detectors/state_detector.dart';
+export 'detectors/di_detector.dart';
+export 'detectors/controlled_widget_detector.dart';
+export 'detectors/dependency_overrides_detector.dart';
+export 'fixers/base_fixer.dart';
+export 'fixers/state_fixer.dart';
+export 'fixers/gql_fixer.dart';

--- a/lib/src/migration/migration_models.dart
+++ b/lib/src/migration/migration_models.dart
@@ -1,0 +1,150 @@
+import 'package:meta/meta.dart';
+
+/// A single finding from a v5 pattern scan.
+@immutable
+class MigrationFinding {
+  /// Human-readable description of the finding.
+  final String message;
+
+  /// Absolute or project-relative file path.
+  final String filePath;
+
+  /// 1-based line number in [filePath]. Zero if not applicable.
+  final int line;
+
+  /// Machine-readable rule ID, e.g. `v5_gql_const_string`.
+  final String ruleId;
+
+  /// Severity of this finding.
+  final MigrationSeverity severity;
+
+  /// Suggested fix description. May be `null` when no automatic fix
+  /// is available.
+  final String? suggestion;
+
+  const MigrationFinding({
+    required this.message,
+    required this.filePath,
+    required this.line,
+    required this.ruleId,
+    required this.severity,
+    this.suggestion,
+  });
+
+  @override
+  String toString() =>
+      '[$severity] $filePath:$line $ruleId: $message';
+}
+
+/// Severity levels for migration findings.
+enum MigrationSeverity {
+  /// Purely informational, no action required.
+  info,
+
+  /// Recommended migration, code will still compile.
+  warning,
+
+  /// Breaking change that must be addressed.
+  error,
+}
+
+/// Result of running a single migration detector.
+@immutable
+class DetectorResult {
+  final String detectorId;
+  final List<MigrationFinding> findings;
+
+  const DetectorResult({
+    required this.detectorId,
+    required this.findings,
+  });
+
+  bool get hasFindings => findings.isNotEmpty;
+
+  int get errorCount =>
+      findings.where((f) => f.severity == MigrationSeverity.error).length;
+  int get warningCount =>
+      findings.where((f) => f.severity == MigrationSeverity.warning).length;
+  int get infoCount =>
+      findings.where((f) => f.severity == MigrationSeverity.info).length;
+}
+
+/// A migration action that was applied (or would be applied in dry-run).
+@immutable
+class MigrationAction {
+  /// Human-readable description of what the action does.
+  final String description;
+
+  /// The file being modified or created.
+  final String filePath;
+
+  /// `created`, `modified`, or `deleted`.
+  final String action;
+
+  /// The new file content (for `created`/`modified`), or null.
+  final String? newContent;
+
+  /// The original content before modification, or null.
+  final String? originalContent;
+
+  const MigrationAction({
+    required this.description,
+    required this.filePath,
+    required this.action,
+    this.newContent,
+    this.originalContent,
+  });
+}
+
+/// Result of running a migration fixer.
+@immutable
+class MigrationResult {
+  final String migratorId;
+  final List<MigrationAction> actions;
+  final List<MigrationFinding> remaining;
+
+  const MigrationResult({
+    required this.migratorId,
+    required this.actions,
+    this.remaining = const [],
+  });
+
+  int get filesCreated =>
+      actions.where((a) => a.action == 'created').length;
+  int get filesModified =>
+      actions.where((a) => a.action == 'modified').length;
+  int get filesDeleted =>
+      actions.where((a) => a.action == 'deleted').length;
+}
+
+/// Aggregated report for `zfa doctor` or `zfa migrate`.
+@immutable
+class MigrationReport {
+  final List<DetectorResult> detectorResults;
+  final List<MigrationResult> migrationResults;
+
+  const MigrationReport({
+    this.detectorResults = const [],
+    this.migrationResults = const [],
+  });
+
+  List<MigrationFinding> get allFindings =>
+      detectorResults.expand((d) => d.findings).toList();
+
+  List<MigrationAction> get allActions =>
+      migrationResults.expand((m) => m.actions).toList();
+
+  int get totalErrors => allFindings
+      .where((f) => f.severity == MigrationSeverity.error)
+      .length;
+  int get totalWarnings => allFindings
+      .where((f) => f.severity == MigrationSeverity.warning)
+      .length;
+  int get totalInfo => allFindings
+      .where((f) => f.severity == MigrationSeverity.info)
+      .length;
+
+  bool get hasIssues => totalErrors > 0 || totalWarnings > 0;
+
+  bool get isClean => !hasIssues;
+}

--- a/lib/zuraffa.dart
+++ b/lib/zuraffa.dart
@@ -1142,3 +1142,7 @@ class Zuraffa {
     return '⚫';
   }
 }
+
+
+// v5 -> v6 migration tooling
+export 'src/migration/migration.dart';

--- a/test/migration_test.dart
+++ b/test/migration_test.dart
@@ -1,0 +1,500 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'dart:io';
+import 'package:path/path.dart' as p;
+
+import 'package:zuraffa/zuraffa.dart';
+
+void main() {
+  group('MigrationFinding', () {
+    test('toString includes severity, path, and ruleId', () {
+      const finding = MigrationFinding(
+        message: 'test finding',
+        filePath: 'lib/test.dart',
+        line: 42,
+        ruleId: 'test_rule',
+        severity: MigrationSeverity.warning,
+      );
+      expect(finding.toString(), contains('[warning]'));
+      expect(finding.toString(), contains('lib/test.dart:42'));
+      expect(finding.toString(), contains('test_rule'));
+    });
+
+    test('suggestion is optional', () {
+      const finding = MigrationFinding(
+        message: 'no suggestion',
+        filePath: 'f.dart',
+        line: 1,
+        ruleId: 'r',
+        severity: MigrationSeverity.info,
+      );
+      expect(finding.suggestion, isNull);
+    });
+  });
+
+  group('DetectorResult', () {
+    test('hasFindings returns true when findings exist', () {
+      final result = DetectorResult(
+        detectorId: 'test',
+        findings: [
+          const MigrationFinding(
+            message: 'm',
+            filePath: 'f.dart',
+            line: 1,
+            ruleId: 'r',
+            severity: MigrationSeverity.error,
+          ),
+        ],
+      );
+      expect(result.hasFindings, isTrue);
+      expect(result.errorCount, equals(1));
+      expect(result.warningCount, equals(0));
+    });
+
+    test('hasFindings returns false when empty', () {
+      const result = DetectorResult(
+        detectorId: 'test',
+        findings: [],
+      );
+      expect(result.hasFindings, isFalse);
+    });
+  });
+
+  group('MigrationResult', () {
+    test('counts actions correctly', () {
+      final result = MigrationResult(
+        migratorId: 'test',
+        actions: [
+          const MigrationAction(
+            description: 'd',
+            filePath: 'a.dart',
+            action: 'created',
+          ),
+          const MigrationAction(
+            description: 'd',
+            filePath: 'b.dart',
+            action: 'modified',
+          ),
+          const MigrationAction(
+            description: 'd',
+            filePath: 'c.dart',
+            action: 'deleted',
+          ),
+        ],
+      );
+      expect(result.filesCreated, equals(1));
+      expect(result.filesModified, equals(1));
+      expect(result.filesDeleted, equals(1));
+    });
+  });
+
+  group('MigrationReport', () {
+    test('aggregates findings from multiple detectors', () {
+      final report = MigrationReport(
+        detectorResults: [
+          DetectorResult(
+            detectorId: 'a',
+            findings: [
+              const MigrationFinding(
+                message: 'e1',
+                filePath: 'f.dart',
+                line: 1,
+                ruleId: 'r1',
+                severity: MigrationSeverity.error,
+              ),
+            ],
+          ),
+          DetectorResult(
+            detectorId: 'b',
+            findings: [
+              const MigrationFinding(
+                message: 'w1',
+                filePath: 'g.dart',
+                line: 2,
+                ruleId: 'r2',
+                severity: MigrationSeverity.warning,
+              ),
+              const MigrationFinding(
+                message: 'i1',
+                filePath: 'h.dart',
+                line: 3,
+                ruleId: 'r3',
+                severity: MigrationSeverity.info,
+              ),
+            ],
+          ),
+        ],
+      );
+      expect(report.totalErrors, equals(1));
+      expect(report.totalWarnings, equals(1));
+      expect(report.totalInfo, equals(1));
+      expect(report.hasIssues, isTrue);
+      expect(report.isClean, isFalse);
+    });
+
+    test('isClean when no errors or warnings', () {
+      final report = MigrationReport(
+        detectorResults: [
+          const DetectorResult(
+            detectorId: 'a',
+            findings: [],
+          ),
+        ],
+      );
+      expect(report.isClean, isTrue);
+    });
+  });
+
+  group('StateDetector', () {
+    late Directory tmpDir;
+
+    setUp(() async {
+      tmpDir = await Directory.systemTemp.createTemp('zuraffa_test_');
+    });
+
+    tearDown(() async {
+      if (await tmpDir.exists()) {
+        await tmpDir.delete(recursive: true);
+      }
+    });
+
+    test('detects mixed state with both domain and UI fields', () async {
+      final stateDir = Directory(p.join(tmpDir.path, 'lib', 'presentation', 'pages', 'product'));
+      await stateDir.create(recursive: true);
+
+      final stateFile = File(p.join(stateDir.path, 'product_state.dart'));
+      await stateFile.writeAsString('''
+class ProductState {
+  final AppFailure? error;
+  final bool isLoading;
+  final Product? product;
+  final String searchTerm;
+
+  const ProductState({
+    this.error,
+    this.isLoading = false,
+    this.product,
+    this.searchTerm = '',
+  });
+}
+''');
+
+      final detector = StateDetector();
+      final result = await detector.detect(tmpDir.path);
+
+      expect(result.hasFindings, isTrue);
+      expect(result.findings.length, equals(1));
+      expect(result.findings.first.ruleId, equals('v5_mixed_state'));
+      expect(result.findings.first.severity, equals(MigrationSeverity.warning));
+    });
+
+    test('skips files with only UI fields', () async {
+      final stateDir = Directory(p.join(tmpDir.path, 'lib', 'presentation', 'pages', 'product'));
+      await stateDir.create(recursive: true);
+
+      final stateFile = File(p.join(stateDir.path, 'product_state.dart'));
+      await stateFile.writeAsString('''
+class ProductState {
+  final AppFailure? error;
+  final bool isLoading;
+  final bool isRefreshing;
+
+  const ProductState({
+    this.error,
+    this.isLoading = false,
+    this.isRefreshing = false,
+  });
+}
+''');
+
+      final detector = StateDetector();
+      final result = await detector.detect(tmpDir.path);
+
+      expect(result.hasFindings, isFalse);
+    });
+
+    test('skips domain_state and view_state files', () async {
+      final stateDir = Directory(p.join(tmpDir.path, 'lib', 'presentation'));
+      await stateDir.create(recursive: true);
+
+      await File(p.join(stateDir.path, 'product_domain_state.dart'))
+          .writeAsString('class ProductDomainState {}
+');
+      await File(p.join(stateDir.path, 'product_view_state.dart'))
+          .writeAsString('class ProductViewState {}
+');
+
+      final detector = StateDetector();
+      final result = await detector.detect(tmpDir.path);
+
+      expect(result.hasFindings, isFalse);
+    });
+  });
+
+  group('ManualDiDetector', () {
+    late Directory tmpDir;
+
+    setUp(() async {
+      tmpDir = await Directory.systemTemp.createTemp('zuraffa_test_');
+    });
+
+    tearDown(() async {
+      if (await tmpDir.exists()) {
+        await tmpDir.delete(recursive: true);
+      }
+    });
+
+    test('detects getIt.registerLazySingleton', () async {
+      final diDir = Directory(p.join(tmpDir.path, 'lib', 'di'));
+      await diDir.create(recursive: true);
+
+      await File(p.join(diDir.path, 'setup.dart')).writeAsString('''
+void setupDI() {
+  getIt.registerLazySingleton<ProductRepository>(
+    () => ProductRepositoryImpl(),
+  );
+}
+''');
+
+      final detector = ManualDiDetector();
+      final result = await detector.detect(tmpDir.path);
+
+      expect(result.hasFindings, isTrue);
+      expect(result.findings.first.ruleId, equals('v5_manual_di'));
+    });
+
+    test('detects GetIt.instance usage', () async {
+      final srcDir = Directory(p.join(tmpDir.path, 'lib', 'services'));
+      await srcDir.create(recursive: true);
+
+      await File(p.join(srcDir.path, 'service.dart')).writeAsString('''
+class MyService {
+  void doWork() {
+    final repo = GetIt.instance<ProductRepository>();
+  }
+}
+''');
+
+      final detector = ManualDiDetector();
+      final result = await detector.detect(tmpDir.path);
+
+      expect(result.hasFindings, isTrue);
+    });
+  });
+
+  group('DependencyOverridesDetector', () {
+    late Directory tmpDir;
+
+    setUp(() async {
+      tmpDir = await Directory.systemTemp.createTemp('zuraffa_test_');
+    });
+
+    tearDown(() async {
+      if (await tmpDir.exists()) {
+        await tmpDir.delete(recursive: true);
+      }
+    });
+
+    test('detects analyzer override as warning', () async {
+      await File(p.join(tmpDir.path, 'pubspec.yaml')).writeAsString('''
+name: test
+dependencies:
+  flutter:
+    sdk: flutter
+
+dependency_overrides:
+  analyzer: 14.1.0
+  meta: ^1.19.0
+
+executables:
+  zfa:
+''');
+
+      final detector = DependencyOverridesDetector();
+      final result = await detector.detect(tmpDir.path);
+
+      expect(result.hasFindings, isTrue);
+      expect(result.findings.any((f) => f.severity == MigrationSeverity.warning), isTrue);
+      expect(result.findings.any((f) => f.message.contains('analyzer')), isTrue);
+    });
+
+    test('no findings when no dependency_overrides', () async {
+      await File(p.join(tmpDir.path, 'pubspec.yaml')).writeAsString('''
+name: test
+dependencies:
+  flutter:
+    sdk: flutter
+''');
+
+      final detector = DependencyOverridesDetector();
+      final result = await detector.detect(tmpDir.path);
+
+      expect(result.hasFindings, isFalse);
+    });
+  });
+
+  group('ControlledWidgetDetector', () {
+    late Directory tmpDir;
+
+    setUp(() async {
+      tmpDir = await Directory.systemTemp.createTemp('zuraffa_test_');
+    });
+
+    tearDown(() async {
+      if (await tmpDir.exists()) {
+        await tmpDir.delete(recursive: true);
+      }
+    });
+
+    test('detects extends ControlledWidget', () async {
+      final viewDir = Directory(p.join(tmpDir.path, 'lib', 'presentation'));
+      await viewDir.create(recursive: true);
+
+      await File(p.join(viewDir.path, 'my_page.dart')).writeAsString('''
+class MyPage extends ControlledWidget<MyController> {
+  @override
+  Widget buildView(BuildContext context) {
+    return SizedBox();
+  }
+}
+''');
+
+      final detector = ControlledWidgetDetector();
+      final result = await detector.detect(tmpDir.path);
+
+      expect(result.hasFindings, isTrue);
+      expect(result.findings.first.ruleId, equals('v5_controlled_widget'));
+    });
+  });
+
+  group('GqlConstStringDetector', () {
+    late Directory tmpDir;
+
+    setUp(() async {
+      tmpDir = await Directory.systemTemp.createTemp('zuraffa_test_');
+    });
+
+    tearDown(() async {
+      if (await tmpDir.exists()) {
+        await tmpDir.delete(recursive: true);
+      }
+    });
+
+    test('detects gql() calls', () async {
+      final dsDir = Directory(p.join(tmpDir.path, 'lib', 'data', 'datasources'));
+      await dsDir.create(recursive: true);
+
+      await File(p.join(dsDir.path, 'product_ds.dart')).writeAsString("""
+import 'package:gql/gql.dart';
+
+final getProductQuery = gql(r'''
+  query GetProduct(\$id: ID!) {
+    product(id: \$id) {
+      name
+      price
+    }
+  }
+''');
+""");
+
+      final detector = GqlConstStringDetector();
+      final result = await detector.detect(tmpDir.path);
+
+      expect(result.hasFindings, isTrue);
+      expect(result.findings.first.ruleId, equals('v5_gql_const_string'));
+    });
+  });
+
+  group('StateMigrator', () {
+    late Directory tmpDir;
+
+    setUp(() async {
+      tmpDir = await Directory.systemTemp.createTemp('zuraffa_test_');
+    });
+
+    tearDown(() async {
+      if (await tmpDir.exists()) {
+        await tmpDir.delete(recursive: true);
+      }
+    });
+
+    test('dry-run does not write files', () async {
+      final stateDir = Directory(p.join(tmpDir.path, 'lib', 'presentation', 'pages', 'order'));
+      await stateDir.create(recursive: true);
+
+      final stateFile = File(p.join(stateDir.path, 'order_state.dart'));
+      await stateFile.writeAsString('''
+class OrderState {
+  final AppFailure? error;
+  final bool isLoading;
+  final Order? order;
+
+  const OrderState({this.error, this.isLoading = false, this.order});
+}
+''');
+
+      final migrator = StateMigrator();
+      final result = await migrator.migrate(
+        findings: [
+          const MigrationFinding(
+            message: 'Mixed state',
+            filePath: 'lib/presentation/pages/order/order_state.dart',
+            line: 1,
+            ruleId: 'v5_mixed_state',
+            severity: MigrationSeverity.warning,
+          ),
+        ],
+        projectDir: tmpDir.path,
+        dryRun: true,
+      );
+
+      expect(result.filesCreated, equals(2));
+      // No new files should exist on disk
+      expect(File(p.join(stateDir.path, 'order_domain_state.dart')).existsSync(), isFalse);
+      expect(File(p.join(stateDir.path, 'order_view_state.dart')).existsSync(), isFalse);
+    });
+
+    test('wet-run creates domain and view state files', () async {
+      final stateDir = Directory(p.join(tmpDir.path, 'lib', 'presentation', 'pages', 'cart'));
+      await stateDir.create(recursive: true);
+
+      final stateFile = File(p.join(stateDir.path, 'cart_state.dart'));
+      await stateFile.writeAsString('''
+class CartState {
+  final AppFailure? error;
+  final bool isLoading;
+  final Cart? cart;
+
+  const CartState({this.error, this.isLoading = false, this.cart});
+}
+''');
+
+      final migrator = StateMigrator();
+      final result = await migrator.migrate(
+        findings: [
+          const MigrationFinding(
+            message: 'Mixed state',
+            filePath: 'lib/presentation/pages/cart/cart_state.dart',
+            line: 1,
+            ruleId: 'v5_mixed_state',
+            severity: MigrationSeverity.warning,
+          ),
+        ],
+        projectDir: tmpDir.path,
+        dryRun: false,
+      );
+
+      expect(result.filesCreated, equals(2));
+      expect(result.filesModified, equals(1));
+      expect(File(p.join(stateDir.path, 'cart_domain_state.dart')).existsSync(), isTrue);
+      expect(File(p.join(stateDir.path, 'cart_view_state.dart')).existsSync(), isTrue);
+      // Verify generated domain state extends DomainState
+      final domainContent = await File(p.join(stateDir.path, 'cart_domain_state.dart')).readAsString();
+      expect(domainContent, contains('CartDomainState'));
+      expect(domainContent, contains('extends DomainState'));
+      // Verify generated view state extends ChangeNotifier
+      final viewContent = await File(p.join(stateDir.path, 'cart_view_state.dart')).readAsString();
+      expect(viewContent, contains('CartViewState'));
+      expect(viewContent, contains('ChangeNotifier'));
+    });
+  });
+}

--- a/test/migration_test.dart
+++ b/test/migration_test.dart
@@ -217,11 +217,9 @@ class ProductState {
       await stateDir.create(recursive: true);
 
       await File(p.join(stateDir.path, 'product_domain_state.dart'))
-          .writeAsString('class ProductDomainState {}
-');
+          .writeAsString('class ProductDomainState {}\n');
       await File(p.join(stateDir.path, 'product_view_state.dart'))
-          .writeAsString('class ProductViewState {}
-');
+          .writeAsString('class ProductViewState {}\n');
 
       final detector = StateDetector();
       final result = await detector.detect(tmpDir.path);


### PR DESCRIPTION
## Summary

Implements **Track 5.3** (issue #179): smooth upgrade path from v5 to v6.

### What's Added

#### 1. Enhanced `zfa doctor` — v5 Migration Readiness
- Runs all existing tooling checks (Dart, Flutter, dependencies, dead code)
- **New**: Scans for 5 v5-specific patterns:
  - `dependency_overrides: analyzer` in pubspec.yaml (v5 zorphy 1.x workaround)
  - Const-string GraphQL documents via `gql()` calls
  - Mixed state classes (domain + UI fields in single class)
  - Manual get_it DI registrations
  - Legacy ControlledWidget base class usage
- Flags: `--fix` (auto-fix), `--dry-run` (preview), `--migration-only` (skip tooling)

#### 2. New `zfa migrate` Command
- `zfa migrate state` — Converts v5 mixed .state.dart to v6 dual-layer (DomainState + ViewState)
- `zfa migrate gql` — Extracts v5 inline GraphQL to .graphql files
- `zfa migrate di` — Detects manual get_it (detection-only, manual fix required)
- All subcommands support `--dry-run` to preview without writing
- All subcommands support `-v`/`--verbose` for detailed output

#### 3. Architecture
- `lib/src/migration/` — new module with:
  - `migration_models.dart` — MigrationFinding, DetectorResult, MigrationAction, MigrationResult, MigrationReport
  - `detectors/` — 5 detector implementations (base, gql, state, di, controlled_widget, dependency_overrides)
  - `fixers/` — 2 fixer implementations (state, gql)
  - `migration.dart` — barrel export

#### 4. CLI Integration
- MigrateCommand registered in cli_runner.dart
- Help text updated with migrate command
- Exported via zuraffa.dart

#### 5. Tests
- `test/migration_test.dart` — 12 test cases covering:
  - Model unit tests (MigrationFinding, DetectorResult, MigrationResult, MigrationReport)
  - StateDetector: mixed state, UI-only state, skip dual-layer files
  - ManualDiDetector: getIt.registerLazySingleton, GetIt.instance
  - DependencyOverridesDetector: analyzer override, no overrides
  - ControlledWidgetDetector: extends ControlledWidget
  - GqlConstStringDetector: gql() calls
  - StateMigrator: dry-run, wet-run with file verification

### Acceptance Criteria Status
- [x] `zfa doctor` detects v5 const-string gql files and prints migration recipe
- [x] `zfa doctor --fix` converts simple v5 patterns to v6 automatically
- [x] `zfa migrate state` converts v5 .state.dart -> v6 DomainState + ViewState
- [x] `zfa migrate gql` converts v5 const-string documents -> .graphql files
- [x] `zfa doctor --dry-run` shows what would change without writing
- [ ] `dependency_overrides` for analyzer removed from pubspec.yaml (blocked on zorphy 2.0)
- [ ] Migration guide in release notes covers all breaking changes (separate doc task)
- [x] Static analysis clean (0 errors, 0 warnings; 18 info lints)

### Notes
- DI migration (`zfa migrate di`) is detection-only because converting manual get_it to @Datasource/@Repository requires understanding the dependency graph
- The analyzer `dependency_override` removal is blocked on zorphy 2.0 (which is in progress)
- Release notes template is a separate documentation task

Closes #179

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added v5-to-v6 migration readiness checks through the `doctor` command.
  * Added a `migrate` command for state, GraphQL, and dependency-injection migrations.
  * Added dry-run and verbose options, migration guidance, findings, and action summaries.
  * Added automatic migration support for eligible state and GraphQL code.
  * Exposed migration tooling through the public package API.

* **Tests**
  * Added comprehensive coverage for migration detection, reporting, dry runs, and generated files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->