### PR TITLE
fix: resolve all 11 remaining CWD-contamination test failures

### DIFF
--- a/test/commands/make_command_test.dart
+++ b/test/commands/make_command_test.dart
@@ -5,15 +5,18 @@ import 'package:test/test.dart';
 import 'package:path/path.dart' as path;
 import 'package:zuraffa/src/cli/cli_runner.dart';
 
-/// Resolve the project root from this test file's location.
+/// CWD-safe project root resolution.
+/// Tries Platform.script (immune to CWD), then CWD walk (with temp guard),
+/// then git rev-parse. Throws [StateError] if the root cannot be found.
 String _findProjectRoot() {
+  // Strategy 1: Walk up from Platform.script (immune to CWD changes).
   try {
     var dir = File(Platform.script.toFilePath()).parent;
     for (var i = 0; i < 10; i++) {
       final pubspec = File('${dir.path}/pubspec.yaml');
       if (pubspec.existsSync()) {
-        final content = pubspec.readAsStringSync();
-        if (RegExp(r'^name:\s*zuraffa\s*$', multiLine: true).hasMatch(content)) {
+        final c = pubspec.readAsStringSync();
+        if (RegExp(r'^name:\s*zuraffa\s*$', multiLine: true).hasMatch(c)) {
           return dir.path;
         }
       }
@@ -21,15 +24,39 @@ String _findProjectRoot() {
       if (parent.path == dir.path) break;
       dir = parent;
     }
-  } catch (_) {}
+  } catch (_) {
+    // Platform.script.toFilePath() may fail if CWD was deleted.
+    // Recover CWD to a known-good location and retry.
+    try { Directory.current = Directory.systemTemp.path; } catch (_) {}
+    try {
+      var dir = File(Platform.script.toFilePath()).parent;
+      for (var i = 0; i < 10; i++) {
+        final pubspec = File('${dir.path}/pubspec.yaml');
+        if (pubspec.existsSync()) {
+          final c = pubspec.readAsStringSync();
+          if (RegExp(r'^name:\s*zuraffa\s*$', multiLine: true).hasMatch(c)) {
+            return dir.path;
+          }
+        }
+        final parent = dir.parent;
+        if (parent.path == dir.path) break;
+        dir = parent;
+      }
+    } catch (_) {}
+  }
+
+  // Strategy 2: Walk up from CWD (may be poisoned, so guard against temp dirs).
   try {
     var dir = Directory.current;
     for (var i = 0; i < 15; i++) {
       final pubspec = File('${dir.path}/pubspec.yaml');
       if (pubspec.existsSync()) {
-        final content = pubspec.readAsStringSync();
-        if (RegExp(r'^name:\s*zuraffa\s*$', multiLine: true).hasMatch(content)) {
-          return dir.path;
+        final c = pubspec.readAsStringSync();
+        if (RegExp(r'^name:\s*zuraffa\s*$', multiLine: true).hasMatch(c)) {
+          final candidate = dir.path;
+          if (!_isTempPath(candidate)) {
+            return candidate;
+          }
         }
       }
       final parent = dir.parent;
@@ -37,8 +64,40 @@ String _findProjectRoot() {
       dir = parent;
     }
   } catch (_) {}
-  return Directory.current.path;
+
+  // Strategy 3: git rev-parse as last resort.
+  try {
+    final result = Process.runSync('git', ['rev-parse', '--show-toplevel']);
+    if (result.exitCode == 0) {
+      final gitRoot = (result.stdout as String).trim();
+      if (!_isTempPath(gitRoot)) {
+        final pubspec = File('$gitRoot/pubspec.yaml');
+        if (pubspec.existsSync()) {
+          final c = pubspec.readAsStringSync();
+          if (RegExp(r'^name:\s*zuraffa\s*$', multiLine: true).hasMatch(c)) {
+            return gitRoot;
+          }
+        }
+      }
+    }
+  } catch (_) {}
+
+  throw StateError(
+    'Cannot determine zuraffa project root. '
+    'CWD=${Directory.current.path}',
+  );
 }
+
+/// Returns true if [path] looks like it is inside a temp directory.
+bool _isTempPath(String p) {
+  final lower = p.toLowerCase();
+  return lower.contains('/tmp') ||
+      lower.contains(RegExp(r'/temp[/"]')) ||
+      lower.contains('/var/folders/') ||
+      lower.contains('/noSuchFile') ||
+      lower == Directory.systemTemp.path;
+}
+
 
 void main() {
   group('MakeCommand', () {

--- a/test/commands/make_command_test.dart
+++ b/test/commands/make_command_test.dart
@@ -82,20 +82,33 @@ String _findProjectRoot() {
     }
   } catch (_) {}
 
+  // Read Directory.current.path defensively to avoid masking the intended StateError.
+  String cwdForError;
+  try {
+    cwdForError = Directory.current.path;
+  } catch (_) {
+    cwdForError = '<unable to read CWD>';
+  }
   throw StateError(
     'Cannot determine zuraffa project root. '
-    'CWD=${Directory.current.path}',
+    'CWD=$cwdForError',
   );
 }
 
 /// Returns true if [path] looks like it is inside a temp directory.
 bool _isTempPath(String p) {
   final lower = p.toLowerCase();
-  return lower.contains('/tmp') ||
-      lower.contains(RegExp(r'/temp[/"]')) ||
+  final systemTempLower = Directory.systemTemp.path.toLowerCase();
+
+  // Check if path starts with /tmp/, equals /tmp, or contains /tmp/ as a segment
+  final isTmpSegment = lower == '/tmp' ||
+                       lower.startsWith('/tmp/') ||
+                       lower.contains('/tmp/');
+
+  return isTmpSegment ||
       lower.contains('/var/folders/') ||
-      lower.contains('/noSuchFile') ||
-      lower == Directory.systemTemp.path;
+      lower.contains('/nosuchfile') ||
+      lower == systemTempLower;
 }
 
 

--- a/test/commands/xray_deck_cli_test.dart
+++ b/test/commands/xray_deck_cli_test.dart
@@ -23,18 +23,20 @@ void main() {
   });
 
   tearDown(() async {
-    if (tempDir.existsSync()) {
-      await tempDir.delete(recursive: true);
-    }
-    // Restore CWD only if the saved path still exists.
+    // CRITICAL: Restore CWD BEFORE deleting tempDir.
+    // If CWD points to tempDir and we delete it, any access to
+    // Directory.current / Uri.base crashes the test runner itself.
     try {
       if (Directory(originalWd).existsSync()) {
-        Directory.current = Directory(originalWd);
+        Directory.current = originalWd;
       } else {
-        Directory.current = Directory.systemTemp;
+        Directory.current = Directory.systemTemp.path;
       }
     } catch (_) {
-      try { Directory.current = Directory.systemTemp; } catch (_) {}
+      try { Directory.current = Directory.systemTemp.path; } catch (_) {}
+    }
+    if (tempDir.existsSync()) {
+      await tempDir.delete(recursive: true);
     }
   });
 

--- a/test/plugins/vpc_records_test.dart
+++ b/test/plugins/vpc_records_test.dart
@@ -24,7 +24,7 @@ String _safeRoot() {
   return Directory.systemTemp.path;
 }
 
-String _safeRoot = _safeRoot();
+String _resolvedRoot = _safeRoot();
 void main() {
   late Directory workspace;
   late String outputDir;

--- a/test/regression/cli_command_test.dart
+++ b/test/regression/cli_command_test.dart
@@ -83,20 +83,33 @@ String _findProjectRoot() {
     }
   } catch (_) {}
 
+  // Read Directory.current.path defensively to avoid masking the intended StateError.
+  String cwdForError;
+  try {
+    cwdForError = Directory.current.path;
+  } catch (_) {
+    cwdForError = '<unable to read CWD>';
+  }
   throw StateError(
     'Cannot determine zuraffa project root. '
-    'CWD=${Directory.current.path}',
+    'CWD=$cwdForError',
   );
 }
 
 /// Returns true if [path] looks like it is inside a temp directory.
 bool _isTempPath(String p) {
   final lower = p.toLowerCase();
-  return lower.contains('/tmp') ||
-      lower.contains(RegExp(r'/temp[/\"]')) ||
+  final systemTempLower = Directory.systemTemp.path.toLowerCase();
+
+  // Check if path starts with /tmp/, equals /tmp, or contains /tmp/ as a segment
+  final isTmpSegment = lower == '/tmp' ||
+                       lower.startsWith('/tmp/') ||
+                       lower.contains('/tmp/');
+
+  return isTmpSegment ||
       lower.contains('/var/folders/') ||
-      lower.contains('/noSuchFile') ||
-      lower == Directory.systemTemp.path;
+      lower.contains('/nosuchfile') ||
+      lower == systemTempLower;
 }
 
 final _zfaRoot = _findProjectRoot();

--- a/test/regression/cli_command_test.dart
+++ b/test/regression/cli_command_test.dart
@@ -6,25 +6,100 @@ import 'package:path/path.dart' as p;
 import 'package:zuraffa/src/cli/cli_runner.dart';
 import 'package:zuraffa/src/core/project/project_root.dart';
 
-/// CWD-safe project root, resolved at file-load time.
-final _zfaRoot = _resolveRoot();
+/// CWD-safe project root resolution.
+/// Tries Platform.script (immune to CWD), then CWD walk (with temp guard),
+/// then git rev-parse. Throws [StateError] if the root cannot be found.
+String _findProjectRoot() {
+  // Strategy 1: Walk up from Platform.script (immune to CWD changes).
+  try {
+    var dir = File(Platform.script.toFilePath()).parent;
+    for (var i = 0; i < 10; i++) {
+      final pubspec = File('${dir.path}/pubspec.yaml');
+      if (pubspec.existsSync()) {
+        final c = pubspec.readAsStringSync();
+        if (RegExp(r'^name:\s*zuraffa\s*$', multiLine: true).hasMatch(c)) {
+          return dir.path;
+        }
+      }
+      final parent = dir.parent;
+      if (parent.path == dir.path) break;
+      dir = parent;
+    }
+  } catch (_) {
+    // Platform.script.toFilePath() may fail if CWD was deleted.
+    // Recover CWD to a known-good location and retry.
+    try { Directory.current = Directory.systemTemp.path; } catch (_) {}
+    try {
+      var dir = File(Platform.script.toFilePath()).parent;
+      for (var i = 0; i < 10; i++) {
+        final pubspec = File('${dir.path}/pubspec.yaml');
+        if (pubspec.existsSync()) {
+          final c = pubspec.readAsStringSync();
+          if (RegExp(r'^name:\s*zuraffa\s*$', multiLine: true).hasMatch(c)) {
+            return dir.path;
+          }
+        }
+        final parent = dir.parent;
+        if (parent.path == dir.path) break;
+        dir = parent;
+      }
+    } catch (_) {}
+  }
 
-String _resolveRoot() {
-  var dir = Directory.current;
-  for (var i = 0; i < 10; i++) {
-    final ps = File('${dir.path}/pubspec.yaml');
-    if (ps.existsSync()) {
-      final c = ps.readAsStringSync();
-      if (RegExp(r'^name:\s*zuraffa\s*$', multiLine: true).hasMatch(c)) {
-        return dir.path;
+  // Strategy 2: Walk up from CWD (may be poisoned, so guard against temp dirs).
+  try {
+    var dir = Directory.current;
+    for (var i = 0; i < 15; i++) {
+      final pubspec = File('${dir.path}/pubspec.yaml');
+      if (pubspec.existsSync()) {
+        final c = pubspec.readAsStringSync();
+        if (RegExp(r'^name:\s*zuraffa\s*$', multiLine: true).hasMatch(c)) {
+          final candidate = dir.path;
+          if (!_isTempPath(candidate)) {
+            return candidate;
+          }
+        }
+      }
+      final parent = dir.parent;
+      if (parent.path == dir.path) break;
+      dir = parent;
+    }
+  } catch (_) {}
+
+  // Strategy 3: git rev-parse as last resort.
+  try {
+    final result = Process.runSync('git', ['rev-parse', '--show-toplevel']);
+    if (result.exitCode == 0) {
+      final gitRoot = (result.stdout as String).trim();
+      if (!_isTempPath(gitRoot)) {
+        final pubspec = File('$gitRoot/pubspec.yaml');
+        if (pubspec.existsSync()) {
+          final c = pubspec.readAsStringSync();
+          if (RegExp(r'^name:\s*zuraffa\s*$', multiLine: true).hasMatch(c)) {
+            return gitRoot;
+          }
+        }
       }
     }
-    final parent = dir.parent;
-    if (parent.path == dir.path) break;
-    dir = parent;
-  }
-  return Directory.current.path;
+  } catch (_) {}
+
+  throw StateError(
+    'Cannot determine zuraffa project root. '
+    'CWD=${Directory.current.path}',
+  );
 }
+
+/// Returns true if [path] looks like it is inside a temp directory.
+bool _isTempPath(String p) {
+  final lower = p.toLowerCase();
+  return lower.contains('/tmp') ||
+      lower.contains(RegExp(r'/temp[/\"]')) ||
+      lower.contains('/var/folders/') ||
+      lower.contains('/noSuchFile') ||
+      lower == Directory.systemTemp.path;
+}
+
+final _zfaRoot = _findProjectRoot();
 
 void main() {
   group('CLI command regression', () {
@@ -66,8 +141,15 @@ class Product {
     });
 
     tearDown(() async {
-      try { Directory.current = _savedCwd; } catch (_) {
-        try { Directory.current = Directory.systemTemp; } catch (_) {}
+      // Restore CWD BEFORE deleting workspace to avoid cascading crashes.
+      try {
+        if (Directory(_savedCwd).existsSync()) {
+          Directory.current = _savedCwd;
+        } else {
+          Directory.current = Directory.systemTemp.path;
+        }
+      } catch (_) {
+        try { Directory.current = Directory.systemTemp.path; } catch (_) {}
       }
       if (workspace.existsSync()) {
         await workspace.delete(recursive: true);

--- a/test/regression/docs_command_consistency_test.dart
+++ b/test/regression/docs_command_consistency_test.dart
@@ -2,16 +2,18 @@ import 'dart:io';
 
 import 'package:test/test.dart';
 
-/// CWD-safe project root resolution using Platform.script.
+/// CWD-safe project root resolution.
+/// Tries Platform.script (immune to CWD), then CWD walk (with temp guard),
+/// then git rev-parse. Throws [StateError] if the root cannot be found.
 String _findProjectRoot() {
-  // Strategy 1: Walk up from this test file's location via Platform.script.
+  // Strategy 1: Walk up from Platform.script (immune to CWD changes).
   try {
     var dir = File(Platform.script.toFilePath()).parent;
     for (var i = 0; i < 10; i++) {
       final pubspec = File('${dir.path}/pubspec.yaml');
       if (pubspec.existsSync()) {
-        final content = pubspec.readAsStringSync();
-        if (RegExp(r'^name:\s*zuraffa\s*$', multiLine: true).hasMatch(content)) {
+        final c = pubspec.readAsStringSync();
+        if (RegExp(r'^name:\s*zuraffa\s*$', multiLine: true).hasMatch(c)) {
           return dir.path;
         }
       }
@@ -19,17 +21,39 @@ String _findProjectRoot() {
       if (parent.path == dir.path) break;
       dir = parent;
     }
-  } catch (_) {}
+  } catch (_) {
+    // Platform.script.toFilePath() may fail if CWD was deleted.
+    // Recover CWD to a known-good location and retry.
+    try { Directory.current = Directory.systemTemp.path; } catch (_) {}
+    try {
+      var dir = File(Platform.script.toFilePath()).parent;
+      for (var i = 0; i < 10; i++) {
+        final pubspec = File('${dir.path}/pubspec.yaml');
+        if (pubspec.existsSync()) {
+          final c = pubspec.readAsStringSync();
+          if (RegExp(r'^name:\s*zuraffa\s*$', multiLine: true).hasMatch(c)) {
+            return dir.path;
+          }
+        }
+        final parent = dir.parent;
+        if (parent.path == dir.path) break;
+        dir = parent;
+      }
+    } catch (_) {}
+  }
 
-  // Strategy 2: Walk up from Directory.current (fallback).
+  // Strategy 2: Walk up from CWD (may be poisoned, so guard against temp dirs).
   try {
     var dir = Directory.current;
     for (var i = 0; i < 15; i++) {
       final pubspec = File('${dir.path}/pubspec.yaml');
       if (pubspec.existsSync()) {
-        final content = pubspec.readAsStringSync();
-        if (RegExp(r'^name:\s*zuraffa\s*$', multiLine: true).hasMatch(content)) {
-          return dir.path;
+        final c = pubspec.readAsStringSync();
+        if (RegExp(r'^name:\s*zuraffa\s*$', multiLine: true).hasMatch(c)) {
+          final candidate = dir.path;
+          if (!_isTempPath(candidate)) {
+            return candidate;
+          }
         }
       }
       final parent = dir.parent;
@@ -38,8 +62,39 @@ String _findProjectRoot() {
     }
   } catch (_) {}
 
-  return Directory.current.path;
+  // Strategy 3: git rev-parse as last resort.
+  try {
+    final result = Process.runSync('git', ['rev-parse', '--show-toplevel']);
+    if (result.exitCode == 0) {
+      final gitRoot = (result.stdout as String).trim();
+      if (!_isTempPath(gitRoot)) {
+        final pubspec = File('$gitRoot/pubspec.yaml');
+        if (pubspec.existsSync()) {
+          final c = pubspec.readAsStringSync();
+          if (RegExp(r'^name:\s*zuraffa\s*$', multiLine: true).hasMatch(c)) {
+            return gitRoot;
+          }
+        }
+      }
+    }
+  } catch (_) {}
+
+  throw StateError(
+    'Cannot determine zuraffa project root. '
+    'CWD=${Directory.current.path}',
+  );
 }
+
+/// Returns true if [path] looks like it is inside a temp directory.
+bool _isTempPath(String p) {
+  final lower = p.toLowerCase();
+  return lower.contains('/tmp') ||
+      lower.contains(RegExp(r'/temp[/"]')) ||
+      lower.contains('/var/folders/') ||
+      lower.contains('/noSuchFile') ||
+      lower == Directory.systemTemp.path;
+}
+
 
 void main() {
   final projectRoot = _findProjectRoot();

--- a/test/regression/docs_command_consistency_test.dart
+++ b/test/regression/docs_command_consistency_test.dart
@@ -79,20 +79,33 @@ String _findProjectRoot() {
     }
   } catch (_) {}
 
+  // Read Directory.current.path defensively to avoid masking the intended StateError.
+  String cwdForError;
+  try {
+    cwdForError = Directory.current.path;
+  } catch (_) {
+    cwdForError = '<unable to read CWD>';
+  }
   throw StateError(
     'Cannot determine zuraffa project root. '
-    'CWD=${Directory.current.path}',
+    'CWD=$cwdForError',
   );
 }
 
 /// Returns true if [path] looks like it is inside a temp directory.
 bool _isTempPath(String p) {
   final lower = p.toLowerCase();
-  return lower.contains('/tmp') ||
-      lower.contains(RegExp(r'/temp[/"]')) ||
+  final systemTempLower = Directory.systemTemp.path.toLowerCase();
+
+  // Check if path starts with /tmp/, equals /tmp, or contains /tmp/ as a segment
+  final isTmpSegment = lower == '/tmp' ||
+                       lower.startsWith('/tmp/') ||
+                       lower.contains('/tmp/');
+
+  return isTmpSegment ||
       lower.contains('/var/folders/') ||
-      lower.contains('/noSuchFile') ||
-      lower == Directory.systemTemp.path;
+      lower.contains('/nosuchfile') ||
+      lower == systemTempLower;
 }
 
 

--- a/test/regression/output_quality_test.dart
+++ b/test/regression/output_quality_test.dart
@@ -5,8 +5,10 @@ import 'package:test/test.dart';
 import 'regression_test_utils.dart';
 
 /// CWD-safe project root resolution.
+/// Tries Platform.script (immune to CWD), then CWD walk (with temp guard),
+/// then git rev-parse. Throws [StateError] if the root cannot be found.
 String _findProjectRoot() {
-  // Strategy 1: Walk up from Platform.script.
+  // Strategy 1: Walk up from Platform.script (immune to CWD changes).
   try {
     var dir = File(Platform.script.toFilePath()).parent;
     for (var i = 0; i < 10; i++) {
@@ -21,8 +23,28 @@ String _findProjectRoot() {
       if (parent.path == dir.path) break;
       dir = parent;
     }
-  } catch (_) {}
-  // Strategy 2: Walk up from CWD (fallback).
+  } catch (_) {
+    // Platform.script.toFilePath() may fail if CWD was deleted.
+    // Recover CWD to a known-good location and retry.
+    try { Directory.current = Directory.systemTemp.path; } catch (_) {}
+    try {
+      var dir = File(Platform.script.toFilePath()).parent;
+      for (var i = 0; i < 10; i++) {
+        final pubspec = File('${dir.path}/pubspec.yaml');
+        if (pubspec.existsSync()) {
+          final c = pubspec.readAsStringSync();
+          if (RegExp(r'^name:\s*zuraffa\s*$', multiLine: true).hasMatch(c)) {
+            return dir.path;
+          }
+        }
+        final parent = dir.parent;
+        if (parent.path == dir.path) break;
+        dir = parent;
+      }
+    } catch (_) {}
+  }
+
+  // Strategy 2: Walk up from CWD (may be poisoned, so guard against temp dirs).
   try {
     var dir = Directory.current;
     for (var i = 0; i < 15; i++) {
@@ -30,7 +52,10 @@ String _findProjectRoot() {
       if (pubspec.existsSync()) {
         final c = pubspec.readAsStringSync();
         if (RegExp(r'^name:\s*zuraffa\s*$', multiLine: true).hasMatch(c)) {
-          return dir.path;
+          final candidate = dir.path;
+          if (!_isTempPath(candidate)) {
+            return candidate;
+          }
         }
       }
       final parent = dir.parent;
@@ -38,7 +63,38 @@ String _findProjectRoot() {
       dir = parent;
     }
   } catch (_) {}
-  return Directory.current.path;
+
+  // Strategy 3: git rev-parse as last resort.
+  try {
+    final result = Process.runSync('git', ['rev-parse', '--show-toplevel']);
+    if (result.exitCode == 0) {
+      final gitRoot = (result.stdout as String).trim();
+      if (!_isTempPath(gitRoot)) {
+        final pubspec = File('$gitRoot/pubspec.yaml');
+        if (pubspec.existsSync()) {
+          final c = pubspec.readAsStringSync();
+          if (RegExp(r'^name:\s*zuraffa\s*$', multiLine: true).hasMatch(c)) {
+            return gitRoot;
+          }
+        }
+      }
+    }
+  } catch (_) {}
+
+  throw StateError(
+    'Cannot determine zuraffa project root. '
+    'CWD=${Directory.current.path}',
+  );
+}
+
+/// Returns true if [path] looks like it is inside a temp directory.
+bool _isTempPath(String p) {
+  final lower = p.toLowerCase();
+  return lower.contains('/tmp') ||
+      lower.contains(RegExp(r'/temp[/\"]')) ||
+      lower.contains('/var/folders/') ||
+      lower.contains('/noSuchFile') ||
+      lower == Directory.systemTemp.path;
 }
 
 void main() {

--- a/test/regression/output_quality_test.dart
+++ b/test/regression/output_quality_test.dart
@@ -81,20 +81,33 @@ String _findProjectRoot() {
     }
   } catch (_) {}
 
+  // Read Directory.current.path defensively to avoid masking the intended StateError.
+  String cwdForError;
+  try {
+    cwdForError = Directory.current.path;
+  } catch (_) {
+    cwdForError = '<unable to read CWD>';
+  }
   throw StateError(
     'Cannot determine zuraffa project root. '
-    'CWD=${Directory.current.path}',
+    'CWD=$cwdForError',
   );
 }
 
 /// Returns true if [path] looks like it is inside a temp directory.
 bool _isTempPath(String p) {
   final lower = p.toLowerCase();
-  return lower.contains('/tmp') ||
-      lower.contains(RegExp(r'/temp[/\"]')) ||
+  final systemTempLower = Directory.systemTemp.path.toLowerCase();
+
+  // Check if path starts with /tmp/, equals /tmp, or contains /tmp/ as a segment
+  final isTmpSegment = lower == '/tmp' ||
+                       lower.startsWith('/tmp/') ||
+                       lower.contains('/tmp/');
+
+  return isTmpSegment ||
       lower.contains('/var/folders/') ||
-      lower.contains('/noSuchFile') ||
-      lower == Directory.systemTemp.path;
+      lower.contains('/nosuchfile') ||
+      lower == systemTempLower;
 }
 
 void main() {

--- a/test/regression/v5_pipeline_contract_test.dart
+++ b/test/regression/v5_pipeline_contract_test.dart
@@ -5,8 +5,10 @@ import 'package:test/test.dart';
 import 'package:zuraffa/src/core/project/project_context_store.dart';
 
 /// CWD-safe project root resolution.
+/// Tries Platform.script (immune to CWD), then CWD walk (with temp guard),
+/// then git rev-parse. Throws [StateError] if the root cannot be found.
 String _findProjectRoot() {
-  // Strategy 1: Walk up from Platform.script.
+  // Strategy 1: Walk up from Platform.script (immune to CWD changes).
   try {
     var dir = File(Platform.script.toFilePath()).parent;
     for (var i = 0; i < 10; i++) {
@@ -21,8 +23,28 @@ String _findProjectRoot() {
       if (parent.path == dir.path) break;
       dir = parent;
     }
-  } catch (_) {}
-  // Strategy 2: Walk up from CWD (fallback).
+  } catch (_) {
+    // Platform.script.toFilePath() may fail if CWD was deleted.
+    // Recover CWD to a known-good location and retry.
+    try { Directory.current = Directory.systemTemp.path; } catch (_) {}
+    try {
+      var dir = File(Platform.script.toFilePath()).parent;
+      for (var i = 0; i < 10; i++) {
+        final pubspec = File('${dir.path}/pubspec.yaml');
+        if (pubspec.existsSync()) {
+          final c = pubspec.readAsStringSync();
+          if (RegExp(r'^name:\s*zuraffa\s*$', multiLine: true).hasMatch(c)) {
+            return dir.path;
+          }
+        }
+        final parent = dir.parent;
+        if (parent.path == dir.path) break;
+        dir = parent;
+      }
+    } catch (_) {}
+  }
+
+  // Strategy 2: Walk up from CWD (may be poisoned, so guard against temp dirs).
   try {
     var dir = Directory.current;
     for (var i = 0; i < 15; i++) {
@@ -30,7 +52,10 @@ String _findProjectRoot() {
       if (pubspec.existsSync()) {
         final c = pubspec.readAsStringSync();
         if (RegExp(r'^name:\s*zuraffa\s*$', multiLine: true).hasMatch(c)) {
-          return dir.path;
+          final candidate = dir.path;
+          if (!_isTempPath(candidate)) {
+            return candidate;
+          }
         }
       }
       final parent = dir.parent;
@@ -38,7 +63,38 @@ String _findProjectRoot() {
       dir = parent;
     }
   } catch (_) {}
-  return Directory.current.path;
+
+  // Strategy 3: git rev-parse as last resort.
+  try {
+    final result = Process.runSync('git', ['rev-parse', '--show-toplevel']);
+    if (result.exitCode == 0) {
+      final gitRoot = (result.stdout as String).trim();
+      if (!_isTempPath(gitRoot)) {
+        final pubspec = File('$gitRoot/pubspec.yaml');
+        if (pubspec.existsSync()) {
+          final c = pubspec.readAsStringSync();
+          if (RegExp(r'^name:\s*zuraffa\s*$', multiLine: true).hasMatch(c)) {
+            return gitRoot;
+          }
+        }
+      }
+    }
+  } catch (_) {}
+
+  throw StateError(
+    'Cannot determine zuraffa project root. '
+    'CWD=${Directory.current.path}',
+  );
+}
+
+/// Returns true if [path] looks like it is inside a temp directory.
+bool _isTempPath(String p) {
+  final lower = p.toLowerCase();
+  return lower.contains('/tmp') ||
+      lower.contains(RegExp(r'/temp[/\"]')) ||
+      lower.contains('/var/folders/') ||
+      lower.contains('/noSuchFile') ||
+      lower == Directory.systemTemp.path;
 }
 
 void main() {

--- a/test/regression/v5_pipeline_contract_test.dart
+++ b/test/regression/v5_pipeline_contract_test.dart
@@ -81,20 +81,33 @@ String _findProjectRoot() {
     }
   } catch (_) {}
 
+  // Read Directory.current.path defensively to avoid masking the intended StateError.
+  String cwdForError;
+  try {
+    cwdForError = Directory.current.path;
+  } catch (_) {
+    cwdForError = '<unable to read CWD>';
+  }
   throw StateError(
     'Cannot determine zuraffa project root. '
-    'CWD=${Directory.current.path}',
+    'CWD=$cwdForError',
   );
 }
 
 /// Returns true if [path] looks like it is inside a temp directory.
 bool _isTempPath(String p) {
   final lower = p.toLowerCase();
-  return lower.contains('/tmp') ||
-      lower.contains(RegExp(r'/temp[/\"]')) ||
+  final systemTempLower = Directory.systemTemp.path.toLowerCase();
+
+  // Check if path starts with /tmp/, equals /tmp, or contains /tmp/ as a segment
+  final isTmpSegment = lower == '/tmp' ||
+                       lower.startsWith('/tmp/') ||
+                       lower.contains('/tmp/');
+
+  return isTmpSegment ||
       lower.contains('/var/folders/') ||
-      lower.contains('/noSuchFile') ||
-      lower == Directory.systemTemp.path;
+      lower.contains('/nosuchfile') ||
+      lower == systemTempLower;
 }
 
 void main() {


### PR DESCRIPTION
## Summary

Fixes all 11 remaining test failures after PR #261 CWD fix.

## Root Causes

1. **vpc_records_test.dart**: Variable `_safeRoot` and function `_safeRoot()` shared the same name, causing a compile-time collision.

2. **make_command_test.dart, output_quality_test.dart, v5_pipeline_contract_test.dart, docs_command_consistency_test.dart** (10 failures): `_findProjectRoot()` fell back to `Directory.current.path` when `Platform.script` strategy failed (e.g., CWD deleted). The poisoned CWD pointed to another test's temp dir, causing file-not-found and path-resolution errors.

3. **cli_command_test.dart**: `_resolveRoot()` only used `Directory.current` (no `Platform.script` strategy), making it vulnerable to CWD poisoning.

4. **xray_deck_cli_test.dart**: tearDown deleted temp dir BEFORE restoring CWD.

## Changes

- **vpc_records_test.dart**: Rename `_safeRoot` variable to `_resolvedRoot`
- **_findProjectRoot()** (5 files): Add 3-layer resolution with CWD recovery, temp-path guard, and git fallback
- **cli_command_test.dart**: Replace `_resolveRoot()` with `Platform.script`-based `_findProjectRoot()` + fix tearDown CWD ordering
- **xray_deck_cli_test.dart**: Restore CWD BEFORE deleting temp dir in tearDown

## Test Results

All 11 previously-failing tests now pass.

Note: output_quality_test has 1 pre-existing formatting failure unrelated to CWD.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project-root detection across varied working-directory and script-location states.
  * Prevented temporary directories from being incorrectly treated as project roots.
  * Added Git-based fallback resolution when other discovery methods are unavailable.
  * Clearer failure handling now reports when a valid project root cannot be found.

* **Tests**
  * Improved test cleanup to restore working directories safely before removing temporary files.
  * Added coverage for invalid paths, recovery scenarios, and project-root resolution failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->