### PR TITLE
feat(CLI): add self-update command

### DIFF
--- a/lib/src/cli/cli_runner.dart
+++ b/lib/src/cli/cli_runner.dart
@@ -12,6 +12,7 @@ import '../commands/plugin_command.dart' as plugincmd;
 import '../commands/make_command.dart';
 import '../commands/doctor_command.dart';
 import '../commands/migrate_command.dart';
+import '../commands/update_command.dart';
 import '../commands/build_command.dart';
 import '../commands/manifest_command.dart';
 import '../commands/apply_command.dart';
@@ -83,6 +84,7 @@ class CliRunner {
     _runner.addCommand(ApplyCommand(registry));
     _runner.addCommand(ModuleCommand());
     _runner.addCommand(XrayCommand());
+    _runner.addCommand(UpdateCommand());
   }
 
   /// Run CLI with arguments.
@@ -224,6 +226,7 @@ CORE COMMANDS:
   schema              Output JSON schema
   validate <file>     Validate JSON configuration
   migrate <target>     Migrate v5 artifacts to v6 (state, gql, di)
+  update              Check for updates and update the installed CLI
 
 MODULAR COMMANDS:
   module <Name>      Scaffold a new feature package with plugin orchestrator

--- a/lib/src/commands/update_command.dart
+++ b/lib/src/commands/update_command.dart
@@ -41,7 +41,7 @@ class UpdateCommand extends Command<void> {
       latest = await _fetchLatestVersion();
     } catch (e) {
       print('  Failed to check for updates: $e');
-      exit(1);
+      throw Exception('Failed to check for updates: $e');
     }
 
     print('Latest version:  $latest');
@@ -88,7 +88,7 @@ class UpdateCommand extends Command<void> {
         print('  $stdout');
       }
       print('Update failed. Try: dart pub global activate zuraffa');
-      exit(1);
+      throw Exception('Update failed. Try: dart pub global activate zuraffa');
     }
   }
 
@@ -110,7 +110,8 @@ class UpdateCommand extends Command<void> {
 
       final body = await response.transform(utf8.decoder).join();
       final json = jsonDecode(body) as Map<String, dynamic>;
-      return json['latest'] as String? ?? 'unknown';
+      final latest = json['latest'] as Map<String, dynamic>?;
+      return latest?['version'] as String? ?? 'unknown';
     } finally {
       client.close(force: true);
     }
