### PR TITLE
fix(zfa make): v6 presentation imports use zuraffa_flutter + wire json_annotation (#281)

### DIFF
--- a/lib/src/core/dependencies/dependency_wirer.dart
+++ b/lib/src/core/dependencies/dependency_wirer.dart
@@ -144,7 +144,15 @@ class DependencyWirer {
         gitPath: 'zorphy_annotation',
         gitRef: defaultGitRef,
       ),
+      // #281: Wire json_annotation as a direct regular dep so generated entity
+      // files (which use @JsonSerializable / JsonKey) satisfy
+      // depend_on_referenced_packages and json_serializable stops warning.
+      const DependencySpec(name: 'json_annotation', kind: DependencyKind.regular),
       const DependencySpec(name: 'build_runner', kind: DependencyKind.dev),
+      // #281: json_serializable is registered as a builder in build.yaml; it
+      // must also be a direct dev dep so build_runner resolves the builder and
+      // depend_on_referenced_packages is satisfied.
+      const DependencySpec(name: 'json_serializable', kind: DependencyKind.dev),
       const DependencySpec(name: 'mocktail', kind: DependencyKind.dev),
       if (isFlutter)
         const DependencySpec(name: 'flutter_lints', kind: DependencyKind.dev),

--- a/lib/src/plugins/state/builders/state_builder.dart
+++ b/lib/src/plugins/state/builders/state_builder.dart
@@ -60,7 +60,10 @@ class StateBuilder {
               ].contains(m),
             ));
 
