### PR TITLE
[v6 EPIC #162] .state.dart Enhancements: State Fragments & Dual-Layer Architecture

### DIFF
--- a/docs/v6_state_migration_guide.md
+++ b/docs/v6_state_migration_guide.md
@@ -1,0 +1,289 @@
+# V6 State Migration Guide: v5 → v6 Dual-Layer Architecture
+
+This guide walks you through migrating from the v5 monolithic `.state.dart`
+pattern to the v6 **dual-layer state architecture** — `DomainState` +
+`ViewState` with fragmented `SignalSlice`s, `FragmentBuilder` for granular
+rebuids, and automated cache-binding for cross-view sync.
+
+## Why Migrate?
+
+### The v5 Problem
+
+In v5, a single generated `.state.dart` file holds **all** state for a
+presenter — both domain data (loaded from UseCases) and transient UI state
+(dropdowns, tabs, scroll position). Because `zfa build` regenerates this
+file, any **manual UI state edits are wiped** on every build cycle.
+Developers resort to `@preserve` blocks and workarounds, and any single
+UseCase update triggers a full listener cycle across the entire presenter.
+
+### The v6 Solution
+
+v6 introduces a strict **dual-layer boundary**:
+
+| Layer | Class | Ownership | Regenerated? |
+|-------|-------|-----------|--------------|
+| **DomainState** | `{Name}DomainState` | Auto-generated | ✅ Every `zfa build` |
+| **ViewState** | `{Name}ViewState` | Developer-edited | ❌ Scaffolded once, preserved |
+| **Presenter** | `{Name}Presenter extends DualLayerPresenter` | Developer-edited | ❌ Scaffolded once, preserved |
+
+Each UseCase gets its own `SignalSlice<T>` inside `DomainState`, enabling
+**O(1) granular rebuilds** — a widget listening to the `product` slice does
+not rebuild when the `reviews` slice updates.
+
+## Architecture Overview
+
+```
+┌──────────────────────────────────────────────┐
+│           DualLayerPresenter                 │
+│  ┌─────────────────┐  ┌─────────────────┐    │
+│  │  DomainState    │  │   ViewState     │    │
+│  │  (generated)    │  │  (hand-edited)  │    │
+│  │                 │  │                 │    │
+│  │  SignalSlice<T> │  │  Signal<T>      │    │
+│  │  ─ product      │  │  ─ isLoading    │    │
+│  │  ─ reviews      │  │  ─ activeTab    │    │
+│  │  ─ related      │  │  ─ scrollOffset │    │
+│  └────────┬────────┘  └────────┬────────┘    │
+│           │                    │              │
+│           ▼                    ▼              │
+│     FragmentBuilder<S>   SignalBuilder<T>    │
+│     (domain rebuilds)    (UI rebuilds)       │
+└──────────────────────────────────────────────┘
+```
+
+## Key Concepts
+
+### SignalSlice
+
+A fine-grained reactive wrapper around a single UseCase's `SignalResult<T>`.
+Each slice is independent — subscribing to one slice does not trigger
+callbacks on other slices.
+
+```dart
+final productSlice = SignalSlice<Product>(
+  useCase: getProductUseCase,
+  params: GetProductParams(id: '123'),
+);
+productSlice.listen((product, error) { /* O(1) rebuild */ });
+```
+
+### DomainState (generated, read-only)
+
+A sealed container of `SignalSlice`s. **Never edit manually** — it is
+overwritten on every `zfa build`.
+
+```dart
+// GENERATED — do not edit
+class ProductDetailDomainState extends DomainState {
+  ProductDetailDomainState({required super.presenter});
+
+  late final product = bind<Product>('product', getProductUseCase, GetProductParams());
+  late final reviews = bind<List<Review>>('reviews', getReviewsUseCase, GetReviewsParams());
+}
+```
+
+### ViewState (scaffolded once, preserved)
+
+Holds transient UI state via `Signal<T>` fields. Safe to edit — the
+generator **never overwrites** an existing `ViewState` file.
+
+```dart
+// SCAFFOLDED — safe to edit, never regenerated
+class ProductDetailViewState extends ViewState {
+  ProductDetailViewState() {
+    registerSignal(isDescriptionExpanded);
+    registerSignal(activeTabIndex);
+  }
+
+  final isDescriptionExpanded = Signal<bool>(false);
+  final activeTabIndex = Signal<int>(0);
+}
+```
+
+### FragmentBuilder & SignalBuilder
+
+- **`FragmentBuilder<S>`** — subscribes to a single `SignalSlice<S>` and
+  rebuilds only when that slice changes. Ships with `onLoading`,
+  `onError`, and `onEmpty` builders.
+- **`SignalBuilder<T>`** — subscribes to a pure UI `Signal<T>` from
+  `ViewState` (e.g. `isEditMode`, `activeTabIndex`).
+
+```dart
+FragmentBuilder<Product>(
+  slice: controller.domain.slice<Product>('product')!,
+  onLoading: (context) => const ProductSkeleton(),
+  onError: (context, error) => ErrorCard(error: error),
+  builder: (context, product) => ProductCard(product: product),
+),
+SignalBuilder<bool>(
+  signal: controller.view.isDescriptionExpanded,
+  builder: (context, expanded) => expanded ? ExpandedView() : CollapsedView(),
+),
+```
+
+### ControlledWidget
+
+The v6 base widget with typed controller access and `onInit` / `onDispose`
+lifecycle hooks.
+
+```dart
+class ProductDetailView extends ControlledWidget<ProductDetailPresenter> {
+  const ProductDetailView({super.key, required super.controller});
+
+  @override
+  void onInit() => controller.domain.slice<Product>('product')?.refresh();
+
+  @override
+  Widget build(BuildContext context) { /* ... */ }
+}
+```
+
+## Migration Steps
+
+### 1. Generate v6 state for an entity
+
+Use the `--v6-state` flag with `zfa view` or `zfa make`:
+
+```bash
+# Via zfa view
+zfa view Product --v6-state --methods=get,update
+
+# Via zfa make (view plugin auto-registers --v6-state)
+zfa make Product view --v6-state --methods=get,update
+```
+
+This generates four files:
+
+| File | Regenerated? | Purpose |
+|------|--------------|---------|
+| `product_domain_state.dart` | ✅ Every build | SignalSlices for domain data |
+| `product_view_state.dart` | ❌ Once | Transient UI state (Signal fields) |
+| `product_presenter.dart` | ❌ Once | DualLayerPresenter wiring |
+| `product_view.dart` | ✅ Template | ControlledWidget + FragmentBuilder |
+
+### 2. Migrate existing v5 state files
+
+Use `zfa migrate state` to convert v5 monolithic `.state.dart` files to the
+v6 slice pattern:
+
+```bash
+# Preview changes
+zfa migrate state --dry-run
+
+# Apply
+zfa migrate state
+```
+
+The migrator:
+- Detects `*Presenter` classes with `UseCase` fields
+- Generates `late final` slice bindings (`bind<T>(...)`) for each UseCase
+- Derives semantic slice keys from field names (strips `UseCase` suffix,
+  common action prefixes like `get`/`fetch`/`load`)
+- Creates a `.bak` backup when writing over the source file
+
+### 3. Move transient UI state to ViewState
+
+Any UI state that lived inside the v5 generated state file (dropdowns,
+tabs, scroll position, form fields) must move to `ViewState`:
+
+**Before (v5):**
+```dart
+// product_state.dart — wiped on every build
+class ProductState {
+  bool isDropdownOpen = false;  // ❌ lost on regeneration
+  int activeTab = 0;            // ❌ lost on regeneration
+}
+```
+
+**After (v6):**
+```dart
+// product_view_state.dart — preserved across builds
+class ProductViewState extends ViewState {
+  ProductViewState() {
+    registerSignal(isDropdownOpen);
+    registerSignal(activeTab);
+  }
+  final isDropdownOpen = Signal<bool>(false);
+  final activeTab = Signal<int>(0);
+}
+```
+
+### 4. Update views to use FragmentBuilder
+
+Replace monolithic state consumption with `FragmentBuilder` + `SignalBuilder`:
+
+**Before (v5):**
+```dart
+// Rebuilds the ENTIRE view on any state change
+Widget build(BuildContext context) {
+  final state = controller.state;
+  return Column(children: [
+    if (state.isLoading) CircularProgressIndicator(),
+    Text(state.product?.name ?? ''),
+    Text(state.reviews?.length.toString() ?? '0'),
+  ]);
+}
+```
+
+**After (v6):**
+```dart
+// Each section rebuilds independently
+Widget build(BuildContext context) {
+  return Column(children: [
+    FragmentBuilder<Product>(
+      slice: controller.domain.slice<Product>('product')!,
+      onLoading: (context) => const CircularProgressIndicator(),
+      builder: (context, product) => Text(product.name),
+    ),
+    FragmentBuilder<List<Review>>(
+      slice: controller.domain.slice<List<Review>>('reviews')!,
+      builder: (context, reviews) => Text('${reviews.length}'),
+    ),
+  ]);
+}
+```
+
+### 5. Enable cache-binding (optional)
+
+For `@Cacheable` entities, the generated `DomainState` automatically calls
+`..bindCache()` on each slice. When a mutation UseCase updates the cache
+(via `CacheMutator.notifyCache()`), **all** active slices for that entity
+type across all views receive the update — no network re-fetch needed.
+
+Enable globally in `.zfa.json`:
+```json
+{
+  "state": { "cacheBinding": true }
+}
+```
+
+## Backward Compatibility
+
+v6 is **fully backward-compatible** with v5:
+
+- Existing v5 views that consume the monolithic state object continue to
+  work — `SlicePresenter.combinedState` exposes all slices as a single map.
+- The `--v6-state` flag is **opt-in**; without it, the v5 generation path is
+  unchanged.
+- `ControlledWidget`, `FragmentBuilder`, and `SignalBuilder` are additive —
+  they don't replace any existing widget classes.
+
+## Verification Checklist
+
+After migrating:
+
+- [ ] `dart analyze` passes with no new issues
+- [ ] `zfa build` regenerates `DomainState` but preserves `ViewState` and
+      `Presenter` edits
+- [ ] Updating one slice does not trigger rebuilds on widgets listening to
+      other slices (use the `FragmentBuilder` golden test as a template)
+- [ ] Disposed views do not receive cache updates (no memory leaks)
+- [ ] Old-style views still compile without changes
+
+## References
+
+- **Parent Epic**: #162 — .state.dart Enhancements
+- **Track 2.1**: #167 — Fragmented Signal Slices
+- **Track 2.2**: #166 — Dual-Layer State Boundary
+- **Track 2.3**: #169 — Automated Cache-Binding
+- **Track 2.4**: #173 — ControlledWidget with FragmentBuilder

--- a/lib/src/commands/view_command.dart
+++ b/lib/src/commands/view_command.dart
@@ -26,6 +26,12 @@ class ViewCommand extends PluginCommand {
       defaultsTo: false,
     );
     argParser.addFlag(
+      'v6-state',
+      help: 'Generate v6 dual-layer state (DomainState + ViewState + '
+          'DualLayerPresenter) and ControlledWidget/FragmentBuilder-based view',
+      defaultsTo: false,
+    );
+    argParser.addFlag(
       'route',
       help: 'Generate route definitions for this view',
       defaultsTo: false,
@@ -58,6 +64,7 @@ class ViewCommand extends PluginCommand {
         (argResults?['methods'] as String?)?.split(',') ?? ['get', 'update'];
     final generateDi = argResults?['di'] as bool? ?? false;
     final generateState = argResults?['state'] as bool? ?? false;
+    final generateV6State = argResults?['v6-state'] as bool? ?? false;
     final generateRoute = argResults?['route'] as bool? ?? false;
     final generateXRay = argResults?['xray'] as bool? ?? false;
 
@@ -93,6 +100,7 @@ class ViewCommand extends PluginCommand {
         'methods': methods,
         'di': generateDi,
         'state': generateState,
+        'v6-state': generateV6State,
         'route': false, // Don't generate route in view capability
         'xray': generateXRay,
         'dryRun': isDryRun,
@@ -119,6 +127,7 @@ class ViewCommand extends PluginCommand {
         'methods': methods,
         'di': generateDi,
         'state': generateState,
+        'v6-state': generateV6State,
         'route': false,
         'xray': generateXRay,
         'dryRun': isDryRun,

--- a/lib/src/models/generator_config.dart
+++ b/lib/src/models/generator_config.dart
@@ -72,6 +72,10 @@ class GeneratorConfig {
   final bool useMockInDi;
   final bool generateDi;
   final bool generateXRay;
+  /// When true, the view plugin generates v6 dual-layer state
+  /// (DomainState + ViewState + DualLayerPresenter) and ControlledWidget /
+  /// FragmentBuilder based views instead of the legacy v5 monolithic state.
+  final bool generateV6State;
   final String diFramework;
   final bool generateRoute;
   final bool generateGql;
@@ -148,6 +152,7 @@ class GeneratorConfig {
     this.useMockInDi = false,
     this.generateDi = false,
     this.generateXRay = false,
+    this.generateV6State = false,
     this.diFramework = 'get_it',
     this.generateRoute = false,
     this.generateGql = false,
@@ -225,6 +230,10 @@ class GeneratorConfig {
       useMockInDi: json['use_mock'] == true || json['use_mock_in_di'] == true,
       generateDi: json['di'] == true || json['generate_di'] == true,
       generateXRay: json['xray'] == true || json['generate_xray'] == true,
+      generateV6State:
+          json['v6_state'] == true ||
+          json['v6State'] == true ||
+          json['v6-state'] == true,
       diFramework: json['di_framework'] ?? 'get_it',
       generateRoute: json['route'] == true || json['generate_route'] == true,
       generateGql: json['gql'] == true || json['generate_gql'] == true,
@@ -318,6 +327,7 @@ class GeneratorConfig {
     bool? useMockInDi,
     bool? generateDi,
     bool? generateXRay,
+    bool? generateV6State,
     String? diFramework,
     bool? generateRoute,
     bool? generateGql,
@@ -389,6 +399,7 @@ class GeneratorConfig {
       useMockInDi: useMockInDi ?? this.useMockInDi,
       generateDi: generateDi ?? this.generateDi,
       generateXRay: generateXRay ?? this.generateXRay,
+      generateV6State: generateV6State ?? this.generateV6State,
       diFramework: diFramework ?? this.diFramework,
       generateRoute: generateRoute ?? this.generateRoute,
       generateGql: generateGql ?? this.generateGql,

--- a/lib/src/plugins/view/capabilities/create_view_capability.dart
+++ b/lib/src/plugins/view/capabilities/create_view_capability.dart
@@ -40,6 +40,13 @@ class CreateViewCapability implements ZuraffaCapability {
         'description': 'Generate with State integration',
         'default': false,
       },
+      'v6-state': {
+        'type': 'boolean',
+        'description':
+            'Generate v6 dual-layer state (DomainState + ViewState + '
+            'DualLayerPresenter) and ControlledWidget/FragmentBuilder-based view',
+        'default': false,
+      },
       'route': {
         'type': 'boolean',
         'description': 'Generate route definitions for this view',
@@ -111,6 +118,7 @@ class CreateViewCapability implements ZuraffaCapability {
         (args['methods'] as List?)?.cast<String>() ?? ['get', 'update'];
     final generateDi = args['di'] ?? false;
     final generateState = args['state'] ?? false;
+    final generateV6State = args['v6-state'] ?? false;
     final generateRoute = args['route'] ?? false;
     final generateXRay = args['xray'] ?? false;
     final force = args['force'] ?? false;
@@ -123,6 +131,7 @@ class CreateViewCapability implements ZuraffaCapability {
       generateRoute: generateRoute,
       methods: methods,
       generateDi: generateDi,
+      generateV6State: generateV6State,
       generateState: generateState,
       generateXRay: generateXRay,
       dryRun: dryRun,

--- a/lib/src/plugins/view/view_plugin.dart
+++ b/lib/src/plugins/view/view_plugin.dart
@@ -17,6 +17,8 @@ import 'builders/view_class_builder.dart';
 import 'capabilities/create_view_capability.dart';
 import 'capabilities/custom_view_capability.dart';
 import 'capabilities/register_view_capability.dart';
+import '../../state/generator/state_generator.dart';
+import '../../state/generator/view_template_generator.dart';
 
 import 'package:code_builder/code_builder.dart';
 
@@ -78,6 +80,14 @@ class ViewPlugin extends FileGeneratorPlugin implements CliAwarePlugin {
         'description':
             'Adaptive layout targets, e.g. mobile,tablet,desktop,macos',
       },
+      'v6-state': {
+        'type': 'boolean',
+        'default': false,
+        'description':
+            'Generate v6 dual-layer state (DomainState + ViewState + '
+            'DualLayerPresenter) and ControlledWidget/FragmentBuilder-based '
+            'views instead of the legacy v5 monolithic state',
+      },
     },
   };
 
@@ -105,9 +115,149 @@ class ViewPlugin extends FileGeneratorPlugin implements CliAwarePlugin {
       generateState: context.data['state'] == true,
       generateDi: context.data['di'] == true,
       generateXRay: context.data['xray'] == true,
+      generateV6State: context.data['v6-state'] == true,
     );
 
     return generate(config, context: context);
+  }
+
+  /// Generates v6 dual-layer state files + ControlledWidget-based view.
+  ///
+  /// Emits:
+  /// - `{Name}DomainState` (regenerated every build, signal slices)
+  /// - `{Name}ViewState` (scaffolded once, preserved)
+  /// - `{Name}Presenter` (extends DualLayerPresenter, scaffolded once)
+  /// - `{Name}View` (extends ControlledWidget, uses FragmentBuilder)
+  Future<List<GeneratedFile>> _generateV6State(
+    GeneratorConfig config, {
+    PluginContext? context,
+  }) async {
+    final fs = context?.fileSystem ?? fileSystem;
+    final entityName = config.name;
+    final domainSnake = config.effectiveDomain;
+    final stateDirPath = path.join(
+      outputDir,
+      'presentation',
+      'pages',
+      domainSnake,
+    );
+
+    // Derive use-case bindings from requested methods. Each method (get,
+    // update, etc.) becomes one signal slice in the DomainState.
+    final methods = config.methods.isNotEmpty
+        ? config.methods
+        : ['get', 'update'];
+    final useCaseBindings = <UseCaseBinding>[];
+    final sliceKeys = <String>[];
+    for (final method in methods) {
+      final sliceKey = _sliceKeyForMethod(method);
+      final returnType = _returnTypeForMethod(method, entityName);
+      final useCaseFieldName = '_${sliceKey}UseCase';
+      final paramsConstructor = '${_pascalCase(method)}${entityName}Params';
+      useCaseBindings.add(
+        UseCaseBinding(
+          sliceKey: sliceKey,
+          useCaseFieldName: useCaseFieldName,
+          paramsConstructor: paramsConstructor,
+          returnType: returnType,
+          cacheable: config.enableCache,
+        ),
+      );
+      sliceKeys.add(sliceKey);
+    }
+
+    final cacheableSliceKeys =
+        config.enableCache ? <String>{...sliceKeys} : null;
+
+    final generatedFiles = <GeneratedFile>[];
+
+    // 1. DomainState (always regenerated)
+    final stateGen = StateGenerator(outputDir: stateDirPath);
+    final domainPath = stateGen.generateDomainState(
+      entityName,
+      useCases: useCaseBindings,
+      cacheableSliceKeys: cacheableSliceKeys,
+    );
+    generatedFiles.add(
+      GeneratedFile(
+        path: domainPath,
+        type: 'domain_state',
+        action: 'overwritten',
+        content: fs.readSync(domainPath),
+      ),
+    );
+
+    // 2. ViewState (scaffolded once, preserved)
+    final viewStatePath = stateGen.generateViewState(entityName);
+    final viewStateAction = stateGen.preservedFiles.contains(viewStatePath)
+        ? 'skipped'
+        : 'created';
+    generatedFiles.add(
+      GeneratedFile(
+        path: viewStatePath,
+        type: 'view_state',
+        action: viewStateAction,
+        content: fs.readSync(viewStatePath),
+      ),
+    );
+
+    // 3. Presenter (scaffolded once, preserved)
+    final viewGen = ViewTemplateGenerator(outputDir: stateDirPath);
+    final presenterPath = viewGen.generatePresenter(
+      entityName,
+      useCases: sliceKeys,
+    );
+    generatedFiles.add(
+      GeneratedFile(
+        path: presenterPath,
+        type: 'presenter',
+        action: 'created',
+        content: fs.readSync(presenterPath),
+      ),
+    );
+
+    // 4. View (ControlledWidget + FragmentBuilder + SignalBuilder)
+    final viewPath = viewGen.generateView(
+      entityName,
+      useCases: sliceKeys,
+    );
+    generatedFiles.add(
+      GeneratedFile(
+        path: viewPath,
+        type: 'view',
+        action: config.force ? 'overwritten' : 'created',
+        content: fs.readSync(viewPath),
+      ),
+    );
+
+    return generatedFiles;
+  }
+
+  /// Maps a CRUD method name to a semantic signal-slice key.
+  String _sliceKeyForMethod(String method) {
+    return switch (method) {
+      'get' || 'watch' => 'entity',
+      'getList' || 'watchList' || 'list' => 'entities',
+      'create' => 'created',
+      'update' => 'updated',
+      'delete' => 'deleted',
+      'toggle' => 'toggled',
+      _ => method,
+    };
+  }
+
+  /// Derives the slice return type for a method.
+  String _returnTypeForMethod(String method, String entityName) {
+    return switch (method) {
+      'getList' || 'watchList' || 'list' => 'List<$entityName>',
+      _ => entityName,
+    };
+  }
+
+  /// Converts a lowercase word to PascalCase.
+  String _pascalCase(String s) {
+    if (s.isEmpty) return s;
+    return s[0].toUpperCase() + s.substring(1);
   }
 
   @override
@@ -117,6 +267,12 @@ class ViewPlugin extends FileGeneratorPlugin implements CliAwarePlugin {
   }) async {
     if (!config.generateView && !config.generateVpcs && !config.revert) {
       return [];
+    }
+
+    // v6 dual-layer state path: generate DomainState + ViewState +
+    // DualLayerPresenter + ControlledWidget/FragmentBuilder-based view.
+    if (config.generateV6State) {
+      return _generateV6State(config, context: context);
     }
 
     if (config.outputDir != outputDir ||

--- a/lib/src/state/generator/state_generator.dart
+++ b/lib/src/state/generator/state_generator.dart
@@ -43,6 +43,7 @@ class StateGenerator {
     String name, {
     required List<UseCaseBinding> useCases,
     String? presenterImport,
+    Set<String>? cacheableSliceKeys,
   }) {
     final className = '${name}DomainState';
     final fileName = snakeCase(name);
@@ -75,26 +76,36 @@ class StateGenerator {
               }),
             );
 
-          // Generate late final slice bindings
+          // Generate late final slice bindings. When a slice is cacheable
+          // (entity is @Cacheable), append a cascade `..bindCache()` so the
+          // field remains a SignalSlice<T> while still subscribing to the
+          // CacheObserver for cross-view sync.
           for (final binding in useCases) {
+            final isCacheable =
+                cacheableSliceKeys?.contains(binding.sliceKey) ?? false;
+            final baseCall = cb
+                .refer('bind')
+                .call(
+                  [
+                    cb.literalString(binding.sliceKey),
+                    cb.refer(binding.useCaseFieldName),
+                    cb.refer(binding.paramsConstructor).call([]),
+                  ],
+                  {},
+                  [cb.refer(binding.returnType)],
+                );
+            // code_builder has no first-class cascade; emit the cascade as a
+            // raw code string so the field type stays SignalSlice<T>.
+            final assignmentCode = isCacheable
+                ? cb.Code('${baseCall.accept(cb.DartEmitter())}..bindCache()')
+                : baseCall.code;
             c.fields.add(
               cb.Field((f) {
                 f
                   ..name = binding.sliceKey
                   ..modifier = cb.FieldModifier.final$
                   ..late = true
-                  ..assignment = cb
-                      .refer('bind')
-                      .call(
-                        [
-                          cb.literalString(binding.sliceKey),
-                          cb.refer(binding.useCaseFieldName),
-                          cb.refer(binding.paramsConstructor).call([]),
-                        ],
-                        {},
-                        [cb.refer(binding.returnType)],
-                      )
-                      .code;
+                  ..assignment = assignmentCode;
               }),
             );
           }
@@ -209,12 +220,18 @@ class UseCaseBinding {
     required this.useCaseFieldName,
     required this.paramsConstructor,
     required this.returnType,
+    this.cacheable = false,
   });
 
   final String sliceKey;
   final String useCaseFieldName;
   final String paramsConstructor;
   final String returnType;
+
+  /// Whether this slice should be bound to the [CacheObserver] for
+  /// automatic cross-view state synchronization. Set when the underlying
+  /// entity is `@Cacheable`.
+  final bool cacheable;
 }
 
 /// Metadata for a ViewState transient field.

--- a/lib/src/state/generator/view_template_generator.dart
+++ b/lib/src/state/generator/view_template_generator.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:code_builder/code_builder.dart' as cb;
 import 'package:dart_style/dart_style.dart';
 import 'package:path/path.dart' as p;
@@ -34,7 +36,11 @@ class ViewTemplateGenerator {
 
     final library = cb.Library((b) {
       b.directives.add(cb.Directive.import('package:flutter/material.dart'));
-      b.directives.add(cb.Directive.import('package:zuraffa/zuraffa.dart'));
+      // zuraffa_flutter re-exports zuraffa core AND provides
+      // ControlledWidget, FragmentBuilder, and SignalBuilder.
+      b.directives.add(
+        cb.Directive.import('package:zuraffa_flutter/zuraffa_flutter.dart'),
+      );
       b.directives.add(
         cb.Directive.import('${snakeCase(name)}_presenter.dart'),
       );
@@ -191,5 +197,79 @@ class ViewTemplateGenerator {
       'activeTabIndex' => 'int',
       _ => 'dynamic',
     };
+  }
+
+  /// Generate a `{name}Presenter` that extends [DualLayerPresenter],
+  /// wiring the generated DomainState and scaffolded ViewState together.
+  ///
+  /// The presenter is scaffolded once (like ViewState) and is safe for the
+  /// developer to extend with orchestration logic. It is **not** regenerated
+  /// if it already exists.
+  String generatePresenter(
+    String name, {
+    List<String> useCases = const [],
+    bool preserveIfExists = true,
+  }) {
+    final className = '${name}Presenter';
+    final domainClassName = '${name}DomainState';
+    final viewClassName = '${name}ViewState';
+    final fileName = '${snakeCase(name)}_presenter.dart';
+    final filePath = p.join(outputDir, fileName);
+
+    if (preserveIfExists && File(filePath).existsSync()) {
+      return filePath;
+    }
+
+    final library = cb.Library((b) {
+      b.directives.add(cb.Directive.import('package:zuraffa/zuraffa.dart'));
+      b.directives.add(
+        cb.Directive.import('${snakeCase(name)}_domain_state.dart'),
+      );
+      b.directives.add(
+        cb.Directive.import('${snakeCase(name)}_view_state.dart'),
+      );
+
+      b.body.add(
+        cb.Class((c) {
+          c
+            ..name = className
+            ..extend = cb.refer('DualLayerPresenter')
+            ..constructors.add(
+              cb.Constructor((ctor) {
+                ctor
+                  ..name = null
+                  ..initializers.add(
+                    cb.Code(
+                      'super(domain: $domainClassName(presenter: '
+                      'SlicePresenter()), view: $viewClassName())',
+                    ),
+                  );
+              }),
+            );
+          // Expose a typed SlicePresenter for the DomainState to bind into.
+          c.fields.add(
+            cb.Field((f) {
+              f
+                ..name = 'slicePresenter'
+                ..modifier = cb.FieldModifier.final$
+                ..type = cb.refer('SlicePresenter')
+                ..assignment = cb.refer('SlicePresenter').call([]).code;
+            }),
+          );
+        }),
+      );
+    });
+
+    final emitter = cb.DartEmitter();
+    final raw = library.accept(emitter).toString();
+    var formatted = raw;
+    try {
+      formatted = _formatter.format(raw);
+    } on FormatterException {
+      // Fallback: unformatted code is better than a crash.
+    }
+
+    writeFile(filePath, formatted);
+    return filePath;
   }
 }

--- a/test/state/cache_binding_generation_test.dart
+++ b/test/state/cache_binding_generation_test.dart
@@ -1,0 +1,151 @@
+import 'dart:io';
+import 'package:test/test.dart';
+import 'package:zuraffa/zuraffa.dart';
+
+/// Tests that StateGenerator emits `..bindCache()` for @Cacheable slices
+/// (Track 2.3 AC#1) and leaves non-cacheable slices untouched.
+void main() {
+  late Directory tempDir;
+  late StateGenerator gen;
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync('zuraffa_cache_gen_');
+    gen = StateGenerator(outputDir: tempDir.path);
+  });
+
+  tearDown(() => tempDir.deleteSync(recursive: true));
+
+  group('Cache-binding generation (Track 2.3 AC#1)', () {
+    test('cacheable slice emits ..bindCache() cascade', () {
+      gen.generateDomainState(
+        'ProductDetail',
+        useCases: [
+          UseCaseBinding(
+            sliceKey: 'product',
+            useCaseFieldName: 'getProductUseCase',
+            paramsConstructor: 'GetProductParams',
+            returnType: 'Product',
+          ),
+        ],
+        cacheableSliceKeys: {'product'},
+      );
+
+      final content = File(
+        '${tempDir.path}/product_detail_domain_state.dart',
+      ).readAsStringSync();
+
+      // The generated field must use a cascade so the field type stays
+      // SignalSlice<T> while still subscribing to the CacheObserver.
+      expect(content.contains("..bindCache()"), true,
+          reason: 'cacheable slice should emit ..bindCache() cascade');
+      expect(content.contains('bind<Product>'), true);
+    });
+
+    test('multiple cacheable slices all emit ..bindCache()', () {
+      gen.generateDomainState(
+        'OrderDetail',
+        useCases: [
+          UseCaseBinding(
+            sliceKey: 'order',
+            useCaseFieldName: 'getOrderUseCase',
+            paramsConstructor: 'GetOrderParams',
+            returnType: 'Order',
+          ),
+          UseCaseBinding(
+            sliceKey: 'items',
+            useCaseFieldName: 'getItemsUseCase',
+            paramsConstructor: 'GetItemsParams',
+            returnType: 'List<OrderItem>',
+          ),
+          UseCaseBinding(
+            sliceKey: 'history',
+            useCaseFieldName: 'getHistoryUseCase',
+            paramsConstructor: 'GetHistoryParams',
+            returnType: 'List<History>',
+          ),
+        ],
+        cacheableSliceKeys: {'order', 'items'},
+      );
+
+      final content = File(
+        '${tempDir.path}/order_detail_domain_state.dart',
+      ).readAsStringSync();
+
+      // Count occurrences of ..bindCache()
+      final count = '..bindCache()'.allMatches(content).length;
+      expect(count, 2,
+          reason: 'exactly 2 cacheable slices should emit ..bindCache()');
+    });
+
+    test('non-cacheable slices do NOT emit ..bindCache()', () {
+      gen.generateDomainState(
+        'ReviewList',
+        useCases: [
+          UseCaseBinding(
+            sliceKey: 'reviews',
+            useCaseFieldName: 'getReviewsUseCase',
+            paramsConstructor: 'GetReviewsParams',
+            returnType: 'List<Review>',
+          ),
+        ],
+        // No cacheableSliceKeys — defaults to null
+      );
+
+      final content = File(
+        '${tempDir.path}/review_list_domain_state.dart',
+      ).readAsStringSync();
+
+      expect(content.contains('..bindCache()'), false,
+          reason: 'non-cacheable slice must NOT emit ..bindCache()');
+      expect(content.contains('bind<List<Review>>'), true);
+    });
+
+    test('mixed cacheable and non-cacheable slices', () {
+      gen.generateDomainState(
+        'Dashboard',
+        useCases: [
+          UseCaseBinding(
+            sliceKey: 'profile',
+            useCaseFieldName: 'getProfileUseCase',
+            paramsConstructor: 'GetProfileParams',
+            returnType: 'Profile',
+          ),
+          UseCaseBinding(
+            sliceKey: 'settings',
+            useCaseFieldName: 'getSettingsUseCase',
+            paramsConstructor: 'GetSettingsParams',
+            returnType: 'Settings',
+          ),
+        ],
+        cacheableSliceKeys: {'profile'}, // only profile is cacheable
+      );
+
+      final content = File(
+        '${tempDir.path}/dashboard_domain_state.dart',
+      ).readAsStringSync();
+
+      final count = '..bindCache()'.allMatches(content).length;
+      expect(count, 1,
+          reason: 'only the cacheable slice should emit ..bindCache()');
+    });
+
+    test('UseCaseBinding.cacheable flag is set correctly', () {
+      final cacheable = UseCaseBinding(
+        sliceKey: 'product',
+        useCaseFieldName: 'getProductUseCase',
+        paramsConstructor: 'GetProductParams',
+        returnType: 'Product',
+        cacheable: true,
+      );
+      final nonCacheable = UseCaseBinding(
+        sliceKey: 'reviews',
+        useCaseFieldName: 'getReviewsUseCase',
+        paramsConstructor: 'GetReviewsParams',
+        returnType: 'List<Review>',
+      );
+
+      expect(cacheable.cacheable, true);
+      expect(nonCacheable.cacheable, false);
+    });
+  });
+}

--- a/test/state/v6_cli_generation_test.dart
+++ b/test/state/v6_cli_generation_test.dart
@@ -1,0 +1,232 @@
+import 'dart:io';
+import 'package:test/test.dart';
+import 'package:zuraffa/zuraffa.dart';
+
+/// Tests for the v6 dual-layer state generation pipeline:
+/// - ViewTemplateGenerator.generatePresenter (Track 2.4)
+/// - ViewTemplateGenerator.generateView with zuraffa_flutter import (Track 2.4 AC#5)
+/// - StateGenerator + ViewTemplateGenerator integration (Track 2.4 golden)
+void main() {
+  late Directory tempDir;
+  late StateGenerator stateGen;
+  late ViewTemplateGenerator viewGen;
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync('zuraffa_v6_cli_');
+    stateGen = StateGenerator(outputDir: tempDir.path);
+    viewGen = ViewTemplateGenerator(outputDir: tempDir.path);
+  });
+
+  tearDown(() => tempDir.deleteSync(recursive: true));
+
+  group('ViewTemplateGenerator.generatePresenter (Track 2.4)', () {
+    test('generates a DualLayerPresenter subclass', () {
+      final path = viewGen.generatePresenter('ProductDetail', useCases: ['product', 'reviews']);
+
+      final file = File(path);
+      expect(file.existsSync(), true);
+
+      final content = file.readAsStringSync();
+      expect(content.contains('class ProductDetailPresenter'), true);
+      expect(content.contains('extends DualLayerPresenter'), true);
+      expect(content.contains('ProductDetailDomainState'), true);
+      expect(content.contains('ProductDetailViewState'), true);
+      expect(content.contains('SlicePresenter'), true);
+    });
+
+    test('presenter is preserved if it already exists', () {
+      // First generation
+      final path = viewGen.generatePresenter('Checkout', useCases: ['cart']);
+      final file = File(path);
+      final original = file.readAsStringSync();
+
+      // Developer edits
+      final edited = original.replaceAll(
+        'SlicePresenter();',
+        'SlicePresenter(); // custom orchestration here',
+      );
+      file.writeAsStringSync(edited);
+
+      // Second generation — should be preserved
+      viewGen.generatePresenter('Checkout', useCases: ['cart', 'payment']);
+
+      final after = file.readAsStringSync();
+      expect(after.contains('custom orchestration here'), true,
+          reason: 'developer edits to presenter must be preserved');
+    });
+
+    test('presenter file imports domain_state and view_state', () {
+      viewGen.generatePresenter('OrderDetail', useCases: ['order']);
+
+      final content = File('${tempDir.path}/order_detail_presenter.dart')
+          .readAsStringSync();
+      expect(content.contains("import 'order_detail_domain_state.dart'"), true);
+      expect(content.contains("import 'order_detail_view_state.dart'"), true);
+      expect(content.contains("import 'package:zuraffa/zuraffa.dart'"), true);
+    });
+  });
+
+  group('ViewTemplateGenerator.generateView v6 import (Track 2.4 AC#5)', () {
+    test('generated view imports zuraffa_flutter (not just zuraffa)', () {
+      viewGen.generateView('ProductDetail', useCases: ['product', 'reviews']);
+
+      final content = File('${tempDir.path}/product_detail_view.dart')
+          .readAsStringSync();
+      // ControlledWidget/FragmentBuilder/SignalBuilder live in zuraffa_flutter
+      expect(
+        content.contains("import 'package:zuraffa_flutter/zuraffa_flutter.dart'"),
+        true,
+        reason: 'generated view must import zuraffa_flutter to access '
+            'ControlledWidget, FragmentBuilder, and SignalBuilder',
+      );
+    });
+
+    test('generated view extends ControlledWidget', () {
+      viewGen.generateView('ProductDetail', useCases: ['product']);
+
+      final content = File('${tempDir.path}/product_detail_view.dart')
+          .readAsStringSync();
+      expect(content.contains('extends ControlledWidget<ProductDetailPresenter>'),
+          true);
+    });
+
+    test('generated view uses FragmentBuilder and SignalBuilder', () {
+      viewGen.generateView(
+        'ProductDetail',
+        useCases: ['product', 'reviews'],
+        uiSignals: ['isDescriptionExpanded'],
+      );
+
+      final content = File('${tempDir.path}/product_detail_view.dart')
+          .readAsStringSync();
+      expect(content.contains('FragmentBuilder'), true);
+      expect(content.contains('SignalBuilder'), true);
+      expect(content.contains('onLoading'), true);
+      expect(content.contains('onError'), true);
+    });
+  });
+
+  group('v6 full generation cycle (Track 2.4 golden)', () {
+    test('DomainState + ViewState + Presenter + View all generated', () {
+      // 1. DomainState
+      final domainPath = stateGen.generateDomainState(
+        'ProductDetail',
+        useCases: [
+          UseCaseBinding(
+            sliceKey: 'product',
+            useCaseFieldName: 'getProductUseCase',
+            paramsConstructor: 'GetProductParams',
+            returnType: 'Product',
+          ),
+          UseCaseBinding(
+            sliceKey: 'reviews',
+            useCaseFieldName: 'getReviewsUseCase',
+            paramsConstructor: 'GetReviewsParams',
+            returnType: 'List<Review>',
+          ),
+        ],
+      );
+      // 2. ViewState
+      final viewStatePath = stateGen.generateViewState('ProductDetail');
+      // 3. Presenter
+      final presenterPath = viewGen.generatePresenter(
+        'ProductDetail',
+        useCases: ['product', 'reviews'],
+      );
+      // 4. View
+      final viewPath = viewGen.generateView(
+        'ProductDetail',
+        useCases: ['product', 'reviews'],
+      );
+
+      expect(File(domainPath).existsSync(), true);
+      expect(File(viewStatePath).existsSync(), true);
+      expect(File(presenterPath).existsSync(), true);
+      expect(File(viewPath).existsSync(), true);
+
+      // DomainState references the slices
+      final domainContent = File(domainPath).readAsStringSync();
+      expect(domainContent.contains('bind<Product>'), true);
+      expect(domainContent.contains('bind<List<Review>>'), true);
+
+      // ViewState has Signal fields
+      final viewStateContent = File(viewStatePath).readAsStringSync();
+      expect(viewStateContent.contains('Signal<bool>'), true);
+
+      // Presenter wires both layers
+      final presenterContent = File(presenterPath).readAsStringSync();
+      expect(presenterContent.contains('DualLayerPresenter'), true);
+
+      // View uses the v6 widgets
+      final viewContent = File(viewPath).readAsStringSync();
+      expect(viewContent.contains('ControlledWidget'), true);
+      expect(viewContent.contains('FragmentBuilder'), true);
+    });
+
+    test('rebuilding preserves ViewState and Presenter, regenerates DomainState', () {
+      // Initial generation
+      stateGen.generateDomainState(
+        'ProductDetail',
+        useCases: [
+          UseCaseBinding(
+            sliceKey: 'product',
+            useCaseFieldName: 'getProductUseCase',
+            paramsConstructor: 'GetProductParams',
+            returnType: 'Product',
+          ),
+        ],
+      );
+      stateGen.generateViewState('ProductDetail');
+      viewGen.generatePresenter('ProductDetail', useCases: ['product']);
+
+      // Developer edits ViewState and Presenter
+      final vsFile = File('${tempDir.path}/product_detail_view_state.dart');
+      vsFile.writeAsStringSync(
+        vsFile.readAsStringSync().replaceFirst(
+              'Signal<bool>(false)',
+              'Signal<bool>(true) // dev edit',
+            ),
+      );
+      final pFile = File('${tempDir.path}/product_detail_presenter.dart');
+      final pOriginal = pFile.readAsStringSync();
+      pFile.writeAsStringSync('$pOriginal\n// dev addition\n');
+
+      // Rebuild — add a new use case
+      final stateGen2 = StateGenerator(outputDir: tempDir.path);
+      stateGen2.generateDomainState(
+        'ProductDetail',
+        useCases: [
+          UseCaseBinding(
+            sliceKey: 'product',
+            useCaseFieldName: 'getProductUseCase',
+            paramsConstructor: 'GetProductParams',
+            returnType: 'Product',
+          ),
+          UseCaseBinding(
+            sliceKey: 'reviews',
+            useCaseFieldName: 'getReviewsUseCase',
+            paramsConstructor: 'GetReviewsParams',
+            returnType: 'List<Review>',
+          ),
+        ],
+      );
+      stateGen2.generateViewState('ProductDetail');
+      final viewGen2 = ViewTemplateGenerator(outputDir: tempDir.path);
+      viewGen2.generatePresenter('ProductDetail', useCases: ['product', 'reviews']);
+
+      // DomainState has the new slice
+      final domainContent = File(
+        '${tempDir.path}/product_detail_domain_state.dart',
+      ).readAsStringSync();
+      expect(domainContent.contains('reviews'), true);
+
+      // ViewState preserved
+      final vsContent = vsFile.readAsStringSync();
+      expect(vsContent.contains('dev edit'), true);
+
+      // Presenter preserved
+      final pContent = pFile.readAsStringSync();
+      expect(pContent.contains('dev addition'), true);
+    });
+  });
+}


### PR DESCRIPTION
Implements the full Track 2.1-2.4 phase for the v6 .state.dart enhancements epic (#162), covering child issues #167, #166, #169, and #173.

## Summary

The v6 state architecture runtime (SignalSlice, SlicePresenter, DomainState, ViewState, DualLayerPresenter, CacheObserver, CacheBinding) and Flutter widgets (ControlledWidget, FragmentBuilder, SignalBuilder) were ~90% implemented. This PR fills the remaining acceptance-criteria gaps across all four child issues.

## Changes by Track

### Track 2.3 (#169) — Automated Cache-Binding (AC#1)
StateGenerator now emits `..bindCache()` cascade on slices whose entity is `@Cacheable`. `generateDomainState()` accepts a `cacheableSliceKeys` set; `UseCaseBinding` gains a `cacheable` flag. Completes the generator-side of the cache observer chain.

### Track 2.4 (#173) — ControlledWidget + FragmentBuilder CLI wiring (AC#5)
- **ViewTemplateGenerator**: fixed import to `package:zuraffa_flutter/zuraffa_flutter.dart` so generated views resolve ControlledWidget/FragmentBuilder/SignalBuilder (which live in zuraffa_flutter, not the pure-Dart zuraffa core).
- **ViewTemplateGenerator.generatePresenter()**: scaffolds a DualLayerPresenter subclass wiring DomainState + ViewState. Preserved across rebuilds.
- **ViewPlugin._generateV6State()**: new v6 generation path — generates DomainState + ViewState + Presenter + ControlledWidget-based View in one pass.
- **GeneratorConfig.generateV6State**: new field (fromJson + copyWith).
- **`--v6-state` flag**: added to `zfa view` and auto-registered in `zfa make` via the view plugin configSchema.

### Track 2.2 (#166) — Migration guide (AC#6)
New `docs/v6_state_migration_guide.md` documenting v5 monolithic → v6 dual-layer migration (slice isolation, FragmentBuilder/SignalBuilder, cache-binding, backward compat, verification checklist).

### Tests (13 new, all passing)
- `test/state/cache_binding_generation_test.dart` (5 tests): `..bindCache()` emitted for cacheable slices, not for non-cacheable, correct count for mixed sets.
- `test/state/v6_cli_generation_test.dart` (8 tests): generatePresenter(), zuraffa_flutter import, ControlledWidget/FragmentBuilder in generated views, full generation+rebuild cycle (DomainState regenerated, ViewState/Presenter preserved).

## Verification
- `dart analyze lib/`: 0 new issues (7 pre-existing info lints unchanged)
- `dart test`: 1068 pass, 0 new failures (2 pre-existing loading errors)
- `flutter test zuraffa_flutter`: 7/7 widget tests pass

## Backward Compatibility
The v6 path is fully opt-in via `--v6-state`. Without it, the v5 generation path is unchanged. ControlledWidget/FragmentBuilder/SignalBuilder are additive — no breaking changes.

Closes #162, #167, #166, #169, #173

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional v6 state generation for views, including separate domain and UI state layers.
  - Generated views can include controlled widgets, presenters, signal slices, and cache synchronization.
  - Added support for preserving existing presenter files during regeneration.
  - Added `--v6-state` command-line and configuration options.

- **Documentation**
  - Added a v5-to-v6 state migration guide with setup, migration, compatibility, and verification instructions.

- **Tests**
  - Added coverage for cache bindings, v6 generation, regeneration, and preservation of developer changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->