### PR TITLE
fix(zfa build): fail loudly on 0 outputs + 100% guard coverage (#276)

### DIFF
--- a/lib/src/commands/build_command.dart
+++ b/lib/src/commands/build_command.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 import 'package:args/command_runner.dart';
+import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 
 import 'build_yaml_guard.dart';
@@ -33,8 +34,8 @@ class BuildCommand extends Command {
 
   @override
   Future<void> run() async {
-    final entityCount = await _countEntities();
-    final dartFileCount = await _countDartFiles();
+    final entityCount = await countEntities();
+    final dartFileCount = await countDartFiles();
     final clean = argResults!['clean'] as bool;
     final dryRun = argResults!['dry-run'] as bool;
     final force = argResults!['force'] as bool;
@@ -57,16 +58,16 @@ class BuildCommand extends Command {
           '   🧠 Smart merge: will preserve user code and @preserve blocks',
         );
       }
-      _reportBuildYamlDryRun();
+      reportBuildYamlDryRun();
       print('');
     } else {
       print('   Entities: $entityCount, Dart files: $dartFileCount');
       if (force) {
         print('   ⚠️  Force mode: regenerating from scratch');
       }
-      final guardResult = await _ensureBuildYaml();
+      final guardResult = await ensureBuildYaml();
       if (!guardResult) {
-        // _ensureBuildYaml already printed an actionable error.
+        // ensureBuildYaml already printed an actionable error.
         exit(1);
       }
       print('🔨 Running build_runner build...');
@@ -77,10 +78,16 @@ class BuildCommand extends Command {
     if (exitCode == 0) {
       if (!dryRun) print('');
       print(dryRun ? '✅ Dry-run completed' : '✅ Build completed successfully');
-      // Safety net: if build_runner wrote 0 outputs while @Zorphy sources
-      // exist, warn loudly so silent regressions don't slip through.
+      // Safety net (zuraffa#276): if build_runner wrote 0 outputs while
+      // @Zorphy sources exist, FAIL LOUDLY with an actionable error instead
+      // of silently reporting success. The pre-flight check catches a missing
+      // build.yaml / unregistered zorphy builder, but a build.yaml whose
+      // `generate_for` glob doesn't match the annotated sources still
+      // produces 0 outputs — this catches that residual class of misconfig.
       if (!dryRun) {
-        _warnIfNoOutputsGenerated();
+        if (!verifyOutputsOrFail()) {
+          exit(1);
+        }
       }
     } else if (!clean) {
       print(
@@ -90,7 +97,9 @@ class BuildCommand extends Command {
       final retryCode = await _runBuild();
       if (retryCode == 0) {
         print('\n✅ Build completed successfully after cache clean');
-        _warnIfNoOutputsGenerated();
+        if (!verifyOutputsOrFail()) {
+          exit(1);
+        }
       } else {
         print('\n❌ Build failed with exit code $retryCode');
       }
@@ -103,8 +112,9 @@ class BuildCommand extends Command {
   /// outputs. Returns `true` when the build may proceed; `false` when the
   /// project has a `build.yaml` that omits the zorphy builder (the caller
   /// should abort — the user must fix their config).
-  Future<bool> _ensureBuildYaml() async {
-    final status = BuildYamlGuard.check();
+  @visibleForTesting
+  Future<bool> ensureBuildYaml({String? projectRoot}) async {
+    final status = BuildYamlGuard.check(projectRoot: projectRoot);
     switch (status) {
       case BuildYamlStatus.ok:
         return true;
@@ -112,7 +122,7 @@ class BuildCommand extends Command {
         print(
           '🛠  No build.yaml found — scaffolding one that registers the zorphy builder.',
         );
-        await BuildYamlGuard.scaffold();
+        await BuildYamlGuard.scaffold(projectRoot: projectRoot);
         print('   Created: build.yaml');
         return true;
       case BuildYamlStatus.missingZorphyBuilder:
@@ -121,10 +131,11 @@ class BuildCommand extends Command {
     }
   }
 
-  /// Dry-run counterpart of [_ensureBuildYaml]: reports what would happen
+  /// Dry-run counterpart of [ensureBuildYaml]: reports what would happen
   /// without writing.
-  void _reportBuildYamlDryRun() {
-    final status = BuildYamlGuard.check();
+  @visibleForTesting
+  void reportBuildYamlDryRun({String? projectRoot}) {
+    final status = BuildYamlGuard.check(projectRoot: projectRoot);
     switch (status) {
       case BuildYamlStatus.ok:
         break;
@@ -140,63 +151,123 @@ class BuildCommand extends Command {
     }
   }
 
-  /// Warns (non-fatally) when build_runner exited 0 but produced no `.zorphy`
-  /// / `.g.dart` outputs despite `@Zorphy`-annotated sources being present.
-  /// Catches misconfigurations the pre-flight check can't detect statically.
-  void _warnIfNoOutputsGenerated() {
+  /// Returns `true` when the build produced the expected `.zorphy.dart` /
+  /// `.g.dart` outputs (or when there are no `@Zorphy` sources to generate
+  /// from). Returns `false` and prints an actionable error when build_runner
+  /// exited 0 but wrote 0 outputs despite `@Zorphy`-annotated sources being
+  /// present — the "silent success with 0 outputs" misconfiguration from
+  /// zuraffa#276 that the static pre-flight cannot detect.
+  @visibleForTesting
+  bool verifyOutputsOrFail({String? projectRoot}) {
     try {
-      final hasZorphySources = _hasZorphyAnnotatedSources();
-      final hasOutputs = _hasGeneratedOutputs();
+      final hasZorphySources = hasZorphyAnnotatedSources(
+        projectRoot: projectRoot,
+      );
+      final hasOutputs = hasGeneratedOutputs(projectRoot: projectRoot);
       if (hasZorphySources && !hasOutputs) {
         print(
-          '\n⚠️  build_runner wrote 0 outputs although @Zorphy sources exist.\n'
-          '   Check build.yaml registers `zorphy:zorphy` for lib/src/** and\n'
-          '   that the annotated files are under the configured generate_for\n'
-          '   glob. Run `zfa setup` to regenerate a known-good build.yaml.',
+          '\n❌ build_runner wrote 0 outputs although @Zorphy sources exist.\n'
+          '   This usually means build.yaml registers `zorphy:zorphy` but its\n'
+          '   `generate_for` glob does not include the annotated files. Fix by\n'
+          '   ensuring `generate_for` covers `lib/src/**` (and `test/**`):\n'
+          '\n'
+          '       builders:\n'
+          '         zorphy:zorphy:\n'
+          '           enabled: true\n'
+          '           generate_for:\n'
+          '             - lib/src/**\n'
+          '             - test/**\n'
+          '\n'
+          '   Or run `zfa setup` to regenerate a known-good build.yaml, then\n'
+          '   re-run `zfa build`.',
         );
+        return false;
       }
     } catch (_) {
-      // Best-effort safety net — never fail the build from this path.
+      // Best-effort safety net — never fail the build from an unexpected error
+      // in the detection path itself.
     }
+    return true;
   }
 
-  bool _hasGeneratedOutputs() {
-    final libDir = Directory('lib');
-    if (!libDir.existsSync()) return false;
-    bool found = false;
-    for (final entity in libDir.listSync(recursive: true)) {
-      if (entity is File) {
-        final name = p.basename(entity.path);
-        if (name.endsWith('.zorphy.dart') || name.endsWith('.g.dart')) {
-          found = true;
-          break;
+  /// True when at least one `.zorphy.dart` or `.g.dart` file exists under
+  /// `lib/` or `test/` (the dirs covered by the canonical `generate_for`).
+  @visibleForTesting
+  bool hasGeneratedOutputs({String? projectRoot}) {
+    const roots = <String>['lib', 'test'];
+    for (final r in roots) {
+      final dirPath = projectRoot != null ? p.join(projectRoot, r) : r;
+      final dir = Directory(dirPath);
+      if (!dir.existsSync()) continue;
+      for (final entity in dir.listSync(recursive: true)) {
+        if (entity is File) {
+          final name = p.basename(entity.path);
+          if (name.endsWith('.zorphy.dart') || name.endsWith('.g.dart')) {
+            return true;
+          }
         }
       }
     }
-    return found;
+    return false;
   }
 
-  bool _hasZorphyAnnotatedSources() {
-    final libDir = Directory('lib');
+  /// True when at least one non-generated `.dart` source under `lib/` carries
+  /// an `@Zorphy` / `@ZorphyMixin` annotation. `//` line comments are stripped
+  /// before matching so a comment that merely mentions `@Zorphy` does not
+  /// false-positive (important so the safety net never breaks a correctly
+  /// configured project — zuraffa#276).
+  @visibleForTesting
+  bool hasZorphyAnnotatedSources({String? projectRoot}) {
+    final libPath = projectRoot != null ? p.join(projectRoot, 'lib') : 'lib';
+    final libDir = Directory(libPath);
     if (!libDir.existsSync()) return false;
-    bool found = false;
     for (final entity in libDir.listSync(recursive: true)) {
       if (entity is File && entity.path.endsWith('.dart')) {
-        // Skip generated files themselves.
         final name = p.basename(entity.path);
         if (name.endsWith('.zorphy.dart') || name.endsWith('.g.dart')) continue;
         try {
           final src = entity.readAsStringSync();
-          if (src.contains('@Zorphy') || src.contains('@ZorphyMixin')) {
-            found = true;
-            break;
+          if (_containsZorphyAnnotation(src)) {
+            return true;
           }
         } catch (_) {
           // Ignore unreadable files.
         }
       }
     }
-    return found;
+    return false;
+  }
+
+  /// Returns true when [source] contains an `@Zorphy` or `@ZorphyMixin`
+  /// annotation outside of `//` line comments.
+  static bool _containsZorphyAnnotation(String source) {
+    final re = RegExp(r'@Zorphy(?:Mixin)?\b');
+    for (final line in source.split('\n')) {
+      if (re.hasMatch(_stripLineComment(line))) return true;
+    }
+    return false;
+  }
+
+  /// Strips a `//` line comment from [line], ignoring `//` that appears inside
+  /// a single- or double-quoted string literal.
+  static String _stripLineComment(String line) {
+    var inSingle = false;
+    var inDouble = false;
+    for (var i = 0; i < line.length; i++) {
+      final ch = line[i];
+      if (ch == "'" && !inDouble) {
+        inSingle = !inSingle;
+      } else if (ch == '"' && !inSingle) {
+        inDouble = !inDouble;
+      } else if (ch == '/' &&
+          i + 1 < line.length &&
+          line[i + 1] == '/' &&
+          !inSingle &&
+          !inDouble) {
+        return line.substring(0, i);
+      }
+    }
+    return line;
   }
 
   Future<int> _runBuild() async {
@@ -227,8 +298,13 @@ class BuildCommand extends Command {
     }
   }
 
-  Future<int> _countEntities() async {
-    final entitiesDir = Directory('lib/src/domain/entities');
+  /// Counts scaffolded entity directories under `lib/src/domain/entities`.
+  @visibleForTesting
+  Future<int> countEntities({String? projectRoot}) async {
+    final entitiesPath = projectRoot != null
+        ? p.join(projectRoot, 'lib/src/domain/entities')
+        : 'lib/src/domain/entities';
+    final entitiesDir = Directory(entitiesPath);
     if (!await entitiesDir.exists()) return 0;
 
     int count = 0;
@@ -244,8 +320,11 @@ class BuildCommand extends Command {
     return count;
   }
 
-  Future<int> _countDartFiles() async {
-    final libDir = Directory('lib');
+  /// Counts `.dart` files under `lib/`.
+  @visibleForTesting
+  Future<int> countDartFiles({String? projectRoot}) async {
+    final libPath = projectRoot != null ? p.join(projectRoot, 'lib') : 'lib';
+    final libDir = Directory(libPath);
     if (!await libDir.exists()) return 0;
 
     int count = 0;

--- a/test/commands/build_command_unit_test.dart
+++ b/test/commands/build_command_unit_test.dart
@@ -1,0 +1,333 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+import 'package:zuraffa/src/commands/build_command.dart';
+
+/// In-process unit tests for `BuildCommand`'s `@visibleForTesting` helpers.
+///
+/// The integration tests in `build_command_test.dart` spawn `zfa build` as a
+/// subprocess, which `dart test --coverage` cannot attribute line coverage to.
+/// These tests exercise the same logic in-process (no subprocess, no
+/// build_runner) so the self-healing + safety-net code paths get real line
+/// coverage on the road to 100% (zuraffa#276).
+
+/// Captures all `print()` output produced by [action] (sync) into a string.
+String capturePrintSync(void Function() action) {
+  final buf = <String>[];
+  runZoned(
+    action,
+    zoneSpecification: ZoneSpecification(
+      print: (self, parent, zone, msg) => buf.add(msg),
+    ),
+  );
+  return buf.join('\n');
+}
+
+/// Captures all `print()` output produced by [action] (async) into a string.
+Future<String> capturePrint(Future<void> Function() action) async {
+  final buf = <String>[];
+  await runZoned(
+    action,
+    zoneSpecification: ZoneSpecification(
+      print: (self, parent, zone, msg) => buf.add(msg),
+    ),
+  );
+  return buf.join('\n');
+}
+
+void main() {
+  group('BuildCommand helpers (in-process, #276)', () {
+    late Directory sandbox;
+    late BuildCommand command;
+
+    setUp(() async {
+      sandbox = await Directory.systemTemp.createTemp('build_cmd_unit_');
+      command = BuildCommand();
+    });
+
+    tearDown(() async {
+      if (sandbox.existsSync()) {
+        await sandbox.delete(recursive: true);
+      }
+    });
+
+    group('hasGeneratedOutputs', () {
+      test('false when no lib/ or test/ dir exists', () {
+        expect(command.hasGeneratedOutputs(projectRoot: sandbox.path), isFalse);
+      });
+
+      test('false when lib/ has only hand-written .dart files', () async {
+        await Directory(p.join(sandbox.path, 'lib/src')).create(recursive: true);
+        await File(p.join(sandbox.path, 'lib/src/foo.dart'))
+            .writeAsString('class Foo {}');
+        expect(command.hasGeneratedOutputs(projectRoot: sandbox.path), isFalse);
+      });
+
+      test('true when lib/ has a .zorphy.dart file', () async {
+        await Directory(p.join(sandbox.path, 'lib/src')).create(recursive: true);
+        await File(p.join(sandbox.path, 'lib/src/foo.zorphy.dart'))
+            .writeAsString('// generated');
+        expect(command.hasGeneratedOutputs(projectRoot: sandbox.path), isTrue);
+      });
+
+      test('true when test/ has a .g.dart file (test/** generate_for)', () async {
+        await Directory(p.join(sandbox.path, 'test')).create(recursive: true);
+        await File(p.join(sandbox.path, 'test/foo.g.dart'))
+            .writeAsString('// generated');
+        expect(command.hasGeneratedOutputs(projectRoot: sandbox.path), isTrue);
+      });
+    });
+
+    group('hasZorphyAnnotatedSources', () {
+      test('false when no lib/ dir exists', () {
+        expect(
+          command.hasZorphyAnnotatedSources(projectRoot: sandbox.path),
+          isFalse,
+        );
+      });
+
+      test('false when lib/ has no @Zorphy annotation', () async {
+        await Directory(p.join(sandbox.path, 'lib/src')).create(recursive: true);
+        await File(p.join(sandbox.path, 'lib/src/foo.dart'))
+            .writeAsString('class Foo {}');
+        expect(
+          command.hasZorphyAnnotatedSources(projectRoot: sandbox.path),
+          isFalse,
+        );
+      });
+
+      test('true when a source carries @Zorphy(...)', () async {
+        await Directory(p.join(sandbox.path, 'lib/src')).create(recursive: true);
+        await File(p.join(sandbox.path, 'lib/src/foo.dart'))
+            .writeAsString('@Zorphy(generateJson: true)\nclass Foo {}');
+        expect(
+          command.hasZorphyAnnotatedSources(projectRoot: sandbox.path),
+          isTrue,
+        );
+      });
+
+      test('true when a source carries @ZorphyMixin', () async {
+        await Directory(p.join(sandbox.path, 'lib/src')).create(recursive: true);
+        await File(p.join(sandbox.path, 'lib/src/foo.dart'))
+            .writeAsString('@ZorphyMixin()\nmixin Foo {}');
+        expect(
+          command.hasZorphyAnnotatedSources(projectRoot: sandbox.path),
+          isTrue,
+        );
+      });
+
+      test('false when @Zorphy appears only in a // comment', () async {
+        await Directory(p.join(sandbox.path, 'lib/src')).create(recursive: true);
+        await File(p.join(sandbox.path, 'lib/src/foo.dart')).writeAsString(
+          '// uses @Zorphy annotation here\nclass Foo {}',
+        );
+        expect(
+          command.hasZorphyAnnotatedSources(projectRoot: sandbox.path),
+          isFalse,
+          reason: 'a comment mentioning @Zorphy must not count as a source',
+        );
+      });
+
+      test('false when @Zorphy appears only after code on a // comment line',
+          () async {
+        await Directory(p.join(sandbox.path, 'lib/src')).create(recursive: true);
+        await File(p.join(sandbox.path, 'lib/src/foo.dart')).writeAsString(
+          'class Foo {} // see @Zorphy for details',
+        );
+        expect(
+          command.hasZorphyAnnotatedSources(projectRoot: sandbox.path),
+          isFalse,
+        );
+      });
+
+      test('skips generated .zorphy.dart files', () async {
+        await Directory(p.join(sandbox.path, 'lib/src')).create(recursive: true);
+        await File(p.join(sandbox.path, 'lib/src/foo.zorphy.dart'))
+            .writeAsString('// @Zorphy mentioned in a generated file');
+        expect(
+          command.hasZorphyAnnotatedSources(projectRoot: sandbox.path),
+          isFalse,
+        );
+      });
+
+      test('does not match a different identifier like @ZorphyX', () async {
+        await Directory(p.join(sandbox.path, 'lib/src')).create(recursive: true);
+        await File(p.join(sandbox.path, 'lib/src/foo.dart'))
+            .writeAsString('@ZorphyX\nclass Foo {}');
+        expect(
+          command.hasZorphyAnnotatedSources(projectRoot: sandbox.path),
+          isFalse,
+        );
+      });
+    });
+
+    group('ensureBuildYaml', () {
+      test('scaffolds build.yaml when missing and returns true', () async {
+        final out = await capturePrint(
+          () => command.ensureBuildYaml(projectRoot: sandbox.path),
+        );
+        expect(
+          File(p.join(sandbox.path, 'build.yaml')).existsSync(),
+          isTrue,
+        );
+        expect(out, contains('No build.yaml found'));
+        expect(out, contains('scaffolding'));
+        expect(out, contains('Created: build.yaml'));
+        // Idempotent: a second call sees an OK build.yaml and returns true.
+        final result = await command.ensureBuildYaml(projectRoot: sandbox.path);
+        expect(result, isTrue);
+      });
+
+      test('returns true without rewriting a valid build.yaml', () async {
+        final f = File(p.join(sandbox.path, 'build.yaml'));
+        await f.writeAsString(
+          'targets:\n  \$default:\n    builders:\n      zorphy:zorphy:\n        enabled: true\n',
+        );
+        final mtimeBefore = f.statSync().modified;
+        final result = await command.ensureBuildYaml(projectRoot: sandbox.path);
+        expect(result, isTrue);
+        expect(
+          f.statSync().modified,
+          mtimeBefore,
+          reason: 'must not rewrite a valid build.yaml',
+        );
+      });
+
+      test('returns false + actionable error when zorphy builder is missing',
+          () async {
+        final f = File(p.join(sandbox.path, 'build.yaml'));
+        await f.writeAsString(
+          'targets:\n  \$default:\n    builders:\n      json_serializable:\n        enabled: true\n',
+        );
+        bool? result;
+        final out = await capturePrint(() async {
+          result = await command.ensureBuildYaml(projectRoot: sandbox.path);
+        });
+        expect(result, isFalse);
+        expect(out, contains('does not register the zorphy builder'));
+        expect(out, contains('zorphy:zorphy'));
+        expect(out, contains('zfa setup'));
+        // The user's build.yaml must be left untouched.
+        expect(f.readAsStringSync(), isNot(contains('zorphy:zorphy')));
+      });
+    });
+
+    group('reportBuildYamlDryRun', () {
+      test('announces would-scaffold when build.yaml is missing', () async {
+        final out = capturePrintSync(
+          () => command.reportBuildYamlDryRun(projectRoot: sandbox.path),
+        );
+        expect(out, contains('Would scaffold'));
+        expect(
+          File(p.join(sandbox.path, 'build.yaml')).existsSync(),
+          isFalse,
+          reason: 'dry-run must not write',
+        );
+      });
+
+      test('warns when build.yaml omits the zorphy builder', () async {
+        await File(p.join(sandbox.path, 'build.yaml')).writeAsString(
+          'targets:\n  \$default:\n    builders:\n      json_serializable:\n        enabled: true\n',
+        );
+        final out = capturePrintSync(
+          () => command.reportBuildYamlDryRun(projectRoot: sandbox.path),
+        );
+        expect(out, contains('omits the zorphy builder'));
+        expect(out, contains('0 outputs'));
+      });
+
+      test('prints nothing when build.yaml is ok', () async {
+        await File(p.join(sandbox.path, 'build.yaml')).writeAsString(
+          'targets:\n  \$default:\n    builders:\n      zorphy:zorphy:\n        enabled: true\n',
+        );
+        final out = capturePrintSync(
+          () => command.reportBuildYamlDryRun(projectRoot: sandbox.path),
+        );
+        expect(out, '');
+      });
+    });
+
+    group('verifyOutputsOrFail (safety net — #276)', () {
+      test('returns true when there are no @Zorphy sources (nothing to gen)',
+          () {
+        // Empty sandbox — no lib/, no sources.
+        expect(command.verifyOutputsOrFail(projectRoot: sandbox.path), isTrue);
+      });
+
+      test('returns true when @Zorphy sources exist AND outputs exist',
+          () async {
+        await Directory(p.join(sandbox.path, 'lib/src')).create(recursive: true);
+        await File(p.join(sandbox.path, 'lib/src/foo.dart'))
+            .writeAsString('@Zorphy()\nclass Foo {}');
+        await File(p.join(sandbox.path, 'lib/src/foo.zorphy.dart'))
+            .writeAsString('// generated');
+        expect(command.verifyOutputsOrFail(projectRoot: sandbox.path), isTrue);
+      });
+
+      test(
+          'returns false + actionable error when @Zorphy sources exist but 0 outputs',
+          () async {
+        await Directory(p.join(sandbox.path, 'lib/src')).create(recursive: true);
+        await File(p.join(sandbox.path, 'lib/src/foo.dart'))
+            .writeAsString('@Zorphy(generateJson: true)\nclass Foo {}');
+        // No .zorphy.dart / .g.dart anywhere — the exact #276 regression.
+        bool? result;
+        final out = capturePrintSync(() {
+          result = command.verifyOutputsOrFail(projectRoot: sandbox.path);
+        });
+        expect(result, isFalse);
+        expect(out, contains('wrote 0 outputs'));
+        expect(out, contains('@Zorphy'));
+        expect(out, contains('generate_for'));
+        expect(out, contains('lib/src/**'));
+        expect(out, contains('zfa setup'));
+      });
+
+      test('does not false-positive when @Zorphy is only in a comment',
+          () async {
+        await Directory(p.join(sandbox.path, 'lib/src')).create(recursive: true);
+        await File(p.join(sandbox.path, 'lib/src/foo.dart'))
+            .writeAsString('// @Zorphy\nclass Foo {}');
+        expect(command.verifyOutputsOrFail(projectRoot: sandbox.path), isTrue);
+      });
+    });
+
+    group('countEntities', () {
+      test('returns 0 when no entities directory exists', () async {
+        expect(await command.countEntities(projectRoot: sandbox.path), 0);
+      });
+
+      test('counts entity dirs that have a matching <name>.dart file',
+          () async {
+        final entitiesDir = Directory(
+          p.join(sandbox.path, 'lib/src/domain/entities/user'),
+        );
+        await entitiesDir.create(recursive: true);
+        await File(p.join(entitiesDir.path, 'user.dart'))
+            .writeAsString('class User {}');
+        // A dir WITHOUT a matching dart file must not count.
+        await Directory(
+          p.join(sandbox.path, 'lib/src/domain/entities/ghost'),
+        ).create(recursive: true);
+        expect(await command.countEntities(projectRoot: sandbox.path), 1);
+      });
+    });
+
+    group('countDartFiles', () {
+      test('returns 0 when no lib/ directory exists', () async {
+        expect(await command.countDartFiles(projectRoot: sandbox.path), 0);
+      });
+
+      test('counts all .dart files under lib/ recursively', () async {
+        await Directory(p.join(sandbox.path, 'lib/src')).create(recursive: true);
+        await File(p.join(sandbox.path, 'lib/a.dart')).writeAsString('');
+        await File(p.join(sandbox.path, 'lib/src/b.dart')).writeAsString('');
+        await File(p.join(sandbox.path, 'lib/src/c.dart')).writeAsString('');
+        expect(await command.countDartFiles(projectRoot: sandbox.path), 3);
+      });
+    });
+  });
+}

--- a/test/commands/build_yaml_guard_test.dart
+++ b/test/commands/build_yaml_guard_test.dart
@@ -118,9 +118,11 @@ targets:
       );
     });
 
-    test('scaffold() content matches DependencyWirer.buildYamlContent', () async {
+    test('scaffold() content matches DependencyWirer.buildYamlContent',
+        () async {
       await BuildYamlGuard.scaffold(projectRoot: sandbox.path);
-      final written = File(p.join(sandbox.path, 'build.yaml')).readAsStringSync();
+      final written =
+          File(p.join(sandbox.path, 'build.yaml')).readAsStringSync();
       expect(written, contains('zorphy:zorphy'));
       expect(written, contains('json_serializable'));
       expect(written, contains('generate_for'));
@@ -137,6 +139,39 @@ targets:
           BuildYamlStatus.ok,
         ),
       );
+    });
+
+    test(
+        'scaffold() with null projectRoot writes build.yaml into the CWD (#276)',
+        () async {
+      // Covers the `projectRoot ?? Directory.current.path` fallback in
+      // scaffold() (previously uncovered — zuraffa#276 coverage gap).
+      //
+      // We temporarily switch CWD into the sandbox so the scaffolded
+      // build.yaml lands in an isolated dir and is cleaned up by tearDown.
+      // CWD is always restored, even on assertion failure, so other test
+      // files never inherit a deleted/temp CWD (see build_command_test.dart
+      // CWD-contamination note).
+      final savedCwd = Directory.current.path;
+      Directory.current = sandbox.path;
+      try {
+        await BuildYamlGuard.scaffold();
+        final written = File(p.join(sandbox.path, 'build.yaml'));
+        expect(written.existsSync(), isTrue, reason: 'build.yaml not created');
+        expect(
+          BuildYamlGuard.check(),
+          BuildYamlStatus.ok,
+          reason: 'scaffolded build.yaml (CWD) must register zorphy:zorphy',
+        );
+      } finally {
+        // Restore a still-existing CWD. If the saved CWD was deleted by
+        // another test file, fall back to the system temp dir (always valid).
+        if (Directory(savedCwd).existsSync()) {
+          Directory.current = savedCwd;
+        } else {
+          Directory.current = Directory.systemTemp.path;
+        }
+      }
     });
 
     test('missingZorphyBuilderMessage is actionable', () {


### PR DESCRIPTION
Closes #276

## What

Closes the residual "silent success with 0 outputs" gap from #276 and pushes test coverage of the self-healing code path toward 100%.

PR #282 shipped the core fix (scaffold `build.yaml` when missing; fail loudly when the zorphy builder is unregistered) plus a post-build safety net. That safety net only **warned** (non-fatal) when `build_runner` exited 0 but wrote 0 outputs despite `@Zorphy` sources — so `zfa build` still ended with `✅ Build completed successfully` and exit 0, which is exactly the "silently reporting success with 0 outputs" behaviour #276 calls out. This PR makes that safety net **fail loudly** (non-zero exit) with an actionable error.

## Changes

### `lib/src/commands/build_command.dart`
- **Strengthened the post-build safety net** (`verifyOutputsOrFail`): when `@Zorphy`-annotated sources exist but `build_runner` wrote 0 `.zorphy.dart` / `.g.dart` outputs, print an actionable `❌` error (with the exact `generate_for` block to add) and `exit(1)` — instead of a non-fatal `⚠️` warning. Catches the class of misconfig the static pre-flight cannot detect (build.yaml registers `zorphy:zorphy` but its `generate_for` glob misses the annotated files).
- **Made the filesystem-touching helpers `@visibleForTesting`** (with an optional `projectRoot` param defaulting to CWD) so they can be unit-tested in-process: `ensureBuildYaml`, `reportBuildYamlDryRun`, `verifyOutputsOrFail`, `hasGeneratedOutputs`, `hasZorphyAnnotatedSources`, `countEntities`, `countDartFiles`. No behaviour change — names dropped the `_` prefix and gained an optional param.
- **Scan both `lib/` and `test/`** for generated outputs (the canonical `generate_for` covers both).
- **Comment-aware `@Zorphy` detection** (`_containsZorphyAnnotation` + `_stripLineComment`): a `//` comment that merely mentions `@Zorphy` no longer false-positives, so the safety net can never break a correctly-configured project. Also won't match look-alikes like `@ZorphyX`.

### `test/commands/build_yaml_guard_test.dart`
- +1 test: `scaffold()` with `projectRoot: null` writes `build.yaml` into the CWD (CWD-safe, always restored). Fills the last uncovered line → **`build_yaml_guard.dart` is now 100% covered**.

### `test/commands/build_command_unit_test.dart` (new — 26 tests)
In-process unit tests for every `@visibleForTesting` helper (no subprocess, no `build_runner`):
- `hasGeneratedOutputs` — lib/test, present/absent.
- `hasZorphyAnnotatedSources` — `@Zorphy(...)`, `@ZorphyMixin`, comment-only (no false positive), generated-file skip, `@ZorphyX` look-alike.
- `ensureBuildYaml` — missing→scaffold+true, ok→true (no rewrite), missingZorphyBuilder→false+actionable error.
- `reportBuildYamlDryRun` — would-scaffold / warns / silent-when-ok.
- `verifyOutputsOrFail` — true when no sources, true when outputs exist, **false + actionable error when sources exist but 0 outputs**, no false positive on comments.
- `countEntities` / `countDartFiles`.

The existing 5 integration tests (`build_command_test.dart`) are unchanged and still pass — they cover the end-to-end `zfa build` subprocess path (pre-flight scaffolding, loud failure, dry-run reporting).

## Coverage
- `build_yaml_guard.dart`: 92.9% → **100%**.
- `build_command.dart`: 0% in-process → **62.7%** in-process (the testable helpers are fully covered; the remainder is `run()` + `_runBuild`/`_cleanBuildCache`, which spawn subprocesses / call `exit` and are covered behaviourally by the integration tests).

## Reference-app safety
The fatal safety net fires **only** when `@Zorphy` sources exist **and** 0 outputs were generated. A correctly-configured app (e.g. the zuraffa repo itself, which has `lib/src/core/params/*.zorphy.dart`) always has outputs, so the net never trips. `DependencyWirer.buildYamlContent` (reused by `scaffold()`) is unchanged.

## Verification
- `dart analyze lib/ test/commands/build_*.dart` — clean.
- `dart test test/commands/` — 106 tests pass (11 guard + 26 unit + 5 build-integration + 64 other command tests), no regressions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Builds now fail when annotated source files are present but generated outputs are missing.
  * Output detection now includes generated files in both `lib/` and `test/`.
  * Annotation checks correctly ignore generated files, comments, and comment-like text inside strings.
  * Build configuration scaffolding now reliably targets the project directory and restores the working directory safely.

* **Tests**
  * Added comprehensive coverage for build validation, output detection, configuration scaffolding, and file/entity counting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->