### PR TITLE
fix(v6): harden V6 test infrastructure — formatting, flakiness, CWD-contamination (#163)

### DIFF
--- a/lib/src/commands/plugin_command.dart
+++ b/lib/src/commands/plugin_command.dart
@@ -188,8 +188,11 @@ class PluginCommand {
       int scanPos = registerIdx + '..register('.length;
       while (scanPos < block.length && parenCount > 0) {
         final ch = block[scanPos];
-        if (ch == '(') parenCount++;
-        else if (ch == ')') parenCount--;
+        if (ch == '(') {
+          parenCount++;
+        } else if (ch == ')') {
+          parenCount--;
+        }
         scanPos++;
       }
 

--- a/lib/src/core/builder/shared/spec_library.dart
+++ b/lib/src/core/builder/shared/spec_library.dart
@@ -36,7 +36,7 @@ class SpecLibrary {
     // This allows the AST merge engine to identify and safely
     // replace generated code while preserving user edits.
     if (wrapWithGeneratedMarkers) {
-      raw = '// GENERATED - DO NOT EDIT\n$raw\n// END GENERATED';
+      raw = '// GENERATED - DO NOT EDIT\n$raw\n\n// END GENERATED';
     }
 
     if (!format) {

--- a/lib/src/graphql/codegen/datasource_generator.dart
+++ b/lib/src/graphql/codegen/datasource_generator.dart
@@ -570,7 +570,7 @@ class DatasourceGenerator {
   }
 
   String _documentVarName(String fieldName) {
-    return NamingUtils.documentVarName(fieldName) + 'Document';
+    return '${NamingUtils.documentVarName(fieldName)}Document';
   }
 
   String _camelCase(String name) {

--- a/lib/src/graphql/gql/documents_dart_generator.dart
+++ b/lib/src/graphql/gql/documents_dart_generator.dart
@@ -45,7 +45,7 @@ class DocumentsDartGenerator {
 
     for (final file in graphqlFiles) {
       final fileName = p.basenameWithoutExtension(file.path);
-      final varName = NamingUtils.documentVarName(fileName) + 'Document';
+      final varName = '${NamingUtils.documentVarName(fileName)}Document';
       final content = file.readAsStringSync();
 
       // Check for duplicate variable names (from different directories)

--- a/lib/src/mcp/auth.dart
+++ b/lib/src/mcp/auth.dart
@@ -51,7 +51,7 @@ class McpAuth {
     return null;
   }
 
-  /// Validates an Authorization header value ("Bearer <token>").
+  /// Validates an Authorization header value (`"Bearer <token>"`).
   bool validateHeader(String? authHeader) {
     if (!isEnabled) return true;
     if (authHeader == null) return false;

--- a/lib/src/plugins/module/builders/module_orchestrator_builder.dart
+++ b/lib/src/plugins/module/builders/module_orchestrator_builder.dart
@@ -6,7 +6,7 @@ import '../../../models/generator_config.dart';
 import '../../../models/generated_file.dart';
 import '../../../utils/file_utils.dart';
 
-/// Builds the <Feature>FeaturePlugin orchestrator file.
+/// Builds the `<Feature>FeaturePlugin` orchestrator file.
 class ModuleOrchestratorBuilder {
   final String outputDir;
   final GeneratorOptions options;

--- a/test/commands/feature_command_test.dart
+++ b/test/commands/feature_command_test.dart
@@ -4,30 +4,7 @@ import 'dart:io';
 
 import 'package:test/test.dart';
 import 'package:zuraffa/src/cli/cli_runner.dart';
-
-/// Resolve a known-good directory via Platform.script.
-/// Immune to CWD changes by other tests.
-String _safeRoot() {
-  try {
-    var dir = File(Platform.script.toFilePath()).parent;
-    for (var i = 0; i < 10; i++) {
-      final ps = File('${dir.path}/pubspec.yaml');
-      if (ps.existsSync()) {
-        final c = ps.readAsStringSync();
-        if (RegExp(r'^name:\s*zuraffa\s*$', multiLine: true).hasMatch(c)) {
-          return dir.path;
-        }
-      }
-      final parent = dir.parent;
-      if (parent.path == dir.path) break;
-      dir = parent;
-    }
-  } catch (_) {}
-  return Directory.systemTemp.path;
-}
-
-String _zfaRoot = _safeRoot();
-
+import '../helpers/project_root.dart';
 
 void main() {
   group('FeatureCommand', () {
@@ -60,7 +37,7 @@ class Product {
 
     tearDown(() async {
       try {
-        Directory.current = _zfaRoot;
+        Directory.current = await findProjectRoot();
       } catch (_) {}
       if (workspace.existsSync()) {
         await workspace.delete(recursive: true);

--- a/test/commands/make_command_test.dart
+++ b/test/commands/make_command_test.dart
@@ -28,7 +28,7 @@ void main() {
       ], workingDirectory: workingDirectory);
     }
 
-    setUpAll(() {
+    setUpAll(() async {
       final homeDir = Platform.environment['HOME'] ?? '';
       final compiledBin = path.join(homeDir, '.local', 'bin', 'zfa');
       final compiledExists = File(compiledBin).existsSync();
@@ -39,7 +39,7 @@ void main() {
       } else {
         // Resolve bin/zfa.dart relative to the project root, NOT CWD.
         // CWD may be a temp dir from another test at setUpAll time.
-        final projectRoot = findProjectRoot();
+        final projectRoot = await findProjectRoot();
         zfaBin = path.join(projectRoot, 'bin', 'zfa.dart');
         useCompiledBinary = false;
       }

--- a/test/commands/update_command_test.dart
+++ b/test/commands/update_command_test.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-import 'dart:io';
 import 'package:test/test.dart';
 import 'package:zuraffa/src/commands/update_command.dart';
 

--- a/test/helpers/project_root.dart
+++ b/test/helpers/project_root.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:isolate';
 
 /// Cached project root, resolved once and reused across all test files.
 String? _cachedProjectRoot;
@@ -9,6 +10,10 @@ String _diagnostics = '';
 /// Returns the absolute path to the zuraffa project root.
 ///
 /// Resolution strategies (tried in order):
+/// 0. [Isolate.resolvePackageUri] — resolves `package:zuraffa/zuraffa.dart`
+///    to its absolute file URI. This is CWD-independent and works under
+///    `dart test` (where [Platform.script] is a pre-compiled `.dill` in a
+///    temp dir and CWD may be contaminated by other test files).
 /// 1. Return cached value if already resolved.
 /// 2. [_ensureValidCwd] — recover CWD if deleted.
 /// 3. Parse [Platform.script] URI by pure string ops (zero CWD/IO).
@@ -18,13 +23,13 @@ String _diagnostics = '';
 /// 7. Read `.dart_tool/package_config.json` relative to Platform.script.
 ///
 /// Throws [StateError] if the root cannot be determined.
-String findProjectRoot() {
+Future<String> findProjectRoot() async {
   if (_cachedProjectRoot != null) return _cachedProjectRoot!;
 
   _diagnostics = '';
   _ensureValidCwd();
 
-  final root = _resolveProjectRoot();
+  final root = await _resolveProjectRoot();
   if (root == null) {
     String cwdForError;
     try {
@@ -76,7 +81,11 @@ void _ensureValidCwd() {
 // Resolution orchestrator
 // ----------------------------------------------------------------
 
-String? _resolveProjectRoot() {
+Future<String?> _resolveProjectRoot() async {
+  // Strategy 0: Isolate.resolvePackageUri (CWD / Platform.script independent).
+  final s0 = await _tryFromPackageResolution();
+  if (s0 != null) return s0;
+
   // Strategy 1: Pure string URI parsing (zero CWD / IO dependency).
   final s1 = _tryFromScriptString();
   if (s1 != null) return s1;
@@ -101,6 +110,36 @@ String? _resolveProjectRoot() {
 
   // Strategy 5: .dart_tool/package_config.json.
   return _tryFromPackageConfig();
+}
+
+// ----------------------------------------------------------------
+// Strategy 0 — Isolate.resolvePackageUri (CWD-independent)
+// ----------------------------------------------------------------
+
+/// Resolve `package:zuraffa/zuraffa.dart` via the isolate's package
+/// resolution table. This works under `dart test` (where Platform.script
+/// is a `.dill` temp file) and is immune to CWD contamination by other
+/// concurrently-running test files.
+Future<String?> _tryFromPackageResolution() async {
+  try {
+    final uri =
+        await Isolate.resolvePackageUri(Uri.parse('package:zuraffa/zuraffa.dart'));
+    if (uri == null) {
+      _diag('S0: resolvePackageUri returned null');
+      return null;
+    }
+    if (uri.scheme != 'file') {
+      _diag('S0: resolved URI is not a file URI ($uri)');
+      return null;
+    }
+    final filePath = uri.toFilePath();
+    _diag('S0: resolved package URI = $filePath');
+    // zuraffa.dart lives at <root>/lib/zuraffa.dart — walk up from lib/.
+    return _walkToRoot(File(filePath).parent.path);
+  } catch (e) {
+    _diag('S0: threw $e');
+    return null;
+  }
 }
 
 // ----------------------------------------------------------------

--- a/test/integration/polymorphic_mock_integration_test.dart
+++ b/test/integration/polymorphic_mock_integration_test.dart
@@ -12,7 +12,7 @@ void main() {
   late String zfaBin;
   late bool useCompiledBinary;
 
-  setUpAll(() {
+  setUpAll(() async {
     final homeDir = Platform.environment['HOME'] ?? '';
     final compiledBin = p.join(homeDir, '.local', 'bin', 'zfa');
     final compiledExists = File(compiledBin).existsSync();
@@ -22,7 +22,7 @@ void main() {
       useCompiledBinary = true;
     } else {
       // Use findProjectRoot() instead of relative path (CWD may be poisoned).
-      final projectRoot = findProjectRoot();
+      final projectRoot = await findProjectRoot();
       zfaBin = p.join(projectRoot, 'bin', 'zfa.dart');
       useCompiledBinary = false;
     }
@@ -57,8 +57,9 @@ void main() {
       reason: '${pubGet.stdout}\n${pubGet.stderr}',
     );
 
+    final resolvedRoot = await findProjectRoot();
     final fixturePath = p.join(
-      findProjectRoot(),
+      resolvedRoot,
       'test', 'fixtures', 'sealed_category_config.dart',
     );
     final fixtureContent = File(fixturePath).readAsStringSync();

--- a/test/regression/cli_command_test.dart
+++ b/test/regression/cli_command_test.dart
@@ -141,10 +141,10 @@ class Product {
 ''');
     }
 
-    late String _savedCwd;
+    late String savedCwd;
 
     setUp(() async {
-      _savedCwd = Directory.current.path;
+      savedCwd = Directory.current.path;
       workspace = await Directory.systemTemp.createTemp('zfa_cli_');
       outputDir = p.join(workspace.path, 'lib', 'src');
       await Directory(outputDir).create(recursive: true);
@@ -156,8 +156,8 @@ class Product {
     tearDown(() async {
       // Restore CWD BEFORE deleting workspace to avoid cascading crashes.
       try {
-        if (Directory(_savedCwd).existsSync()) {
-          Directory.current = _savedCwd;
+        if (Directory(savedCwd).existsSync()) {
+          Directory.current = savedCwd;
         } else {
           Directory.current = Directory.systemTemp.path;
         }

--- a/test/regression/docs_command_consistency_test.dart
+++ b/test/regression/docs_command_consistency_test.dart
@@ -3,8 +3,8 @@ import 'dart:io';
 import 'package:test/test.dart';
 import '../helpers/project_root.dart';
 
-void main() {
-  final projectRoot = findProjectRoot();
+Future<void> main() async {
+  final projectRoot = await findProjectRoot();
 
   String readDoc(String relativePath) {
     final file = File('$projectRoot/$relativePath');

--- a/test/regression/output_quality_test.dart
+++ b/test/regression/output_quality_test.dart
@@ -5,8 +5,8 @@ import 'package:test/test.dart';
 import 'regression_test_utils.dart';
 import '../helpers/project_root.dart';
 
-void main() {
-  final zfaRoot = findProjectRoot();
+Future<void> main() async {
+  final zfaRoot = await findProjectRoot();
 
   late RegressionWorkspace workspace;
   late List<String> generatedPaths;

--- a/test/regression/regression_test_utils.dart
+++ b/test/regression/regression_test_utils.dart
@@ -27,7 +27,7 @@ Future<void> disposeWorkspace(RegressionWorkspace workspace) async {
 }
 
 Future<void> writePubspec(RegressionWorkspace workspace, {String? repoRootOverride}) async {
-  final repoRoot = repoRootOverride ?? findProjectRoot();
+  final repoRoot = repoRootOverride ?? await findProjectRoot();
   final content =
       '''
 name: zuraffa_test_app

--- a/test/regression/v5_pipeline_contract_test.dart
+++ b/test/regression/v5_pipeline_contract_test.dart
@@ -5,8 +5,8 @@ import 'package:test/test.dart';
 import 'package:zuraffa/src/core/project/project_context_store.dart';
 import '../helpers/project_root.dart';
 
-void main() {
-  final projectRoot = findProjectRoot();
+Future<void> main() async {
+  final projectRoot = await findProjectRoot();
 
   File fileAt(String relativePath) => File('$projectRoot/$relativePath');
 

--- a/test/smart_merge_test.dart
+++ b/test/smart_merge_test.dart
@@ -70,7 +70,7 @@ class \$Todo {
       if (!Platform.isWindows) {
         await Process.run('chmod', ['444', testFile.path]);
 
-        expect(
+        await expectLater(
           () async => await SmartMergeWriter.writeMerged(
             fileSystem: fs,
             path: 'readonly.dart',

--- a/test/src/commands/plugin_command_add_test.dart
+++ b/test/src/commands/plugin_command_add_test.dart
@@ -27,11 +27,9 @@ String _safeRoot() {
 String _zfaRoot = _safeRoot();
 void main() {
   late Directory tmpDir;
-  late String originalPath;
 
   setUp(() {
     tmpDir = Directory.systemTemp.createTempSync('zfa_plugin_test_');
-    originalPath = Directory.current.path;
     Directory.current = tmpDir.path;
     Directory('${tmpDir.path}/lib').createSync();
   });


### PR DESCRIPTION
## Summary

Advances the V6 Twin-Turbo Moonshot Architecture epic (#163) by hardening the test infrastructure that verifies the V6 code-generation pipeline. The V6 tracks (DDA, state slices, GraphQL, X-Ray, decorators, MCP 2.0, migration) are all implemented on `development`, but three test suites were failing — blocking the architecture from being verifiable end-to-end. This PR fixes all three and cleans up analyzer warnings.

**Test results: 1054 pass / 3 fail → 1062 pass / 0 fail**

## Changes

### 1. Generated-code formatting fix (`output_quality_test`)
`SpecLibrary.emitLibrary` wrapped generated files with `// END GENERATED` immediately after the last code line. The SDK 3.11 `dart format` CLI requires a blank line before a trailing comment, but the pinned `dart_style` package didn't add one — so all DDA-generated DI files failed `dart format --set-exit-if-changed`. Added the blank line in the marker wrapping (safe — the zorphy `RegionParser` matches markers via `trimmed().startsWith(...)`, so a blank line is harmless).

### 2. Flaky `smart_merge_test` determinism
The permission-denied regression test used `expect()` with an async closure + `throwsA`. Under parallel load the Future wasn't awaited before the test completed, causing intermittent "emitted null" failures. Switched to `await expectLater()` — the correct async-throwing assertion pattern.

### 3. CWD-contamination loading failures (root cause of issue #256)
`findProjectRoot()` relied on CWD (strategy S3) and `Platform.script` (S1/S2/S5). Under `dart test`, `Platform.script` points to a pre-compiled `.dill` in a temp kernel dir, and CWD gets contaminated by `feature_command_test` (which sets `Directory.current` to a temp workspace). Concurrent test files calling `findProjectRoot()` at load time then failed with "Cannot determine zuraffa project root".

**Fix:** Made `findProjectRoot()` async with a new primary strategy (S0) using `Isolate.resolvePackageUri(Uri.parse('package:zuraffa/zuraffa.dart'))` — CWD-independent and works under `dart test`. Updated all 6 callers to `await`. Also fixed `feature_command_test` tearDown to restore CWD to the real repo root (was restoring to `/tmp` via a broken `_safeRoot()`).

### 4. Analyzer warning cleanups (16 → 6 issues)
Fixed 10 actionable warnings: doc-comment HTML escaping (backticks), string interpolation preference, curly-brace flow control, unused imports/variables in tests. Remaining 6 are architectural (pubspec git-deps for zorphy monorepo) or cascade-risky (unused top-level vars needing helper removal).

## Verification
- `dart analyze`: 6 issues (all pre-existing/architectural, down from 16)
- `dart test`: **1062 pass, 0 fail** (up from 1054/3)
- The 3 previously-failing tests now pass both in isolation and under full parallelism

Closes #163

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved formatting for authentication examples and plugin-related documentation.
* **Style**
  * Improved formatting and readability of generated output, including spacing before completion markers.
  * Simplified internal naming expressions without changing generated results.
* **Tests**
  * Improved project-root discovery across test environments.
  * Updated asynchronous test setup and fixture resolution for more reliable test execution.
  * Cleaned up unused test variables and imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->