### PR TITLE
fix(setup): flutter overrides analyzer/meta so `zfa setup --flutter` wires

### DIFF
--- a/lib/src/core/dependencies/dependency_wirer.dart
+++ b/lib/src/core/dependencies/dependency_wirer.dart
@@ -95,22 +95,39 @@ class DependencyWirer {
   static const zuraffaGitUrl = 'https://github.com/arrrrny/zuraffa';
 
   /// Git source for the zorphy monorepo (contains `zorphy` and
-  /// `zorphy_annotation` sub-packages).
-  static const zorphyGitUrl = 'https://github.com/arrrrny/zorphy';
+  /// `zorphy_annotation` sub-packages). Must match the exact URL string used
+  /// by the zuraffa root pubspec (https://github.com/arrrrny/zorphy.git):
+  /// pub treats git sources as identical only when the URL string matches
+  /// verbatim, and a `.git`-vs-bare mismatch breaks version solving when
+  /// `zuraffa_flutter` pulls `zuraffa` transitively.
+  static const zorphyGitUrl = 'https://github.com/arrrrny/zorphy.git';
 
   /// Default git ref — tracks the development branch which is where active
   /// v6 work lands before merging to master.
   static const defaultGitRef = 'development';
 
-  /// The analyzer version zuraffa pins (see root pubspec.yaml). Overriding
-  /// analyzer in downstream apps prevents version-conflict failures when
-  /// `dart pub get` resolves the transitive graph.
+  /// The analyzer version zuraffa pins in pure-Dart packages (see root
+  /// pubspec.yaml). Overriding analyzer in downstream apps prevents
+  /// version-conflict failures when `dart pub get` resolves the transitive
+  /// graph.
   static const analyzerOverrideVersion = '14.1.0';
+
+  /// Flutter apps cannot use the [analyzerOverrideVersion] override: the
+  /// Flutter SDK pins `meta 1.18.0` while analyzer >=13.1.0 requires
+  /// `meta ^1.18.3`, so version solving always fails. These match
+  /// `zuraffa_flutter`'s own `dependency_overrides`
+  /// (zuraffa_flutter/pubspec.yaml): analyzer is capped at ^13.1.0 and meta
+  /// is overlaid with ^1.19.0 so the graph resolves under the Flutter SDK.
+  static const flutterAnalyzerOverrideVersion = '^13.1.0';
+  static const flutterMetaOverrideVersion = '^1.19.0';
 
   /// Returns the standard zuraffa dependency set for the given project type.
   ///
   /// [isFlutter] selects `zuraffa_flutter` + `flutter_lints` (Flutter apps)
-  /// versus `zuraffa` (pure Dart packages). All other entries are shared.
+  /// versus `zuraffa` (pure Dart packages), and picks the override set:
+  /// Flutter apps get the analyzer + meta overrides that match
+  /// `zuraffa_flutter`'s own pubspec, pure Dart packages pin analyzer
+  /// directly. All other entries are shared.
   static List<DependencySpec> standardSet({required bool isFlutter}) {
     return [
       DependencySpec(
@@ -131,11 +148,23 @@ class DependencyWirer {
       const DependencySpec(name: 'mocktail', kind: DependencyKind.dev),
       if (isFlutter)
         const DependencySpec(name: 'flutter_lints', kind: DependencyKind.dev),
-      const DependencySpec(
-        name: 'analyzer',
-        kind: DependencyKind.override,
-        version: analyzerOverrideVersion,
-      ),
+      if (isFlutter) ...[
+        const DependencySpec(
+          name: 'analyzer',
+          kind: DependencyKind.override,
+          version: flutterAnalyzerOverrideVersion,
+        ),
+        const DependencySpec(
+          name: 'meta',
+          kind: DependencyKind.override,
+          version: flutterMetaOverrideVersion,
+        ),
+      ] else
+        const DependencySpec(
+          name: 'analyzer',
+          kind: DependencyKind.override,
+          version: analyzerOverrideVersion,
+        ),
     ];
   }
 
@@ -293,6 +322,33 @@ class DependencyWirer {
         .where((s) => s.kind == DependencyKind.override)
         .toList();
 
+    // --- dependency_overrides via direct pubspec edit ---
+    // Written BEFORE `pub add` so the version resolution that command
+    // triggers already sees the overrides. In Flutter apps the analyzer +
+    // meta overrides are what make the transitive graph resolvable in the
+    // first place, so they must be in the pubspec before anything resolves.
+    if (overrideSpecs.isNotEmpty) {
+      var newContent = pubspecFile.readAsStringSync();
+      for (final spec in overrideSpecs) {
+        newContent = addOverrideToPubspec(
+          newContent,
+          spec.name,
+          spec.version ?? '',
+        );
+        print('   ✅ Added override:${spec.name}=${spec.version}');
+      }
+      try {
+        await pubspecFile.writeAsString(newContent);
+        // Record overrides as added only after the write succeeds.
+        added.addAll(overrideSpecs.map((s) => s.name));
+      } catch (e) {
+        print(
+          '   ⚠️  Failed to write dependency_overrides to pubspec.yaml: $e',
+        );
+        failed.addAll(overrideSpecs.map((s) => s.name));
+      }
+    }
+
     // --- regular / dev deps via `pub add` ---
     // Flutter projects must use `flutter pub add`/`flutter pub get`: the
     // standalone `dart` executable cannot resolve `sdk: flutter` deps.
@@ -320,28 +376,8 @@ class DependencyWirer {
       }
     }
 
-    // --- dependency_overrides via direct pubspec edit ---
+    // --- final re-resolve so the whole graph is consistent ---
     if (overrideSpecs.isNotEmpty) {
-      var newContent = pubspecFile.readAsStringSync();
-      for (final spec in overrideSpecs) {
-        newContent = addOverrideToPubspec(
-          newContent,
-          spec.name,
-          spec.version ?? '',
-        );
-        print('   ✅ Added override:${spec.name}=${spec.version}');
-      }
-      try {
-        await pubspecFile.writeAsString(newContent);
-        // Record overrides as added only after the write succeeds.
-        added.addAll(overrideSpecs.map((s) => s.name));
-      } catch (e) {
-        print(
-          '   ⚠️  Failed to write dependency_overrides to pubspec.yaml: $e',
-        );
-        failed.addAll(overrideSpecs.map((s) => s.name));
-      }
-      // Re-resolve so the override takes effect.
       try {
         final getResult = await Process.run(
           pubExecutable,
@@ -352,7 +388,8 @@ class DependencyWirer {
           final err = getResult.stderr.toString().trim();
           if (err.isNotEmpty) {
             print(
-              '   ⚠️  $pubExecutable pub get reported issues after override edit:',
+              '   ⚠️  $pubExecutable pub get reported issues after wiring '
+              'overrides ${overrideSpecs.map((s) => '${s.name}=${s.version}').join(', ')}:',
             );
             print('      ${err.split('\n').take(3).join('\n      ')}');
           }

--- a/lib/src/core/dependencies/dependency_wirer.dart
+++ b/lib/src/core/dependencies/dependency_wirer.dart
@@ -197,7 +197,14 @@ class DependencyWirer {
         case DependencyKind.dev:
           return !devDeps.containsKey(spec.name);
         case DependencyKind.override:
-          return !overrides.containsKey(spec.name);
+          if (!overrides.containsKey(spec.name)) {
+            return true; // missing entirely
+          }
+          // Key exists: check if the value matches the required version.
+          final existing = overrides[spec.name];
+          final existingStr = (existing is String ? existing : existing.toString()).trim();
+          final requiredStr = (spec.version ?? '').trim();
+          return existingStr != requiredStr; // stale if different
       }
     }).toList();
   }
@@ -218,7 +225,9 @@ class DependencyWirer {
   ///
   /// - If the `dependency_overrides:` section does not exist, it is appended.
   /// - If it exists but [key] is absent, the entry is inserted under it.
-  /// - If [key] already exists, the content is returned unchanged (idempotent).
+  /// - If [key] already exists with the same [value], the content is returned
+  ///   unchanged (idempotent). If the existing value differs, it is replaced
+  ///   in place.
   ///
   /// Pure function — does not perform I/O.
   static String addOverrideToPubspec(
@@ -253,7 +262,14 @@ class DependencyWirer {
         break;
       }
       if (line.startsWith(keyPrefix)) {
-        return content; // already present
+        // Key exists: check if the value matches.
+        final existingValue = line.substring(keyPrefix.length).trim();
+        if (existingValue == value) {
+          return content; // already has the correct value
+        }
+        // Value differs: replace the line.
+        lines[i] = '  $key: $value';
+        return lines.join('\n');
       }
     }
 

--- a/test/commands/setup_command_test.dart
+++ b/test/commands/setup_command_test.dart
@@ -157,7 +157,8 @@ dev_dependencies:
   mocktail: ^1.0.4
   flutter_lints: ^6.0.0
 dependency_overrides:
-  analyzer: 14.1.0
+  analyzer: ^13.1.0
+  meta: ^1.19.0
 ''';
       final missing = DependencyWirer.findMissing(fullPubspec, isFlutter: true);
       expect(missing, isEmpty);

--- a/test/core/dependencies/dependency_wirer_test.dart
+++ b/test/core/dependencies/dependency_wirer_test.dart
@@ -329,6 +329,46 @@ dependency_overrides:
         expect(missing, isEmpty);
       });
 
+      test('flutter project: stale analyzer override version is detected as missing', () {
+        final pubspec = '''
+name: my_app
+environment:
+  sdk: ^3.11.0
+
+dependencies:
+  flutter:
+    sdk: flutter
+  zuraffa_flutter:
+    git:
+      url: https://github.com/arrrrny/zuraffa
+      path: zuraffa_flutter
+  zorphy_annotation:
+    git:
+      url: https://github.com/arrrrny/zorphy
+      path: zorphy_annotation
+
+dev_dependencies:
+  build_runner: ^2.15.2
+  mocktail: ^1.0.4
+  flutter_lints: ^6.0.0
+
+dependency_overrides:
+  analyzer: 14.1.0
+  meta: ^1.19.0
+''';
+        final missing = DependencyWirer.findMissing(
+          pubspec,
+          isFlutter: true,
+        );
+
+        // Flutter projects expect analyzer: ^13.1.0, not 14.1.0, so analyzer
+        // should be detected as needing an update.
+        expect(missing.length, 1);
+        expect(missing.first.name, 'analyzer');
+        expect(missing.first.kind, DependencyKind.override);
+        expect(missing.first.version, DependencyWirer.flutterAnalyzerOverrideVersion);
+      });
+
       test('returns all specs for unparseable pubspec', () {
         final pubspec = 'this is not ::: valid yaml {{{';
         final missing = DependencyWirer.findMissing(
@@ -417,14 +457,14 @@ dependencies:
         expect(analyzerIdx, lessThan(depsIdx));
       });
 
-      test('is idempotent when key already exists', () {
+      test('is idempotent when key already exists with matching value', () {
         final pubspec = '''
 name: my_app
 environment:
   sdk: ^3.11.0
 
 dependency_overrides:
-  analyzer: 13.0.0
+  analyzer: 14.1.0
 
 dependencies:
   http: ^1.6.0
@@ -435,8 +475,35 @@ dependencies:
           '14.1.0',
         );
 
-        // Should be unchanged — existing value preserved
+        // Should be unchanged — value already matches
         expect(result, equals(pubspec));
+      });
+
+      test('replaces existing value when it differs from new value', () {
+        final pubspec = '''
+name: my_app
+environment:
+  sdk: ^3.11.0
+
+dependency_overrides:
+  analyzer: 14.1.0
+
+dependencies:
+  http: ^1.6.0
+''';
+        final result = DependencyWirer.addOverrideToPubspec(
+          pubspec,
+          'analyzer',
+          '^13.1.0',
+        );
+
+        // Old value (14.1.0) should be replaced with new value (^13.1.0)
+        expect(result, contains('  analyzer: ^13.1.0'));
+        expect(result, isNot(contains('  analyzer: 14.1.0')));
+        // Other content should be preserved
+        expect(result, contains('name: my_app'));
+        expect(result, contains('dependencies:'));
+        expect(result, contains('http: ^1.6.0'));
       });
 
       test('handles pubspec with no trailing newline', () {

--- a/test/core/dependencies/dependency_wirer_test.dart
+++ b/test/core/dependencies/dependency_wirer_test.dart
@@ -59,6 +59,12 @@ void main() {
         expect(zorphyAnn.isGit, isTrue);
         expect(zorphyAnn.gitUrl, DependencyWirer.zorphyGitUrl);
         expect(zorphyAnn.gitPath, 'zorphy_annotation');
+        // Must match the URL string used by the zuraffa root pubspec
+        // (https://github.com/arrrrny/zorphy.git): pub only unifies git
+        // sources when the URL matches verbatim, so a bare-zorphy variant
+        // breaks version solving once zuraffa_flutter pulls zuraffa
+        // transitively.
+        expect(zorphyAnn.gitUrl, 'https://github.com/arrrrny/zorphy.git');
       });
 
       test('build_runner and mocktail are dev dependencies', () {
@@ -72,13 +78,30 @@ void main() {
         expect(mocktail.isGit, isFalse);
       });
 
-      test('analyzer is an override with the pinned version', () {
+      test('flutter project overrides analyzer ^13.1.0 + meta ^1.19.0', () {
         final specs = DependencyWirer.standardSet(isFlutter: true);
+        final analyzer = specs.firstWhere((s) => s.name == 'analyzer');
+        final meta = specs.firstWhere((s) => s.name == 'meta');
+
+        expect(analyzer.kind, DependencyKind.override);
+        expect(analyzer.version, DependencyWirer.flutterAnalyzerOverrideVersion);
+        expect(analyzer.isOverride, isTrue);
+        // Flutter apps need the meta overlay too: the Flutter SDK pins
+        // meta 1.18.0 while analyzer >=13.1.0 requires meta ^1.18.3.
+        expect(meta.kind, DependencyKind.override);
+        expect(meta.version, DependencyWirer.flutterMetaOverrideVersion);
+        expect(meta.isOverride, isTrue);
+      });
+
+      test('dart project keeps the pinned analyzer 14.1.0 override only', () {
+        final specs = DependencyWirer.standardSet(isFlutter: false);
         final analyzer = specs.firstWhere((s) => s.name == 'analyzer');
 
         expect(analyzer.kind, DependencyKind.override);
         expect(analyzer.version, DependencyWirer.analyzerOverrideVersion);
         expect(analyzer.isOverride, isTrue);
+        // Pure Dart packages do not overlay meta.
+        expect(specs.map((s) => s.name), isNot(contains('meta')));
       });
     });
 
@@ -132,7 +155,8 @@ dev_dependencies:
   flutter_lints: ^6.0.0
 
 dependency_overrides:
-  analyzer: 14.1.0
+  analyzer: ^13.1.0
+  meta: ^1.19.0
 ''';
         final missing = DependencyWirer.findMissing(
           pubspec,
@@ -162,7 +186,8 @@ dev_dependencies:
   flutter_lints: ^6.0.0
 
 dependency_overrides:
-  analyzer: 14.1.0
+  analyzer: ^13.1.0
+  meta: ^1.19.0
 ''';
         final missing = DependencyWirer.findMissing(
           pubspec,
@@ -196,7 +221,8 @@ dev_dependencies:
   flutter_lints: ^6.0.0
 
 dependency_overrides:
-  analyzer: 14.1.0
+  analyzer: ^13.1.0
+  meta: ^1.19.0
 ''';
         final missing = DependencyWirer.findMissing(
           pubspec,
@@ -208,7 +234,7 @@ dependency_overrides:
         expect(missing.first.kind, DependencyKind.dev);
       });
 
-      test('detects missing analyzer override only', () {
+      test('detects missing analyzer + meta overrides only', () {
         final pubspec = '''
 name: my_app
 environment:
@@ -234,6 +260,38 @@ dev_dependencies:
         final missing = DependencyWirer.findMissing(
           pubspec,
           isFlutter: true,
+        );
+
+        expect(missing.length, 2);
+        expect(missing.map((s) => s.name), containsAll(['analyzer', 'meta']));
+        expect(
+          missing.every((s) => s.kind == DependencyKind.override),
+          isTrue,
+        );
+      });
+
+      test('dart project: missing analyzer override only', () {
+        final pubspec = '''
+name: my_pkg
+environment:
+  sdk: ^3.11.0
+
+dependencies:
+  zuraffa:
+    git:
+      url: https://github.com/arrrrny/zuraffa
+  zorphy_annotation:
+    git:
+      url: https://github.com/arrrrny/zorphy
+      path: zorphy_annotation
+
+dev_dependencies:
+  build_runner: ^2.15.2
+  mocktail: ^1.0.4
+''';
+        final missing = DependencyWirer.findMissing(
+          pubspec,
+          isFlutter: false,
         );
 
         expect(missing.length, 1);


### PR DESCRIPTION
## What

Fixes #279 — `zfa setup --flutter` failed dependency wiring on every Flutter app.

**Root cause:** `DependencyWirer.standardSet()` unconditionally added `override:analyzer=14.1.0` for both Flutter and Dart projects. The Flutter SDK pins `meta 1.18.0` while analyzer >=13.1.0 requires `meta ^1.18.3`, so version solving always failed.

## Changes

- **`standardSet()` branches on `isFlutter`:**
  - Flutter apps → `override:analyzer=^13.1.0` + `override:meta=^1.19.0` (exactly matches `zuraffa_flutter`'s own `dependency_overrides`).
  - Pure Dart packages → keep `override:analyzer=14.1.0` (no `meta` overlay).
- **`wire()` writes `dependency_overrides` before running `pub add`** so the resolution `pub add` triggers already sees the overrides — without this, `flutter pub add zuraffa_flutter` fails before any override exists, no matter which versions are chosen.
- **Failure path surfaces the added overrides** (`pub get` error now names `analyzer=…, meta=…`).
- **`zorphyGitUrl` fixed to the canonical `https://github.com/arrrrny/zorphy.git`** — the zuraffa root pubspec uses the `.git`-suffixed URL, and pub only unifies git sources when the URL string matches verbatim. The bare-URL variant broke version solving once `zuraffa_flutter` pulled `zuraffa` transitively (this was masked before because `zuraffa_flutter` always failed first).

## Verification

- End-to-end: ran the real `DependencyWirer.wire()` against a fresh `flutter create` app — all 6 deps wired, `failed=[]`, `flutter pub get` resolves under the Flutter SDK.
- End-to-end Dart branch: `zuraffa` + `zorphy_annotation` + dev deps wired with `analyzer=14.1.0`, resolves.
- `dart test test/core/dependencies/dependency_wirer_test.dart test/commands/setup_command_test.dart` — 70/70 pass (extended for the Flutter vs Dart override branches).
- `dart analyze` on all touched files — no issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved dependency setup for Flutter projects with compatible Analyzer and Meta package overrides.
  * Preserved tailored Analyzer dependency handling for Dart-only projects.
  * Updated Zorphy package sourcing for more reliable retrieval.
* **Bug Fixes**
  * Dependency resolution now applies overrides before package installation and performs a final resolution.
  * Improved resolution diagnostics to show the override versions involved.
* **Tests**
  * Expanded coverage for Flutter and Dart dependency configurations, including missing dependencies and version overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->