### PR TITLE
fix(test builder): add toggle case to per-method entity test generator (#289)

### DIFF
--- a/lib/src/plugins/test/builders/test_builder_entity.dart
+++ b/lib/src/plugins/test/builders/test_builder_entity.dart
@@ -54,6 +54,19 @@ extension TestBuilderEntity on TestBuilder {
         className = 'Update${entityName}UseCase';
         returnTypeConstructor = 't$entityName';
         break;
+      case 'toggle':
+        // #289: PR #287 added 'toggle' to the entity-methods default used by
+        // the di/test plugins (['get', 'update', 'toggle']) so canonical
+        // `zfa make <Entity> --preset=crud --with=vpc,state,di,test` routes to
+        // per-method generation. Every other generator (usecase, controller,
+        // presenter, view, repository, datasource, di) has a `toggle` case —
+        // the per-method test builder must too, otherwise the test plugin
+        // crashes with `Unknown method: toggle` before any file is written.
+        // Mirrors the usecase generator: `Toggle${entityName}UseCase` returns
+        // the toggled entity (Future<Entity>), not a stream and not void.
+        className = 'Toggle${entityName}UseCase';
+        returnTypeConstructor = 't$entityName';
+        break;
       case 'delete':
         className = 'Delete${entityName}UseCase';
         returnTypeConstructor = 'null';

--- a/lib/src/plugins/test/builders/test_builder_helpers.dart
+++ b/lib/src/plugins/test/builders/test_builder_helpers.dart
@@ -89,6 +89,22 @@ extension TestBuilderHelpers on TestBuilder {
             'UpdateParams<$idType, $dataType>',
           ).call([], {'id': idValue, 'data': dataValue}),
         ];
+      case 'toggle':
+        // #289: registerFallbackValue needs a concrete ToggleParams instance
+        // matching the usecase generator's signature (ToggleParams<I, F>
+        // with id/field/value). `${entityName}Fields` is the Field-class
+        // re-exported by the entity file; `config.queryField` (default 'id')
+        // resolves to a `Field<Entity, IdType>` constant the same way the
+        // `get` branch below does for its QueryParams filter.
+        return [
+          refer(
+            'ToggleParams<$idType, ${entityName}Fields>',
+          ).call([], {
+            'id': idValue,
+            'field': refer('${entityName}Fields').property(config.queryField),
+            'value': literalBool(true),
+          }),
+        ];
       case 'delete':
         return [
           refer('DeleteParams<$idType>').constInstance([], {'id': idValue}),
@@ -182,6 +198,25 @@ extension TestBuilderHelpers on TestBuilder {
       verifyCall = refer(
         mockVarName,
       ).property('update').call([refer('any').call([])]);
+    } else if (method == 'toggle') {
+      // #289: Mirror the usecase generator's toggle shape — ToggleParams<I, F>
+      // with id, field (a Field<Entity, IdType> from ${entityName}Fields), and
+      // a bool value. The mock repository call is `toggle(any())`, identical to
+      // update/create — the per-method test builder only needs the params
+      // expression and the mock call shape to match.
+      paramsExpr = refer(
+        'ToggleParams<$idType, ${entityName}Fields>',
+      ).call([], {
+        'id': idValue,
+        'field': refer('${entityName}Fields').property(config.queryField),
+        'value': literalBool(true),
+      });
+      arrangeCall = refer(
+        mockVarName,
+      ).property('toggle').call([refer('any').call([])]);
+      verifyCall = refer(
+        mockVarName,
+      ).property('toggle').call([refer('any').call([])]);
     } else if (method == 'delete') {
       paramsExpr = refer('DeleteParams<$idType>').call([], {'id': idValue});
       arrangeCall = refer(

--- a/test/integration/toggle_method_test.dart
+++ b/test/integration/toggle_method_test.dart
@@ -165,4 +165,67 @@ void main() {
     expect(controllerContent, contains('isToggling'));
     expect(controllerContent, contains('_presenter.toggleTodo'));
   });
+
+  // Regression test for #289: PR #287 added 'toggle' to the entity-methods
+  // default used by the di/test plugins (['get', 'update', 'toggle']) so a
+  // canonical `zfa make <Entity> --preset=crud --with=vpc,state,di,test`
+  // routes through the per-method generators. The test builder's method
+  // switch had no `toggle` case, so the test plugin crashed with
+  // `Unknown method: toggle` before emitting any file. This locks in the
+  // fix: with the test plugin on + toggle in the methods list, generation
+  // succeeds AND the per-method toggle usecase test file is emitted with the
+  // expected shape.
+  test(
+    '#289 — toggle test file is generated when test plugin is on (no Unknown method: toggle crash)',
+    () async {
+      final generator = CodeGenerator(
+        config: GeneratorConfig(
+          name: 'Todo',
+          methods: const ['get', 'update', 'toggle'],
+          generateData: true,
+          generateLocal: true,
+          generateUseCase: true,
+          generateVpcs: true,
+          generateState: true,
+          generateDi: true,
+          generateTest: true,
+          outputDir: outputDir,
+        ),
+        outputDir: outputDir,
+        options: const GeneratorOptions(
+          dryRun: false,
+          force: true,
+          verbose: false,
+        ),
+      );
+
+      final result = await generator.generate();
+      expect(
+        result.success,
+        isTrue,
+        reason: 'Generation crashed: ${result.errors.join('; ')}',
+      );
+
+      // The per-method test builder must emit a toggle-specific test file.
+      final toggleTestFile = File(
+        '$outputDir/../../test/domain/usecases/todo/toggle_todo_usecase_test.dart',
+      );
+      expect(
+        toggleTestFile.existsSync(),
+        isTrue,
+        reason: 'toggle_todo_usecase_test.dart should be generated',
+      );
+
+      final content = toggleTestFile.readAsStringSync();
+      // Class name follows the usecase generator's pattern.
+      expect(content, contains('ToggleTodoUseCase'));
+      // The mock repository must be exercised via its toggle method.
+      expect(content, contains('mockRepository.toggle('));
+      // The params constructor must match the usecase generator's signature.
+      expect(content, contains('ToggleParams<String, TodoFields>'));
+      // The Field constant must come from the entity's Fields class
+      // (config.queryField defaults to 'id').
+      expect(content, contains('TodoFields.id'));
+    },
+  );
 }


### PR DESCRIPTION
Closes #289

## Summary

Fixes #289 — `zfa make` crashed with `Unknown method: toggle` whenever an entity make used the default entity-methods default (introduced by #287) together with the test plugin (`--with=test`).

## Root cause

PR #287 added the entity-methods default `[\"get\", \"update\", \"toggle\"]` to both `di_plugin.dart` and `test_plugin.dart` so canonical `zfa make <Entity> --preset=crud --with=vpc,state,di,test` invocations route through per-method generation. Every other generator that switches on `method` already had a `case \"toggle\"`:

- usecase ✓ (entity_usecase_generator.dart)
- controller ✓ (controller_plugin_methods.dart)
- presenter ✓ (presenter_plugin.dart)
- view ✓ (view_plugin.dart)
- repository ✓ (interface/cached/simple/synced)
- datasource ✓ (local/remote/interface)
- di ✓ (di_plugin.dart)
- mock ✓

…EXCEPT the per-method test builder (`test_builder_entity.dart`) — its `switch (method)` covered get / getList / list / create / update / delete / watch / watchList but not toggle, so the test plugin crashed with `ArgumentError: Unknown method: toggle` before emitting any file. The two test-builder helpers (`_getFallbackValues` and `_generateFutureTests` in `test_builder_helpers.dart`) also had no toggle branch, so even if the switch were relaxed the emitted test file would have been empty.

## Fix

Purely additive — three files, +111 lines, no deletions:

1. **`lib/src/plugins/test/builders/test_builder_entity.dart`** — add `case \"toggle\":` to the method switch. Mirrors the usecase generator: `Toggle\${entityName}UseCase`, returns the toggled entity (`Future<Entity>`), so `returnTypeConstructor = \"t\$entityName\"`, `isStream = false`, `isCompletable = false`. The usecase-file-name logic falls through to the standard `${method}_${entitySnake}_usecase.dart` pattern, so the emitted test file is named `toggle_<entity>_usecase_test.dart`.

2. **`lib/src/plugins/test/builders/test_builder_helpers.dart`**:
   - `_getFallbackValues`: add `case \"toggle\":` returning `ToggleParams<idType, \${entityName}Fields>(id: idValue, field: \${entityName}Fields.<queryField>, value: true)` so `registerFallbackValue` receives a concrete `ToggleParams` matching the usecase generator signature.
   - `_generateFutureTests`: add `else if (method == \"toggle\")` branch constructing the same `ToggleParams` and calling `mockVarName.toggle(any())` for both arrange and verify (mirrors the update branch).

3. **`test/integration/toggle_method_test.dart`** — new regression test case that exercises the exact failing config from the issue (`methods: [get, update, toggle]` + all generation flags + `generateTest: true`) and asserts:
   - generation succeeds (no `Unknown method: toggle`),
   - `toggle_<entity>_usecase_test.dart` is emitted,
   - the file references `Toggle<Entity>UseCase`, `mockRepository.toggle(`, `ToggleParams<String, <Entity>Fields>`, and `<Entity>Fields.id`.

## Why option 1 from the issue (add toggle case) vs. option 2 (drop toggle from defaults) vs. option 3 (shared registry)

- **Option 1 (chosen)** — minimal, surgical, aligns the test builder with every other generator. Restores the per-method test coverage for toggle that #287 was trying to enable in the first place.
- **Option 2 (drop toggle from defaults)** — would silently lose test coverage for the toggle usecase. Against the spirit of #287.
- **Option 3 (shared method-support registry)** — over-engineering for a single missing case.

## Verification

- `dart analyze lib/`: 1 pre-existing info-level lint in `decorator_dispatcher.dart` (unrelated, not touched). Test plugin subtree: clean.
- `dart test test/integration/toggle_method_test.dart`: 2/2 pass.
- `dart test test/integration/ test/commands/make_command_test.dart`: 32/32 pass.
- `dart test test/commands/test_command_test.dart test/core/plugin_system/plan_store_test.dart`: 10/10 pass.
- `dart test test/integration/full_entity_workflow_test.dart test/integration/di_flag_parsing_test.dart test/integration/sync_with_di_test.dart`: 3/3 pass.
- `dart test test/regression/`: 34/34 pass.

## Reproduction

Before this fix, the exact commands from the issue crash:

```bash
zfa setup zikzak_r2 --flutter --platforms=ios,macos
cd zikzak_r2
zfa entity create -n Product --field id:String --field name:String --field price:double
zfa make Product --preset=crud --with=vpc,state,di,test
# ❌ Generation failed: Invalid argument(s): Unknown method: toggle
```

After this fix, the same commands complete successfully and emit (among others):

- `test/domain/usecases/product/toggle_product_usecase_test.dart`
- `test/domain/usecases/product/get_product_usecase_test.dart`
- `test/domain/usecases/product/update_product_usecase_test.dart`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for generating tests for entity toggle operations.
  * Generated toggle tests now include entity IDs, configured fields, and enabled-state values.
  * Added repository interaction setup and verification for toggle operations.

* **Tests**
  * Added integration coverage confirming toggle test generation succeeds and produces the expected test structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->