-    final imports = <String>['package:zuraffa/zuraffa.dart'];
+    // #281: Presentation-layer state imports 'package:zuraffa_flutter/zuraffa_flutter.dart'
+    // (which re-exports zuraffa core) so generated Flutter apps compile against
+    // the same direct dep setup wires and avoid depend_on_referenced_packages.
+    final imports = <String>['package:zuraffa_flutter/zuraffa_flutter.dart'];
 
     if (config.isCustomUseCase || config.isOrchestrator) {
       final types = <String>[if (!config.noEntity) config.name];

--- a/lib/src/plugins/test/builders/test_builder_custom.dart
+++ b/lib/src/plugins/test/builders/test_builder_custom.dart
@@ -32,7 +32,7 @@ extension TestBuilderCustom on TestBuilder {
     final directives = [
       Directive.import('package:flutter_test/flutter_test.dart'),
       Directive.import('package:mocktail/mocktail.dart'),
-      Directive.import('package:zuraffa/zuraffa.dart'),
+      Directive.import('package:zuraffa_flutter/zuraffa_flutter.dart'),
       Directive.import(
         'package:$packageName/src/domain/usecases/${config.effectiveDomain}/${config.nameSnake}_usecase.dart',
       ),

--- a/lib/src/plugins/test/builders/test_builder_entity.dart
+++ b/lib/src/plugins/test/builders/test_builder_entity.dart
@@ -113,7 +113,7 @@ extension TestBuilderEntity on TestBuilder {
     final directives = [
       Directive.import('package:flutter_test/flutter_test.dart'),
       Directive.import('package:mocktail/mocktail.dart'),
-      if (method != 'create') Directive.import('package:zuraffa/zuraffa.dart'),
+      if (method != 'create') Directive.import('package:zuraffa_flutter/zuraffa_flutter.dart'),
     ];
 
     String toPackageImport(String filePath) {

--- a/lib/src/plugins/test/builders/test_builder_orchestrator.dart
+++ b/lib/src/plugins/test/builders/test_builder_orchestrator.dart
@@ -20,7 +20,7 @@ extension TestBuilderOrchestrator on TestBuilder {
     final directives = [
       Directive.import('package:flutter_test/flutter_test.dart'),
       Directive.import('package:mocktail/mocktail.dart'),
-      Directive.import('package:zuraffa/zuraffa.dart'),
+      Directive.import('package:zuraffa_flutter/zuraffa_flutter.dart'),
       Directive.import(
         'package:$packageName/src/domain/usecases/${config.effectiveDomain}/${config.nameSnake}_usecase.dart',
       ),

--- a/lib/src/plugins/test/builders/test_builder_polymorphic.dart
+++ b/lib/src/plugins/test/builders/test_builder_polymorphic.dart
@@ -25,7 +25,7 @@ extension TestBuilderPolymorphic on TestBuilder {
       final directives = [
         Directive.import('package:flutter_test/flutter_test.dart'),
         Directive.import('package:mocktail/mocktail.dart'),
-        Directive.import('package:zuraffa/zuraffa.dart'),
+        Directive.import('package:zuraffa_flutter/zuraffa_flutter.dart'),
         Directive.import(
           'package:$packageName/src/domain/usecases/${config.effectiveDomain}/${classSnake}_usecase.dart',
         ),

--- a/lib/src/state/generator/state_generator.dart
+++ b/lib/src/state/generator/state_generator.dart
@@ -50,7 +50,10 @@ class StateGenerator {
     final filePath = p.join(outputDir, '${fileName}_domain_state.dart');
 
     final library = cb.Library((b) {
-      b.directives.add(cb.Directive.import('package:zuraffa/zuraffa.dart'));
+      // #281: v6 dual-layer state files import 'package:zuraffa_flutter/zuraffa_flutter.dart'
+      // (re-exports zuraffa core: DomainState/ViewState/Signal/SignalSlice) so
+      // generated Flutter apps compile against the same direct dep setup wires.
+      b.directives.add(cb.Directive.import('package:zuraffa_flutter/zuraffa_flutter.dart'));
       if (presenterImport != null) {
         b.directives.add(cb.Directive.import(presenterImport));
       }
@@ -156,7 +159,8 @@ class StateGenerator {
           ];
 
     final library = cb.Library((b) {
-      b.directives.add(cb.Directive.import('package:zuraffa/zuraffa.dart'));
+      // #281: ViewState imports 'package:zuraffa_flutter/zuraffa_flutter.dart' (re-exports zuraffa core).
+      b.directives.add(cb.Directive.import('package:zuraffa_flutter/zuraffa_flutter.dart'));
 
       b.body.add(
         cb.Class((c) {

--- a/lib/src/state/generator/view_template_generator.dart
+++ b/lib/src/state/generator/view_template_generator.dart
@@ -221,7 +221,9 @@ class ViewTemplateGenerator {
     }
 
     final library = cb.Library((b) {
-      b.directives.add(cb.Directive.import('package:zuraffa/zuraffa.dart'));
+      // #281: v6 Presenter imports 'package:zuraffa_flutter/zuraffa_flutter.dart'
+      // (re-exports zuraffa core: DualLayerPresenter/DomainState/ViewState).
+      b.directives.add(cb.Directive.import('package:zuraffa_flutter/zuraffa_flutter.dart'));
       b.directives.add(
         cb.Directive.import('${snakeCase(name)}_domain_state.dart'),
       );
@@ -254,6 +256,21 @@ class ViewTemplateGenerator {
                 ..modifier = cb.FieldModifier.final$
                 ..type = cb.refer('SlicePresenter')
                 ..assignment = cb.refer('SlicePresenter').call([]).code;
+            }),
+          );
+          // #281: Override `view` with a covariant return type so the generated
+          // view template's `controller.view.<signal>` resolves the concrete
+          // {Name}ViewState signals (e.g. isLoading) instead of the base
+          // ViewState. The super view is the $viewClassName instance passed to
+          // super above, so the cast is always safe.
+          c.methods.add(
+            cb.Method((m) {
+              m
+                ..name = 'view'
+                ..type = cb.MethodType.getter
+                ..returns = cb.refer(viewClassName)
+                ..annotations.add(cb.refer('override'))
+                ..body = cb.Code('=> super.view as $viewClassName;');
             }),
           );
         }),

--- a/test/commands/setup_command_test.dart
+++ b/test/commands/setup_command_test.dart
@@ -130,6 +130,8 @@ void main() {
       expect(names, contains('zuraffa_flutter'));
       expect(names, contains('zorphy_annotation'));
       expect(names, contains('build_runner'));
+      expect(names, contains('json_annotation'));
+      expect(names, contains('json_serializable'));
       expect(names, contains('mocktail'));
       expect(names, contains('flutter_lints'));
       expect(names, contains('analyzer'));
@@ -152,8 +154,10 @@ environment:
 dependencies:
   zuraffa_flutter: any
   zorphy_annotation: any
+  json_annotation: ^4.12.0
 dev_dependencies:
   build_runner: ^2.15.2
+  json_serializable: ^6.13.2
   mocktail: ^1.0.4
   flutter_lints: ^6.0.0
 dependency_overrides:

--- a/test/core/dependencies/dependency_wirer_test.dart
+++ b/test/core/dependencies/dependency_wirer_test.dart
@@ -14,6 +14,8 @@ void main() {
         expect(names, isNot(contains('zuraffa')));
         expect(names, contains('zorphy_annotation'));
         expect(names, contains('build_runner'));
+        expect(names, contains('json_annotation'));
+        expect(names, contains('json_serializable'));
         expect(names, contains('mocktail'));
         expect(names, contains('flutter_lints'));
         expect(names, contains('analyzer'));
@@ -27,6 +29,8 @@ void main() {
         expect(names, isNot(contains('zuraffa_flutter')));
         expect(names, contains('zorphy_annotation'));
         expect(names, contains('build_runner'));
+        expect(names, contains('json_annotation'));
+        expect(names, contains('json_serializable'));
         expect(names, contains('mocktail'));
         expect(names, isNot(contains('flutter_lints')));
         expect(names, contains('analyzer'));
@@ -122,7 +126,9 @@ environment:
         expect(names, containsAll([
           'zuraffa_flutter',
           'zorphy_annotation',
+          'json_annotation',
           'build_runner',
+          'json_serializable',
           'mocktail',
           'flutter_lints',
           'analyzer',
@@ -148,9 +154,11 @@ dependencies:
       url: https://github.com/arrrrny/zorphy
       path: zorphy_annotation
       ref: development
+  json_annotation: ^4.12.0
 
 dev_dependencies:
   build_runner: ^2.15.2
+  json_serializable: ^6.13.2
   mocktail: ^1.0.4
   flutter_lints: ^6.0.0
 
@@ -179,9 +187,11 @@ dependencies:
     git:
       url: https://github.com/arrrrny/zorphy
       path: zorphy_annotation
+  json_annotation: ^4.12.0
 
 dev_dependencies:
   build_runner: ^2.15.2
+  json_serializable: ^6.13.2
   mocktail: ^1.0.4
   flutter_lints: ^6.0.0
 
@@ -215,8 +225,10 @@ dependencies:
     git:
       url: https://github.com/arrrrny/zorphy
       path: zorphy_annotation
+  json_annotation: ^4.12.0
 
 dev_dependencies:
+  json_serializable: ^6.13.2
   mocktail: ^1.0.4
   flutter_lints: ^6.0.0
 
@@ -251,9 +263,11 @@ dependencies:
     git:
       url: https://github.com/arrrrny/zorphy
       path: zorphy_annotation
+  json_annotation: ^4.12.0
 
 dev_dependencies:
   build_runner: ^2.15.2
+  json_serializable: ^6.13.2
   mocktail: ^1.0.4
   flutter_lints: ^6.0.0
 ''';
@@ -284,9 +298,11 @@ dependencies:
     git:
       url: https://github.com/arrrrny/zorphy
       path: zorphy_annotation
+  json_annotation: ^4.12.0
 
 dev_dependencies:
   build_runner: ^2.15.2
+  json_serializable: ^6.13.2
   mocktail: ^1.0.4
 ''';
         final missing = DependencyWirer.findMissing(
@@ -313,9 +329,11 @@ dependencies:
     git:
       url: https://github.com/arrrrny/zorphy
       path: zorphy_annotation
+  json_annotation: ^4.12.0
 
 dev_dependencies:
   build_runner: ^2.15.2
+  json_serializable: ^6.13.2
   mocktail: ^1.0.4
 
 dependency_overrides:
@@ -346,9 +364,11 @@ dependencies:
     git:
       url: https://github.com/arrrrny/zorphy
       path: zorphy_annotation
+  json_annotation: ^4.12.0
 
 dev_dependencies:
   build_runner: ^2.15.2
+  json_serializable: ^6.13.2
   mocktail: ^1.0.4
   flutter_lints: ^6.0.0
 

--- a/test/state/v6_cli_generation_test.dart
+++ b/test/state/v6_cli_generation_test.dart
@@ -29,6 +29,9 @@ void main() {
       final content = file.readAsStringSync();
       expect(content.contains('class ProductDetailPresenter'), true);
       expect(content.contains('extends DualLayerPresenter'), true);
+      // #281: presenter overrides `view` with a covariant return type so the
+      // generated view's `controller.view.<signal>` resolves concrete signals.
+      expect(content.contains('ProductDetailViewState get view'), true);
       expect(content.contains('ProductDetailDomainState'), true);
       expect(content.contains('ProductDetailViewState'), true);
       expect(content.contains('SlicePresenter'), true);
@@ -62,7 +65,8 @@ void main() {
           .readAsStringSync();
       expect(content.contains("import 'order_detail_domain_state.dart'"), true);
       expect(content.contains("import 'order_detail_view_state.dart'"), true);
-      expect(content.contains("import 'package:zuraffa/zuraffa.dart'"), true);
+      expect(content.contains("import 'package:zuraffa_flutter/zuraffa_flutter.dart'"),
+          true);
     });
   });
 


### PR DESCRIPTION
Closes #281

## Problem
`zfa make` generated non-compiling code on the v6 stack. Generated presentation/state/test files imported `package:zuraffa/zuraffa.dart` (v5), but v6 Flutter apps depend on `zuraffa_flutter` (which re-exports `zuraffa` + the Flutter layer). This triggered `depend_on_referenced_packages` lints and, for `--v6-state`, `controller.view.<signal>` failed to resolve because `DualLayerPresenter.view` was typed as the base `ViewState`. Setup also didn't wire `json_annotation`, so `json_serializable` warned.

PR #284/#287 already fixed the import for the view/controller/presenter plugins; this completes the fix for the remaining generators.

## Fix
**Root cause #1 — presentation/test imports → `zuraffa_flutter`** (8 generators):
- `state/builders/state_builder.dart` (default `{entity}_state.dart` path — the issue's repro path)
- `state/generator/state_generator.dart` (DomainState + ViewState, `--v6-state` path)
- `state/generator/view_template_generator.dart` (v6 Presenter; View was already correct)
- 4 test builders: `test_builder_entity`, `test_builder_orchestrator`, `test_builder_custom`, `test_builder_polymorphic`

All now emit `package:zuraffa_flutter/zuraffa_flutter.dart` (re-exports `zuraffa` core: `ViewState`/`DomainState`/`Signal`/`SignalSlice`/`AppFailure`/...), consistent with the PR #284/#287 fix.

**Root cause #3 — `DualLayerPresenter.view` typing** (`--v6-state` path):
Dart has no default generic type params, so instead the generated Presenter overrides `view` with a covariant return type:
```dart
@override
ProductDetailViewState get view => super.view as ProductDetailViewState;
```
This makes `controller.view.isLoading` (etc.) resolve the concrete ViewState signals, with zero changes to the base class (fully backward-compatible).

**Root cause #4 — `json_annotation` / `json_serializable` wiring**:
`dependency_wirer.dart` `standardSet` now wires `json_annotation` (regular) + `json_serializable` (dev). Fixes `depend_on_referenced_packages` for generated entity files (which use `@JsonSerializable`/`JsonKey`) and the `json_serializable` builder warning.

**Root cause #2** (entity import in controller/domain-state) was already fixed by PR #284/#287 — confirmed present, no change needed.

## Verification
- `dart analyze lib/ test/` — clean (only 3 pre-existing warnings unrelated to this change).
- `dart test` — all affected suites pass:
  - `test/state/` (78), `test/core/dependencies/` (45), `test/commands/` (34)
  - `test/plugins/{view,controller,presenter,state}/`
  - `test/regression/output_quality_test.dart` — "generated output passes dart analyze" ✓
  - `test/dda/` (35), `test/migration_test.dart` (18)
- Direct e2e check: default state file + v6 DomainState/ViewState/Presenter all import `zuraffa_flutter` (not v5); presenter has the typed `view` getter.

## Files (11)
**lib**: `dependency_wirer.dart`, `state_builder.dart`, 4 `test_builder_*.dart`, `state_generator.dart`, `view_template_generator.dart`
**test**: `setup_command_test.dart`, `dependency_wirer_test.dart`, `v6_cli_generation_test.dart`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Generated presenters now expose strongly typed view states, improving access to view signals and reducing casting.
  - Generated state, presenter, and test files now use the Flutter integration package consistently.

- **Bug Fixes**
  - Project setup now recognizes and configures the required JSON annotation and serialization tooling.
  - Improved dependency detection for Flutter and Dart projects, including scenarios where build tooling is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->