@@ -118,24 +119,52 @@ class UpdateCommand extends Command<void> {
 
   /// Compare two semantic versions.
   /// Returns negative if [a] < [b], zero if equal, positive if [a] > [b].
+  /// Follows SemVer: pre-release versions have lower precedence than stable.
   static int compareVersions(String a, String b) {
-    final aParts = parseVersion(a);
-    final bParts = parseVersion(b);
+    final aParsed = parseVersion(a);
+    final bParsed = parseVersion(b);
+
+    // Compare major.minor.patch
     for (var i = 0; i < 3; i++) {
-      if (aParts[i] != bParts[i]) return aParts[i] - bParts[i];
+      if (aParsed.numeric[i] != bParsed.numeric[i]) {
+        return aParsed.numeric[i] - bParsed.numeric[i];
+      }
     }
-    return 0;
+
+    // If numeric parts are equal, compare pre-release identifiers
+    // Per SemVer: stable > pre-release, pre-release compared lexically
+    if (aParsed.preRelease == null && bParsed.preRelease == null) {
+      return 0; // Both stable and equal
+    }
+    if (aParsed.preRelease == null) {
+      return 1; // a is stable, b is pre-release: a > b
+    }
+    if (bParsed.preRelease == null) {
+      return -1; // a is pre-release, b is stable: a < b
+    }
+
+    // Both have pre-release: compare lexically
+    return aParsed.preRelease!.compareTo(bParsed.preRelease!);
   }
 
-  /// Parse a version string like "1.2.3" into a list of 3 ints.
-  /// Pre-release/build suffixes are stripped before parsing.
-  static List<int> parseVersion(String v) {
-    final clean = v.split(RegExp(r'[-+]')).first;
-    final parts = clean.split('.');
-    return [
-      int.tryParse(parts.elementAtOrNull(0) ?? '0') ?? 0,
-      int.tryParse(parts.elementAtOrNull(1) ?? '0') ?? 0,
-      int.tryParse(parts.elementAtOrNull(2) ?? '0') ?? 0,
+  /// Parse a version string like "1.2.3" or "1.2.3-alpha" into numeric and pre-release parts.
+  /// Build metadata (after +) is ignored per SemVer.
+  static ({List<int> numeric, String? preRelease}) parseVersion(String v) {
+    // Strip build metadata (everything after +)
+    final withoutBuild = v.split('+').first;
+
+    // Split on - to separate numeric from pre-release
+    final parts = withoutBuild.split('-');
+    final numericPart = parts.first;
+    final preRelease = parts.length > 1 ? parts.sublist(1).join('-') : null;
+
+    final numericParts = numericPart.split('.');
+    final numeric = [
+      int.tryParse(numericParts.elementAtOrNull(0) ?? '0') ?? 0,
+      int.tryParse(numericParts.elementAtOrNull(1) ?? '0') ?? 0,
+      int.tryParse(numericParts.elementAtOrNull(2) ?? '0') ?? 0,
     ];
+
+    return (numeric: numeric, preRelease: preRelease);
   }
 }

--- a/lib/src/commands/update_command.dart
+++ b/lib/src/commands/update_command.dart
@@ -1,0 +1,141 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:args/command_runner.dart';
+import '../version.dart';
+
+/// CLI command to check for and apply updates to the zfa CLI.
+class UpdateCommand extends Command<void> {
+  static const _pubDevUrl = 'https://pub.dev/api/packages/zuraffa';
+  static const _timeout = Duration(seconds: 15);
+
+  @override
+  String get name => 'update';
+
+  @override
+  String get description => 'Check for updates and update the installed zfa CLI.';
+
+  UpdateCommand() {
+    argParser.addFlag(
+      'dry-run',
+      negatable: false,
+      help: 'Check for updates without installing.',
+    );
+    argParser.addFlag(
+      'force',
+      negatable: false,
+      help: 'Force reinstall the latest version even if already up to date.',
+    );
+  }
+
+  @override
+  Future<void> run() async {
+    final dryRun = argResults!['dry-run'] == true;
+    final force = argResults!['force'] == true;
+
+    final current = version;
+    print('Current version: $current');
+    print('Checking pub.dev for latest version...');
+
+    String latest;
+    try {
+      latest = await _fetchLatestVersion();
+    } catch (e) {
+      print('  Failed to check for updates: $e');
+      exit(1);
+    }
+
+    print('Latest version:  $latest');
+
+    final cmp = compareVersions(current, latest);
+
+    if (cmp >= 0 && !force) {
+      print('');
+      print('zfa is already up to date.');
+      return;
+    }
+
+    if (dryRun) {
+      print('');
+      print('Update available: $current -> $latest');
+      print('Run "zfa update" to install.');
+      return;
+    }
+
+    print('');
+    if (force && cmp >= 0) {
+      print('Force reinstalling zuraffa...');
+    } else {
+      print('Updating zuraffa $current -> $latest...');
+    }
+
+    final result = await Process.run(
+      'dart',
+      ['pub', 'global', 'activate', 'zuraffa'],
+    ).timeout(_timeout * 4);
+
+    if (result.exitCode == 0) {
+      print(result.stdout.toString().trim());
+      print('');
+      print('Update complete. Restart your terminal or run:');
+      print('  zfa --version');
+    } else {
+      final stderr = result.stderr.toString().trim();
+      if (stderr.isNotEmpty) {
+        print('  $stderr');
+      }
+      final stdout = result.stdout.toString().trim();
+      if (stdout.isNotEmpty) {
+        print('  $stdout');
+      }
+      print('Update failed. Try: dart pub global activate zuraffa');
+      exit(1);
+    }
+  }
+
+  /// Fetch the latest version string from the pub.dev API.
+  Future<String> _fetchLatestVersion() async {
+    final client = HttpClient()
+      ..connectionTimeout = _timeout;
+    try {
+      final request = await client.getUrl(Uri.parse(_pubDevUrl));
+      request.headers.set('User-Agent', 'zfa update');
+      final response = await request.close().timeout(_timeout);
+
+      if (response.statusCode != 200) {
+        throw HttpException(
+          'pub.dev returned ${response.statusCode}',
+          uri: Uri.parse(_pubDevUrl),
+        );
+      }
+
+      final body = await response.transform(utf8.decoder).join();
+      final json = jsonDecode(body) as Map<String, dynamic>;
+      return json['latest'] as String? ?? 'unknown';
+    } finally {
+      client.close(force: true);
+    }
+  }
+
+  /// Compare two semantic versions.
+  /// Returns negative if [a] < [b], zero if equal, positive if [a] > [b].
+  static int compareVersions(String a, String b) {
+    final aParts = parseVersion(a);
+    final bParts = parseVersion(b);
+    for (var i = 0; i < 3; i++) {
+      if (aParts[i] != bParts[i]) return aParts[i] - bParts[i];
+    }
+    return 0;
+  }
+
+  /// Parse a version string like "1.2.3" into a list of 3 ints.
+  /// Pre-release/build suffixes are stripped before parsing.
+  static List<int> parseVersion(String v) {
+    final clean = v.split(RegExp(r'[-+]')).first;
+    final parts = clean.split('.');
+    return [
+      int.tryParse(parts.elementAtOrNull(0) ?? '0') ?? 0,
+      int.tryParse(parts.elementAtOrNull(1) ?? '0') ?? 0,
+      int.tryParse(parts.elementAtOrNull(2) ?? '0') ?? 0,
+    ];
+  }
+}

--- a/test/commands/update_command_test.dart
+++ b/test/commands/update_command_test.dart
@@ -27,10 +27,19 @@ void main() {
       });
 
       test('handles pre-release suffixes', () {
-        // Pre-release is treated as the base version (suffix stripped)
-        expect(UpdateCommand.compareVersions('1.0.0-alpha', '1.0.0'), 0);
-        expect(UpdateCommand.compareVersions('1.0.0-beta', '1.0.0'), 0);
+        // Per SemVer: pre-release versions have lower precedence than stable
+        expect(UpdateCommand.compareVersions('1.0.0-alpha', '1.0.0'), isNegative);
+        expect(UpdateCommand.compareVersions('1.0.0-beta', '1.0.0'), isNegative);
+        expect(UpdateCommand.compareVersions('1.0.0', '1.0.0-alpha'), isPositive);
+        // Build metadata is ignored
         expect(UpdateCommand.compareVersions('1.0.0+build', '1.0.0'), 0);
+      });
+
+      test('pre-release ordering', () {
+        // Pre-release versions with same numeric part are compared lexically
+        expect(UpdateCommand.compareVersions('1.0.0-alpha', '1.0.0-beta'), isNegative);
+        expect(UpdateCommand.compareVersions('1.0.0-beta', '1.0.0-alpha'), isPositive);
+        expect(UpdateCommand.compareVersions('1.0.0-alpha', '1.0.0-alpha'), 0);
       });
 
       test('handles missing parts', () {
@@ -54,24 +63,43 @@ void main() {
 
     group('_parseVersion', () {
       test('parses standard version', () {
-        expect(UpdateCommand.parseVersion('1.2.3'), [1, 2, 3]);
+        final result = UpdateCommand.parseVersion('1.2.3');
+        expect(result.numeric, [1, 2, 3]);
+        expect(result.preRelease, isNull);
       });
 
       test('parses version with pre-release', () {
-        expect(UpdateCommand.parseVersion('1.2.3-alpha.1'), [1, 2, 3]);
+        final result = UpdateCommand.parseVersion('1.2.3-alpha.1');
+        expect(result.numeric, [1, 2, 3]);
+        expect(result.preRelease, 'alpha.1');
       });
 
       test('parses version with build metadata', () {
-        expect(UpdateCommand.parseVersion('1.2.3+build.42'), [1, 2, 3]);
+        final result = UpdateCommand.parseVersion('1.2.3+build.42');
+        expect(result.numeric, [1, 2, 3]);
+        expect(result.preRelease, isNull);
+      });
+
+      test('parses version with both pre-release and build metadata', () {
+        final result = UpdateCommand.parseVersion('1.2.3-alpha+build.42');
+        expect(result.numeric, [1, 2, 3]);
+        expect(result.preRelease, 'alpha');
       });
 
       test('handles short versions', () {
-        expect(UpdateCommand.parseVersion('1'), [1, 0, 0]);
-        expect(UpdateCommand.parseVersion('1.2'), [1, 2, 0]);
+        var result = UpdateCommand.parseVersion('1');
+        expect(result.numeric, [1, 0, 0]);
+        expect(result.preRelease, isNull);
+
+        result = UpdateCommand.parseVersion('1.2');
+        expect(result.numeric, [1, 2, 0]);
+        expect(result.preRelease, isNull);
       });
 
       test('handles empty string', () {
-        expect(UpdateCommand.parseVersion(''), [0, 0, 0]);
+        final result = UpdateCommand.parseVersion('');
+        expect(result.numeric, [0, 0, 0]);
+        expect(result.preRelease, isNull);
       });
     });
   });

--- a/test/commands/update_command_test.dart
+++ b/test/commands/update_command_test.dart
@@ -1,0 +1,78 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:test/test.dart';
+import 'package:zuraffa/src/commands/update_command.dart';
+
+void main() {
+  group('UpdateCommand', () {
+    group('_compareVersions', () {
+      test('equal versions return 0', () {
+        expect(UpdateCommand.compareVersions('1.0.0', '1.0.0'), 0);
+        expect(UpdateCommand.compareVersions('2.3.4', '2.3.4'), 0);
+      });
+
+      test('major version difference', () {
+        expect(UpdateCommand.compareVersions('1.0.0', '2.0.0'), isNegative);
+        expect(UpdateCommand.compareVersions('2.0.0', '1.0.0'), isPositive);
+      });
+
+      test('minor version difference', () {
+        expect(UpdateCommand.compareVersions('1.1.0', '1.2.0'), isNegative);
+        expect(UpdateCommand.compareVersions('1.2.0', '1.1.0'), isPositive);
+      });
+
+      test('patch version difference', () {
+        expect(UpdateCommand.compareVersions('1.0.1', '1.0.2'), isNegative);
+        expect(UpdateCommand.compareVersions('1.0.2', '1.0.1'), isPositive);
+      });
+
+      test('handles pre-release suffixes', () {
+        // Pre-release is treated as the base version (suffix stripped)
+        expect(UpdateCommand.compareVersions('1.0.0-alpha', '1.0.0'), 0);
+        expect(UpdateCommand.compareVersions('1.0.0-beta', '1.0.0'), 0);
+        expect(UpdateCommand.compareVersions('1.0.0+build', '1.0.0'), 0);
+      });
+
+      test('handles missing parts', () {
+        expect(UpdateCommand.compareVersions('1', '1.0.0'), 0);
+        expect(UpdateCommand.compareVersions('1.2', '1.2.0'), 0);
+        expect(UpdateCommand.compareVersions('1', '2.0.0'), isNegative);
+      });
+
+      test('handles non-numeric gracefully', () {
+        expect(UpdateCommand.compareVersions('unknown', '0.0.0'), 0);
+        expect(UpdateCommand.compareVersions('1.0.0', 'unknown'), isPositive);
+      });
+      
+      test('complex comparison chain', () {
+        expect(UpdateCommand.compareVersions('5.1.0', '6.0.0'), isNegative);
+        expect(UpdateCommand.compareVersions('6.0.0', '5.1.0'), isPositive);
+        expect(UpdateCommand.compareVersions('6.0.0', '6.0.1'), isNegative);
+        expect(UpdateCommand.compareVersions('6.0.1', '6.0.0'), isPositive);
+      });
+    });
+
+    group('_parseVersion', () {
+      test('parses standard version', () {
+        expect(UpdateCommand.parseVersion('1.2.3'), [1, 2, 3]);
+      });
+
+      test('parses version with pre-release', () {
+        expect(UpdateCommand.parseVersion('1.2.3-alpha.1'), [1, 2, 3]);
+      });
+
+      test('parses version with build metadata', () {
+        expect(UpdateCommand.parseVersion('1.2.3+build.42'), [1, 2, 3]);
+      });
+
+      test('handles short versions', () {
+        expect(UpdateCommand.parseVersion('1'), [1, 0, 0]);
+        expect(UpdateCommand.parseVersion('1.2'), [1, 2, 0]);
+      });
+
+      test('handles empty string', () {
+        expect(UpdateCommand.parseVersion(''), [0, 0, 0]);
+      });
+    });
+  });
+}


### PR DESCRIPTION
Closes #260

Adds a `zfa update` command that checks pub.dev for the latest published version and updates the installed CLI in place via `dart pub global activate`.

The existing `validate` command (JSON config validator) already occupies that namespace, so self-update was the missing piece.

**Behaviour:**
- `zfa update` — fetches latest from pub.dev, installs if newer.
- `zfa update --dry-run` — check only, prints available update.
- `zfa update --force` — reinstall latest even if already current.

**Implementation:**
- Zero new dependencies (uses `dart:io` `HttpClient` for pub.dev API).
- Static `compareVersions` / `parseVersion` helpers (tested, reusable).
- 15s HTTP timeout, 60s activate timeout.
- Registered in `CliRunner` + help text.

**Verification:**
- `dart analyze`: no issues
- 13 new unit tests: all pass
- Existing `make_command_test`: no regression

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `update` CLI command to check for the latest version.
  * Supports dry-run checks and forced reinstallation.
  * Displays update status, command output, and errors.
  * Added the command to CLI help documentation.

* **Tests**
  * Added coverage for version parsing and comparison, including prerelease and incomplete versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->