### PR TITLE
fix: move misplaced migration export before declarations (#223)

### DIFF
--- a/lib/zuraffa.dart
+++ b/lib/zuraffa.dart
@@ -456,6 +456,8 @@ export 'src/state/widgets/fragment_builder.dart';
 
 // StateMigrator — converts v5 .state.dart to v6 slice pattern.
 export 'src/state/migration/state_migrator.dart';
+// v5 -> v6 migration tooling
+export 'src/migration/migration.dart';
 
 // DomainState — auto-generated read-only slice container.
 export 'src/state/domain_state.dart';
@@ -1168,7 +1170,6 @@ class Zuraffa {
 }
 
 
-// v5 -> v6 migration tooling
-export 'src/migration/migration.dart';
+
 
 


### PR DESCRIPTION
Closes #223\n\nMoves the \x27export src/migration/migration.dart\x27 directive from line 1172 (after declarations, which Dart disallows) up to line 460, grouped with the other migration-related exports.\n\nBefore: the export sat at the bottom of the barrel file after class/function declarations.\nAfter: it sits right below the state_migrator export in the directive block.