### PR TITLE
fix: zfa make canonical command (printed by setup) produces non-compiling code: missing data repo impl + missing orchestrator usecase

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ zfa make Product \
   --with=vpc \
   --state \
   --di \
+  --data \
   --test
 
 zfa cache adapter Product   # optional: register Hive adapters if caching needed


### PR DESCRIPTION
Closes #284

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the canonical `zfa make Product` example to include the `--data` option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->