### PR TITLE
fix: remove export of nonexistent graphql/naming_utils.dart (#222)

### DIFF
--- a/lib/zuraffa.dart
+++ b/lib/zuraffa.dart
@@ -512,8 +512,6 @@ export 'src/graphql/gql/graphql_document_builder.dart';
 // DocumentsDartGenerator — documents.dart with DocumentNode constants.
 export 'src/graphql/gql/documents_dart_generator.dart';
 
-// NamingUtils — shared naming utilities for consistent variable naming.
-export 'src/graphql/gql/naming_utils.dart';
 
 // GraphQLValidator — validates documents against the cached schema.
 export 'src/graphql/validators/graphql_validator.dart';


### PR DESCRIPTION
Closes #222\n\nRemove the stale barrel export for \x27src/graphql/gql/naming_utils.dart\x27 which does not exist in the repo. This was likely left behind when GraphQL work was deprioritized.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed an internal naming utility from the package’s public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->