### PR TITLE
fix(zfa make): toggle field type uses Field<Entity, dynamic> not EntityFields (#292)

### DIFF
--- a/lib/src/core/constants/known_types.dart
+++ b/lib/src/core/constants/known_types.dart
@@ -40,6 +40,20 @@ class KnownTypes {
   /// Zuraffa result and failure types
   static const zuraffaResults = ['Result', 'AppFailure'];
 
+  /// Zorphy query/framework types (re-exported by zuraffa.dart via
+  /// zorphy_annotation). These are NOT entities and must not trigger entity
+  /// imports — e.g. `Field<Entity, dynamic>` appears as a type argument in
+  /// `ToggleParams` and would otherwise produce a spurious
+  /// `domain/entities/field/field.dart` import. (#292)
+  static const zorphyTypes = [
+    'Field',
+    'Eq',
+    'Filter',
+    'Sort',
+    'SortOrder',
+    'FilterOperator',
+  ];
+
   /// All types that should be excluded from entity import generation
   static const allExcluded = [
     ...dartPrimitives,
@@ -47,6 +61,7 @@ class KnownTypes {
     ...dartTypes,
     ...zuraffaParams,
     ...zuraffaResults,
+    ...zorphyTypes,
   ];
 
   /// Check if a type name should be excluded from entity imports

--- a/lib/src/plugins/controller/controller_plugin_methods.dart
+++ b/lib/src/plugins/controller/controller_plugin_methods.dart
@@ -283,7 +283,7 @@ extension ControllerPluginMethods on ControllerPlugin {
     String entityCamel,
     bool withState,
   ) {
-    final fieldEnum = '${entityName}Fields';
+    final fieldEnum = 'Field<$entityName, dynamic>';
     final hasListMethod =
         config.methods.contains('getList') ||
         config.methods.contains('watchList');

--- a/lib/src/plugins/datasource/builders/interface_generator.dart
+++ b/lib/src/plugins/datasource/builders/interface_generator.dart
@@ -187,7 +187,7 @@ class DataSourceInterfaceBuilder {
           );
           break;
         case 'toggle':
-          final fieldEnum = '${config.name}Fields';
+          final fieldEnum = 'Field<${config.name}, dynamic>';
           methods.add(
             Method(
               (m) => m

--- a/lib/src/plugins/datasource/builders/local_generator_impl.dart
+++ b/lib/src/plugins/datasource/builders/local_generator_impl.dart
@@ -190,7 +190,7 @@ extension LocalDataSourceBuilderImpl on LocalDataSourceBuilder {
           }
           break;
         case 'toggle':
-          final fieldEnum = '${config.name}Fields';
+          final fieldEnum = 'Field<${config.name}, dynamic>';
           methods.add(
             _buildMethodWithBody(
               name: 'toggle',
@@ -351,7 +351,7 @@ extension LocalDataSourceBuilderImpl on LocalDataSourceBuilder {
           );
           break;
         case 'toggle':
-          final fieldEnum = '${config.name}Fields';
+          final fieldEnum = 'Field<${config.name}, dynamic>';
           methods.add(
             _buildMethodWithBody(
               name: 'toggle',

--- a/lib/src/plugins/datasource/builders/remote_generator.dart
+++ b/lib/src/plugins/datasource/builders/remote_generator.dart
@@ -255,7 +255,7 @@ class RemoteDataSourceBuilder {
           );
           break;
         case 'toggle':
-          final fieldEnum = '${config.name}Fields';
+          final fieldEnum = 'Field<${config.name}, dynamic>';
           methods.add(
             Method(
               (m) => m

--- a/lib/src/plugins/presenter/presenter_plugin.dart
+++ b/lib/src/plugins/presenter/presenter_plugin.dart
@@ -638,7 +638,7 @@ class PresenterPlugin extends FileGeneratorPlugin implements CliAwarePlugin {
     ParsedUseCaseInfo info,
     String entityName,
   ) {
-    final fieldEnum = '${entityName}Fields';
+    final fieldEnum = 'Field<$entityName, dynamic>';
     final toggleParams =
         refer('ToggleParams<${config.idFieldType}, $fieldEnum>').call([], {
           'id': refer(config.idField),

--- a/lib/src/plugins/repository/generators/implementation_generator_cached.dart
+++ b/lib/src/plugins/repository/generators/implementation_generator_cached.dart
@@ -79,7 +79,7 @@ extension RepositoryImplementationGeneratorCached
             ..body = _buildCacheAwareUpdateBody(baseCacheKey),
         );
       case 'toggle':
-        final fieldEnum = '${config.name}Fields';
+        final fieldEnum = 'Field<${config.name}, dynamic>';
         return Method(
           (m) => m
             ..name = 'toggle'

--- a/lib/src/plugins/repository/generators/implementation_generator_simple.dart
+++ b/lib/src/plugins/repository/generators/implementation_generator_simple.dart
@@ -107,7 +107,7 @@ extension RepositoryImplementationGeneratorSimple
             ),
         );
       case 'toggle':
-        final fieldEnum = '${config.name}Fields';
+        final fieldEnum = 'Field<${config.name}, dynamic>';
         return Method(
           (m) => m
             ..name = 'toggle'

--- a/lib/src/plugins/repository/generators/implementation_generator_synced.dart
+++ b/lib/src/plugins/repository/generators/implementation_generator_synced.dart
@@ -87,7 +87,7 @@ extension RepositoryImplementationGeneratorSynced
             ..body = _buildSyncedUpdateBody(),
         );
       case 'toggle':
-        final fieldEnum = '${config.name}Fields';
+        final fieldEnum = 'Field<${config.name}, dynamic>';
         return Method(
           (m) => m
             ..name = 'toggle'

--- a/lib/src/plugins/repository/generators/interface_generator.dart
+++ b/lib/src/plugins/repository/generators/interface_generator.dart
@@ -352,7 +352,7 @@ class RepositoryInterfaceGenerator {
           );
           break;
         case 'toggle':
-          final fieldEnum = '${config.name}Fields';
+          final fieldEnum = 'Field<${config.name}, dynamic>';
           methods.add(
             _buildMethod(
               name: 'toggle',

--- a/lib/src/plugins/test/builders/test_builder_helpers.dart
+++ b/lib/src/plugins/test/builders/test_builder_helpers.dart
@@ -97,9 +97,7 @@ extension TestBuilderHelpers on TestBuilder {
         // resolves to a `Field<Entity, IdType>` constant the same way the
         // `get` branch below does for its QueryParams filter.
         return [
-          refer(
-            'ToggleParams<$idType, ${entityName}Fields>',
-          ).call([], {
+          refer('ToggleParams<$idType, Field<$entityName, dynamic>>').call([], {
             'id': idValue,
             'field': refer('${entityName}Fields').property(config.queryField),
             'value': literalBool(true),
@@ -204,13 +202,12 @@ extension TestBuilderHelpers on TestBuilder {
       // a bool value. The mock repository call is `toggle(any())`, identical to
       // update/create — the per-method test builder only needs the params
       // expression and the mock call shape to match.
-      paramsExpr = refer(
-        'ToggleParams<$idType, ${entityName}Fields>',
-      ).call([], {
-        'id': idValue,
-        'field': refer('${entityName}Fields').property(config.queryField),
-        'value': literalBool(true),
-      });
+      paramsExpr = refer('ToggleParams<$idType, Field<$entityName, dynamic>>')
+          .call([], {
+            'id': idValue,
+            'field': refer('${entityName}Fields').property(config.queryField),
+            'value': literalBool(true),
+          });
       arrangeCall = refer(
         mockVarName,
       ).property('toggle').call([refer('any').call([])]);

--- a/lib/src/plugins/usecase/generators/entity_usecase_generator.dart
+++ b/lib/src/plugins/usecase/generators/entity_usecase_generator.dart
@@ -219,7 +219,7 @@ class EntityUseCaseGenerator {
         break;
       case 'toggle':
         className = 'Toggle${entityName}UseCase';
-        final fieldEnum = '${entityName}Fields';
+        final fieldEnum = 'Field<$entityName, dynamic>';
         baseClass = TypeReference(
           (t) => t
             ..symbol = 'UseCase'

--- a/test/integration/toggle_method_test.dart
+++ b/test/integration/toggle_method_test.dart
@@ -51,7 +51,7 @@ void main() {
     final repoContent = repoFile.readAsStringSync();
     expect(
       repoContent.contains(
-        'Future<Todo> toggle(ToggleParams<String, TodoFields> params)',
+        'Future<Todo> toggle(ToggleParams<String, Field<Todo, dynamic>> params)',
       ),
       isTrue,
     );
@@ -64,7 +64,7 @@ void main() {
     final useCaseContent = useCaseFile.readAsStringSync();
     expect(
       useCaseContent.contains(
-        'extends UseCase<Todo, ToggleParams<String, TodoFields>>',
+        'extends UseCase<Todo, ToggleParams<String, Field<Todo, dynamic>>>',
       ),
       isTrue,
     );
@@ -77,7 +77,7 @@ void main() {
     final dataRepoContent = dataRepoFile.readAsStringSync();
     expect(
       dataRepoContent.contains(
-        'Future<Todo> toggle(ToggleParams<String, TodoFields> params)',
+        'Future<Todo> toggle(ToggleParams<String, Field<Todo, dynamic>> params)',
       ),
       isTrue,
     );
@@ -91,7 +91,7 @@ void main() {
     final dataSourceContent = dataSourceFile.readAsStringSync();
     expect(
       dataSourceContent.contains(
-        'Future<Todo> toggle(ToggleParams<String, TodoFields> params)',
+        'Future<Todo> toggle(ToggleParams<String, Field<Todo, dynamic>> params)',
       ),
       isTrue,
     );
@@ -104,7 +104,7 @@ void main() {
     final remoteContent = remoteFile.readAsStringSync();
     expect(
       remoteContent.contains(
-        'Future<Todo> toggle(ToggleParams<String, TodoFields> params) async',
+        'Future<Todo> toggle(ToggleParams<String, Field<Todo, dynamic>> params) async',
       ),
       isTrue,
     );
@@ -123,7 +123,7 @@ void main() {
     final localContent = localFile.readAsStringSync();
     expect(
       localContent.contains(
-        'Future<Todo> toggle(ToggleParams<String, TodoFields> params) async',
+        'Future<Todo> toggle(ToggleParams<String, Field<Todo, dynamic>> params) async',
       ),
       isTrue,
     );
@@ -222,7 +222,7 @@ void main() {
       // The mock repository must be exercised via its toggle method.
       expect(content, contains('mockRepository.toggle('));
       // The params constructor must match the usecase generator's signature.
-      expect(content, contains('ToggleParams<String, TodoFields>'));
+      expect(content, contains('ToggleParams<String, Field<Todo, dynamic>>'));
       // The Field constant must come from the entity's Fields class
       // (config.queryField defaults to 'id').
       expect(content, contains('TodoFields.id'));


### PR DESCRIPTION
Closes #292

## Problem

`zfa make <Entity> --preset=crud --with=vpc,state,di,test` generated toggle
usecase/test files that typed `ToggleParams<I, F>` with `F = EntityFields`
(the abstract `Fields` class holding only static constants) instead of
`F = Field<Entity, dynamic>` (the actual field-descriptor type). The generated
test then passed `ProductFields.id` — a `Field<Product, String>` constant —
where `ProductFields` was expected, producing 3 analyze errors:

```
error • The argument type 'Field<Product, String>' can't be assigned to the
        parameter type 'ProductFields'.
  • test/domain/usecases/product/toggle_product_usecase_test.dart:20:16, 35:18, 49:18
```

## Root Cause

`ToggleParams<I, F>` declares `final F field;`. In zorphy-generated entities,
`ProductFields.id` is `Field<Product, String>` (a static constant descriptor),
**not** a `ProductFields` instance (`ProductFields` is an `abstract final class`
with only static members). The toggle generators parameterized on
`${entityName}Fields` (the class itself) instead of `Field<Entity, dynamic>`
(the descriptor type), so `field: ProductFields.id` was unassignable.

## Fix

**Generator type-argument fix (11 files):** Changed the `fieldEnum` local in
every toggle case from `'${entityName}Fields'` / `'${config.name}Fields'` to
`'Field<$entityName, dynamic>'` / `'Field<${config.name}, dynamic>'`. This
flows into every `ToggleParams<..., fieldEnum>` type argument and every
`field`-parameter type automatically. VALUE references
(`${entityName}Fields.id` — the static constant) are unchanged; only
TYPE-argument usages changed.

Affected generators:
- `usecase/generators/entity_usecase_generator.dart`
- `presenter/presenter_plugin.dart` (`_buildToggleMethod`)
- `controller/controller_plugin_methods.dart` (`_buildToggleMethod`)
- `datasource/builders/{local_generator_impl,interface_generator,remote_generator}.dart`
- `repository/generators/{implementation_generator_cached,simple,synced,interface_generator}.dart`
- `test/builders/test_builder_helpers.dart` (inline `ToggleParams` type ×2)

`Field<TEntity, TValue>` is from `zorphy_annotation`, re-exported by
`package:zuraffa/zuraffa.dart` (and `zuraffa_flutter`), so it is already in
scope in every generated file — no new imports needed.

**Import-resolution fix (1 file):** Added a `zorphyTypes` excluded list
(`Field`, `Eq`, `Filter`, `Sort`, `SortOrder`, `FilterOperator`) to
`KnownTypes` so `CommonPatterns.entityImports` doesn't emit a spurious
`domain/entities/field/field.dart` import when `Field<Entity, dynamic>`
appears as a type argument (the fallback path adds the path even when the
file doesn't exist).

**Test assertion update (1 file):** Updated
`test/integration/toggle_method_test.dart` assertions from
`ToggleParams<String, TodoFields>` →
`ToggleParams<String, Field<Todo, dynamic>>`. `TodoFields.id` value-reference
assertions kept (still correct).

## Verification

- Re-ran the canonical flow from the issue
  (`zfa setup → entity create → make → build → flutter analyze`):
  **0 errors** (down from 3; 16 remaining are pre-existing info-level
  `depend_on_referenced_packages` warnings unrelated to this issue)
- `dart analyze` on all 12 changed generator/lib files: **No issues found**
- `dart analyze` on full zuraffa `lib/`: **0 errors**
- **300+ tests pass**: toggle integration test, full-entity/presentation/sync/
  multi-entity/cache/custom-usecase/append-mode integration tests, and all
  plugin/core/commands/domain unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recognizing framework types without generating unnecessary entity imports.
  * Standardized toggle operations to accept generic entity fields across repositories, use cases, data sources, presenters, and generated implementations.

* **Bug Fixes**
  * Prevented framework types from being incorrectly treated as entity types during generation.

* **Tests**
  * Updated integration coverage to verify the standardized toggle field handling across application layers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->