### PR TITLE
fix: make_command_test tearDown always restores CWD to valid dir

### DIFF
--- a/test/commands/make_command_test.dart
+++ b/test/commands/make_command_test.dart
@@ -70,8 +70,19 @@ class Product {
     });
 
     tearDown(() async {
-      if (Directory(previousCwd).existsSync()) {
-        Directory.current = previousCwd;
+      // Always restore CWD to a known-valid directory before deleting
+      // the workspace, to prevent poisoning CWD for subsequently loaded
+      // test files that call findProjectRoot() at the top of main().
+      try {
+        if (Directory(previousCwd).existsSync()) {
+          Directory.current = previousCwd;
+        } else {
+          Directory.current = Directory.systemTemp.path;
+        }
+      } catch (_) {
+        try {
+          Directory.current = Directory.systemTemp.path;
+        } catch (_) {}
       }
       if (workspace.existsSync()) {
         await workspace.delete(recursive: true);


### PR DESCRIPTION
## Problem\n\nmake_command_test tearDown only restored CWD when previousCwd existed. When another test deleted previousCwd, the tearDown left CWD pointing to the workspace temp dir, which was then deleted — poisoning CWD for all subsequently loaded test files.\n\nThis is the root cause of the 3 remaining failures (output_quality_test, v5_pipeline_contract_test, docs_command_consistency_test).\n\n## Fix\n\nAlways restore CWD to a valid directory before deleting the workspace. Falls back to systemTemp when previousCwd does not exist.\n\nCombined with the shared findProjectRoot() helper (PR #269), this provides belt-and-suspenders protection against CWD poisoning.