### PR TITLE
fix(zfa make): entity-aware id-field resolution + mock datasource methods default (#294)

### DIFF
--- a/lib/src/commands/make_command.dart
+++ b/lib/src/commands/make_command.dart
@@ -7,6 +7,7 @@ import '../cli/plugin_loader.dart';
 import '../core/plugin_system/plugin_registry.dart';
 import '../core/plugin_system/plugin_manager.dart';
 import '../models/generated_file.dart';
+import '../utils/entity_field_resolver.dart';
 
 /// Command to run multiple plugins explicitly.
 /// Usage: `zfa make <Name> <plugin1> <plugin2> ... [flags]`
@@ -338,6 +339,40 @@ class MakeCommand extends Command<void> {
       overrideOutputDir: fixedOutputDir,
     );
     context.data.addAll(normalizedOptions);
+
+    // #294: auto-resolve the entity's actual id-like field from the
+    // entity source file so the generated presenter/test/datasource
+    // code references a Field constant that exists on the entity's
+    // Fields class. Without this, generators hardcode `EntityFields.id`
+    // and produce broken code for entities whose id is e.g. `depotId`.
+    // User-provided --id-field / --query-field always wins.
+    if (context.data['no-entity'] != true) {
+      final resolvedIdField = EntityFieldResolver.resolveIdField(
+        entityName: entityName,
+        projectRoot: manager.projectRoot,
+      );
+      if (resolvedIdField != null) {
+        if (!argResults!.wasParsed('id-field') &&
+            (context.data['id-field'] == null ||
+                context.data['id-field'] == 'id')) {
+          context.data['id-field'] = resolvedIdField.name;
+          context.data['id-field-type'] = resolvedIdField.nonNullableType;
+          if (context.core.verbose) {
+            print(
+              '🔍 Resolved id field for "$entityName": '
+              '${resolvedIdField.name} (${resolvedIdField.nonNullableType})',
+            );
+          }
+        }
+        if (!argResults!.wasParsed('query-field') &&
+            (context.data['query-field'] == null ||
+                context.data['query-field'] == 'id')) {
+          context.data['query-field'] = resolvedIdField.name;
+          // query-field-type falls back to id-field-type inside
+          // GeneratorConfig's constructor (see generator_config.dart).
+        }
+      }
+    }
 
     if (context.core.verbose) {
       print(

--- a/lib/src/generator/code_generator.dart
+++ b/lib/src/generator/code_generator.dart
@@ -125,7 +125,22 @@ class CodeGenerator {
   Future<GeneratorResult> generate() async {
     try {
       // Resolve the same normalized plan contract used by the CLI.
-      final data = Map<String, dynamic>.from(config.toJson());
+      // #294: GeneratorConfig.toJson() emits snake_case keys (id_field,
+      // query_field, ...) but plugins read kebab-case keys (id-field,
+      // query-field, ...) — exactly what MakeCommand's arg-parser
+      // produces. Mirror MakeCommand._normalizedOptions() here so the
+      // CodeGenerator path (used by tests + programmatic callers) honors
+      // the caller's `GeneratorConfig.idField` / `queryField` instead of
+      // silently falling through to the plugins' hardcoded `'id'`
+      // default.
+      final data = <String, dynamic>{};
+      config.toJson().forEach((key, value) {
+        data[key] = value;
+        final kebab = key.replaceAll('_', '-');
+        if (kebab != key) {
+          data[kebab] = value;
+        }
+      });
       if (data['methods'] is List) {
         data['methods'] = List<String>.from(data['methods'] as List);
       }

--- a/lib/src/plugins/datasource/datasource_plugin.dart
+++ b/lib/src/plugins/datasource/datasource_plugin.dart
@@ -138,6 +138,13 @@ class DataSourcePlugin extends FileGeneratorPlugin implements CliAwarePlugin {
           context.data['use-service'] == true ||
           context.data['useService'] == true,
       noEntity: context.data['no-entity'] == true,
+      // #294: read id-field / query-field from the CLI/MakeCommand-resolved
+      // context so generators don't hardcode `EntityFields.id` for
+      // entities whose id field is e.g. `depotId`.
+      idField: context.data['id-field'] ?? 'id',
+      idFieldType: context.data['id-field-type'] ?? 'String',
+      queryField: context.data['query-field'] ?? 'id',
+      queryFieldType: context.data['query-field-type'],
       appendToExisting:
           context.data['append'] == true ||
           context.data['method_append'] == true ||

--- a/lib/src/plugins/mock/builders/mock_datasource_builder.dart
+++ b/lib/src/plugins/mock/builders/mock_datasource_builder.dart
@@ -614,6 +614,118 @@ class MockDataSourceBuilder {
           );
           break;
 
+        case 'toggle':
+          // #294: the mock datasource must implement `toggle` to match
+          // the datasource interface (which now defaults to including
+          // toggle in its methods list). Without this case the builder
+          // silently dropped toggle, producing a class that failed
+          // `implements` with `non_abstract_class_inherits_abstract_member`.
+          final toggleFieldEnum = 'Field<$entityName, dynamic>';
+          final toggleParamsType =
+              'ToggleParams<${config.idFieldType}, $toggleFieldEnum>';
+          final isNoParamsToggle = config.idFieldType == 'NoParams';
+          final toggleBodyStatements = <Code>[
+            refer('logger').property('info').call([
+              isNoParamsToggle
+                  ? literalString('Toggling $entityName')
+                  : literalString(
+                      'Toggling $entityName: \${params.id} on field \${params.field}',
+                    ),
+            ]).statement,
+            refer(
+              'Future',
+            ).property('delayed').call([refer('_delay')]).awaited.statement,
+          ];
+
+          if (isNoParamsToggle) {
+            toggleBodyStatements.addAll([
+              declareFinal('existing')
+                  .assign(
+                    refer(
+                      '${entityName}MockData',
+                    ).property('sample$entityName'),
+                  )
+                  .statement,
+              refer('logger').property('info').call([
+                literalString('Successfully toggled $entityName'),
+              ]).statement,
+              refer('existing').returned.statement,
+            ]);
+          } else if (hasListMethods) {
+            final orElse = Method(
+              (m) => m
+                ..lambda = true
+                ..body = refer('notFoundFailure')
+                    .call([literalString('$entityName not found in mock data')])
+                    .thrown
+                    .code,
+            ).closure;
+            toggleBodyStatements.addAll([
+              declareFinal('existing')
+                  .assign(
+                    refer('${entityName}MockData')
+                        .property('${entityCamel}s')
+                        .property('firstWhere')
+                        .call(
+                          [
+                            Method(
+                              (m) => m
+                                ..requiredParameters.add(
+                                  Parameter((p) => p..name = 'item'),
+                                )
+                                ..lambda = true
+                                ..body = refer('item')
+                                    .property(config.idField)
+                                    .equalTo(refer('params').property('id'))
+                                    .code,
+                            ).closure,
+                          ],
+                          {'orElse': orElse},
+                        ),
+                  )
+                  .statement,
+              refer('logger').property('info').call([
+                literalString('Successfully toggled $entityName'),
+              ]).statement,
+              refer('existing').returned.statement,
+            ]);
+          } else {
+            toggleBodyStatements.addAll([
+              declareFinal('existing')
+                  .assign(
+                    refer(
+                      '${entityName}MockData',
+                    ).property('sample$entityName'),
+                  )
+                  .statement,
+              refer('logger').property('info').call([
+                literalString('Successfully toggled $entityName'),
+              ]).statement,
+              refer('existing').returned.statement,
+            ]);
+          }
+
+          methods.add(
+            Method(
+              (m) => m
+                ..name = 'toggle'
+                ..annotations.add(refer('override'))
+                ..returns = refer('Future<$entityName>')
+                ..modifier = MethodModifier.async
+                ..requiredParameters.add(
+                  Parameter(
+                    (p) => p
+                      ..name = 'params'
+                      ..type = refer(toggleParamsType),
+                  ),
+                )
+                ..body = Block(
+                  (b) => b..statements.addAll(toggleBodyStatements),
+                ),
+            ),
+          );
+          break;
+
         case 'delete':
           final deleteParamsType = 'DeleteParams<${config.idFieldType}>';
           final isNoParams = config.idFieldType == 'NoParams';

--- a/lib/src/plugins/mock/mock_plugin.dart
+++ b/lib/src/plugins/mock/mock_plugin.dart
@@ -100,7 +100,16 @@ class MockPlugin extends FileGeneratorPlugin implements CliAwarePlugin {
       force: context.core.force,
       verbose: context.core.verbose,
       revert: context.core.revert,
-      methods: context.data['methods']?.cast<String>().toList() ?? [],
+      // #294: default to the canonical CRUD method set used by the
+      // di/usecase/test/state/controller/datasource/repository plugins
+      // (['get', 'update', 'toggle']) so `--preset=crud --with=mock`
+      // generates a fully-implemented mock datasource instead of an
+      // empty class that fails `implements` with `non_abstract_class_inherits_abstract_member`.
+      methods:
+          context.data['methods']?.cast<String>().toList() ??
+          (context.get<bool>('no-entity') == true
+              ? []
+              : ['get', 'update', 'toggle']),
       domain: context.data['domain'],
       repo: context.data['repo'],
       generateMock: true,
@@ -108,6 +117,13 @@ class MockPlugin extends FileGeneratorPlugin implements CliAwarePlugin {
       generateMockJson: context.get<bool>('mock-json') ?? false,
       mockJsonDomain: context.data['mock-json-domain'],
       noEntity: context.data['no-entity'] == true,
+      // #294: read id-field / query-field from the CLI/MakeCommand-resolved
+      // context so generators don't hardcode `EntityFields.id` for
+      // entities whose id field is e.g. `depotId`.
+      idField: context.data['id-field'] ?? 'id',
+      idFieldType: context.data['id-field-type'] ?? 'String',
+      queryField: context.data['query-field'] ?? 'id',
+      queryFieldType: context.data['query-field-type'],
       generateData: context.data['data'] == true,
       generateDataSource: context.data['datasource'] == true,
       generateRepository: context.data['repository'] == true,

--- a/lib/src/plugins/repository/repository_plugin.dart
+++ b/lib/src/plugins/repository/repository_plugin.dart
@@ -116,6 +116,13 @@ class RepositoryPlugin extends FileGeneratorPlugin implements CliAwarePlugin {
       syncDirection: context.get<String>('sync-direction') ?? 'push',
       generateLocal: context.get<bool>('local') ?? false,
       noEntity: context.get<bool>('no-entity') ?? false,
+      // #294: read id-field / query-field from the CLI/MakeCommand-resolved
+      // context so generators don't hardcode `EntityFields.id` for
+      // entities whose id field is e.g. `depotId`.
+      idField: context.data['id-field'] ?? 'id',
+      idFieldType: context.data['id-field-type'] ?? 'String',
+      queryField: context.data['query-field'] ?? 'id',
+      queryFieldType: context.data['query-field-type'],
       useService: useService,
       generateRepository: true,
       appendToExisting:

--- a/lib/src/plugins/test/test_plugin.dart
+++ b/lib/src/plugins/test/test_plugin.dart
@@ -94,6 +94,13 @@ class TestPlugin extends FileGeneratorPlugin implements CliAwarePlugin {
       usecases: context.data['usecases']?.cast<String>().toList() ?? [],
       variants: context.data['variants']?.cast<String>().toList() ?? [],
       noEntity: context.get<bool>('no-entity') ?? false,
+      // #294: read id-field / query-field from the CLI/MakeCommand-resolved
+      // context so generators don't hardcode `EntityFields.id` for
+      // entities whose id field is e.g. `depotId`.
+      idField: context.data['id-field'] ?? 'id',
+      idFieldType: context.data['id-field-type'] ?? 'String',
+      queryField: context.data['query-field'] ?? 'id',
+      queryFieldType: context.data['query-field-type'],
       domain: context.get<String>('domain'),
       repo: context.get<String>('repo'),
       service: context.get<String>('service'),

--- a/lib/src/plugins/usecase/usecase_plugin.dart
+++ b/lib/src/plugins/usecase/usecase_plugin.dart
@@ -120,6 +120,13 @@ class UseCasePlugin extends FileGeneratorPlugin implements CliAwarePlugin {
       usecases: context.data['usecases']?.cast<String>().toList() ?? [],
       variants: context.data['variants']?.cast<String>().toList() ?? [],
       noEntity: context.get<bool>('no-entity') ?? false,
+      // #294: read id-field / query-field from the CLI/MakeCommand-resolved
+      // context so generators don't hardcode `EntityFields.id` for
+      // entities whose id field is e.g. `depotId`.
+      idField: context.data['id-field'] ?? 'id',
+      idFieldType: context.data['id-field-type'] ?? 'String',
+      queryField: context.data['query-field'] ?? 'id',
+      queryFieldType: context.data['query-field-type'],
       generateUseCase: true,
       generateData: context.data['data'] == true,
       generateRepository: context.data['repository'] == true,

--- a/lib/src/utils/entity_field_resolver.dart
+++ b/lib/src/utils/entity_field_resolver.dart
@@ -1,0 +1,179 @@
+// entity_field_resolver.dart
+//
+// Resolves the id-like field of a Zorphy entity by reading the entity's
+// source file. Used by `zfa make` to populate `id-field` / `query-field`
+// defaults so that the generated presenter / test / datasource code
+// references a field that actually exists on the entity's Fields class.
+//
+// Background (issue #294): before this fix, the generators hardcoded
+// `EntityFields.id` regardless of the entity's actual fields. Entities
+// like `StorePrice` (whose id field is `depotId`) produced broken
+// generated code that referenced `StorePriceFields.id` (undefined getter).
+//
+// Resolution order:
+//   1. a field literally named `id`
+//   2. the first field whose name ends with `Id` (e.g. `depotId`, `userId`)
+//   3. the first declared field
+//
+// The resolver returns null when the entity file cannot be located or
+// contains no parseable field declarations; in that case the caller
+// keeps its existing default (`'id'`).
+
+import 'dart:io';
+import 'package:path/path.dart' as p;
+
+/// A single parsed field declaration: a Dart type string and a field name.
+class EntityFieldInfo {
+  /// Field name as it appears in the entity source (e.g. `depotId`, `id`).
+  final String name;
+
+  /// Field type as written in the entity source (e.g. `String`, `int?`,
+  /// `Map<String, dynamic>`). Nullable trailing `?` is preserved.
+  final String type;
+
+  const EntityFieldInfo({required this.name, required this.type});
+
+  /// Strips a trailing `?` from [type] to produce a non-nullable type
+  /// string. Used when feeding the value into `idFieldType` (which is
+  /// conventionally a non-nullable type token like `String`).
+  String get nonNullableType {
+    var t = type.trim();
+    while (t.endsWith('?')) {
+      t = t.substring(0, t.length - 1).trim();
+    }
+    return t;
+  }
+
+  @override
+  String toString() => 'EntityFieldInfo(name: $name, type: $type)';
+}
+
+/// Reads a Zorphy entity source file and resolves the entity's id-like
+/// field. See the file doc comment for the resolution order.
+class EntityFieldResolver {
+  /// Default location of entity source files relative to the project root.
+  static const String defaultEntityOutputDir = 'lib/src/domain/entities';
+
+  /// Resolves the id field for [entityName] inside [projectRoot].
+  ///
+  /// Looks up `<projectRoot>/<entityOutputDir>/<snake(entityName)>/<snake(entityName)>.dart`.
+  /// Returns `null` when the entity file does not exist or contains no
+  /// parseable field declarations.
+  ///
+  /// [entityOutputDir] defaults to [defaultEntityOutputDir] but can be
+  /// overridden (e.g. in tests).
+  static EntityFieldInfo? resolveIdField({
+    required String entityName,
+    required String projectRoot,
+    String entityOutputDir = defaultEntityOutputDir,
+  }) {
+    final snake = _toSnake(entityName);
+    final entityFile = File(
+      p.join(projectRoot, entityOutputDir, snake, '$snake.dart'),
+    );
+    if (!entityFile.existsSync()) return null;
+
+    final fields = parseEntityFields(entityFile.readAsStringSync());
+    if (fields.isEmpty) return null;
+
+    // 1. literal `id`
+    for (final f in fields) {
+      if (f.name == 'id') return f;
+    }
+    // 2. first ending in `Id` (camelCase, length > 2 to avoid matching `Id`)
+    for (final f in fields) {
+      if (f.name.length > 2 && f.name.endsWith('Id')) return f;
+    }
+    // 3. first declared field
+    return fields.first;
+  }
+
+  /// Parses `<entity>.dart` source content for field declarations.
+  ///
+  /// Recognises both forms emitted by `zfa entity create`:
+  ///   - `  Type get fieldName;`     (Zorphy abstract entity, the default)
+  ///   - `  final Type fieldName;`   (concrete class hand-written)
+  ///   - `  Type fieldName;`        (concrete class without final)
+  ///
+  /// Returns the list of [EntityFieldInfo] in declaration order.
+  /// Comments and method bodies are ignored.
+  static List<EntityFieldInfo> parseEntityFields(String content) {
+    final fields = <EntityFieldInfo>[];
+
+    // Strip /* block comments */ so the regex does not match field-like
+    // text inside them.
+    final cleaned = content.replaceAll(
+      RegExp(r'/\*[\s\S]*?\*/'),
+      '',
+    );
+
+    // Match a single line of the form `  Type get fieldName;` OR
+    // `  final Type fieldName;` OR `  Type fieldName;`.
+    //
+    // Group 1 = type (greedy enough to include `Map<String, dynamic>?`)
+    // Group 2 = field name
+    //
+    // We require the line to start with whitespace (indentation inside a
+    // class body) and to end with a semicolon, so we don't accidentally
+    // pick up method declarations or top-level statements.
+    final pattern = RegExp(
+      r'^\s+(?:final\s+)?([A-Za-z_][\w<>?,\s]*?)\s+(?:get\s+)?([A-Za-z_]\w*)\s*;',
+      multiLine: true,
+    );
+
+    for (final match in pattern.allMatches(cleaned)) {
+      final type = match.group(1)!.trim();
+      final name = match.group(2)!.trim();
+      if (type.isEmpty || name.isEmpty) continue;
+      // Skip well-known non-field keywords that the regex might catch.
+      if (_reservedTypeTokens.contains(type)) continue;
+      // Skip method-returning constructors like `MyClass` followed by what
+      // looks like a parameter list — these are handled by the
+      // `(?:get\s+)?` branch only when there is no `(`, which is already
+      // enforced by the trailing `\s*;`.
+      fields.add(EntityFieldInfo(name: name, type: type));
+    }
+
+    return fields;
+  }
+
+  /// Tokens that may appear in the type position of a class body line but
+  /// are not actually field types (e.g. `static`, `const`, `void` for a
+  /// method that happens to end with `;`). These are filtered out by
+  /// [parseEntityFields].
+  static const Set<String> _reservedTypeTokens = {
+    'static',
+    'const',
+    'final',
+    'void',
+    'return',
+    'if',
+    'else',
+    'for',
+    'while',
+    'switch',
+    'case',
+    'default',
+  };
+
+  /// Converts a PascalCase / camelCase name to snake_case (matches the
+  /// `EntityConfig.snakeName` logic in zorphy so the file path lookup
+  /// is consistent with what `zfa entity create` actually writes).
+  static String _toSnake(String input) {
+    if (input.isEmpty) return '';
+    // Strip a leading `$` (Zorphy prefix for abstract entity classes).
+    var s = input;
+    while (s.startsWith(r'$')) {
+      s = s.substring(1);
+    }
+    final result = <String>[];
+    for (var i = 0; i < s.length; i += 1) {
+      final char = s[i];
+      if (i > 0 && char.toUpperCase() == char && char != '_') {
+        result.add('_');
+      }
+      result.add(char.toLowerCase());
+    }
+    return result.join();
+  }
+}

--- a/test/regression/issue_294_entity_without_id_test.dart
+++ b/test/regression/issue_294_entity_without_id_test.dart
@@ -1,0 +1,417 @@
+// Regression tests for issue #294.
+//
+// Gap 1: Generators hardcoded `EntityFields.id` regardless of the entity's
+//        actual fields, breaking entities like `StorePrice` whose id field
+//        is `depotId`. The fix wires `MakeCommand` to auto-resolve the
+//        id-like field via `EntityFieldResolver` and feed the resolved
+//        name through `context.data['id-field']` / `context.data['query-field']`.
+//        Plugins already read those keys with `?? 'id'` so the resolved
+//        name propagates without further plugin changes.
+//
+// Gap 2: `mock_plugin.dart` defaulted `methods` to `[]` (unlike the
+//        di/usecase/test/state/controller/datasource/repository plugins,
+//        which default to `['get', 'update', 'toggle']`). An empty methods
+//        list produced an empty mock datasource class that failed
+//        `implements` with `non_abstract_class_inherits_abstract_member`.
+//        The fix mirrors the other plugins' default.
+
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
+import 'package:test/test.dart';
+import 'package:zuraffa/src/core/generator_options.dart';
+import 'package:zuraffa/src/core/plugin_system/plugin_context.dart';
+import 'package:zuraffa/src/core/plugin_system/discovery_engine.dart';
+import 'package:zuraffa/src/generator/code_generator.dart';
+import 'package:zuraffa/src/models/generator_config.dart';
+import 'package:zuraffa/src/plugins/mock/mock_plugin.dart';
+import 'package:zuraffa/src/utils/entity_field_resolver.dart';
+
+import '../regression/regression_test_utils.dart';
+
+void main() {
+  late RegressionWorkspace workspace;
+  late String outputDir;
+
+  setUp(() async {
+    workspace = await createWorkspace('issue_294_entity_without_id');
+    await writePubspec(workspace);
+    await runFlutterPubGet(workspace);
+    outputDir = workspace.outputDir;
+  });
+
+  // ---------------------------------------------------------------------------
+  // Gap 1 regression: entity WITHOUT an `id` field
+  // ---------------------------------------------------------------------------
+
+  group('#294 Gap 1 — entity without `id` field', () {
+    test(
+      'resolver finds `depotId` for StorePrice (no `id` declared)',
+      () async {
+        await writeEntityStubWithoutId(
+          workspace,
+          name: 'StorePrice',
+          fields: const [
+            (name: 'depotId', type: 'String'),
+            (name: 'storeName', type: 'String'),
+            (name: 'price', type: 'double'),
+          ],
+        );
+
+        final resolved = EntityFieldResolver.resolveIdField(
+          entityName: 'StorePrice',
+          projectRoot: workspace.directory.path,
+        );
+
+        expect(resolved, isNotNull,
+            reason: 'Resolver should find depotId for StorePrice');
+        expect(resolved!.name, 'depotId');
+        expect(resolved.type, 'String');
+      },
+    );
+
+    test(
+      'generated presenter + test reference `StorePriceFields.depotId`, '
+      'NOT `StorePriceFields.id`',
+      () async {
+        await writeEntityStubWithoutId(
+          workspace,
+          name: 'StorePrice',
+          fields: const [
+            (name: 'depotId', type: 'String'),
+            (name: 'storeName', type: 'String'),
+            (name: 'price', type: 'double'),
+          ],
+        );
+
+        // Simulate what MakeCommand.run() does after the resolver
+        // resolves `depotId`: feed the resolved name into GeneratorConfig.
+        // This is exactly the shape the MakeCommand now produces.
+        final generator = CodeGenerator(
+          config: GeneratorConfig(
+            name: 'StorePrice',
+            methods: const ['get', 'update', 'toggle'],
+            idField: 'depotId',
+            idFieldType: 'String',
+            queryField: 'depotId',
+            generateData: true,
+            generateLocal: true,
+            generateUseCase: true,
+            generateVpcs: true,
+            generateState: true,
+            generateDi: true,
+            generateTest: true,
+            outputDir: outputDir,
+          ),
+          outputDir: outputDir,
+          options: const GeneratorOptions(
+            dryRun: false,
+            force: true,
+            verbose: false,
+          ),
+        );
+
+        final result = await generator.generate();
+        expect(result.success, isTrue,
+            reason: 'Generation failed: ${result.errors.join('; ')}');
+
+        // The presenter's toggle method must reference the actual id field.
+        final presenterFile = File(
+          '$outputDir/presentation/pages/store_price/store_price_presenter.dart',
+        );
+        expect(presenterFile.existsSync(), isTrue,
+            reason: 'store_price_presenter.dart should be generated');
+        final presenterContent = presenterFile.readAsStringSync();
+
+        // Positive: the generated toggle code must use `StorePriceFields.depotId`
+        expect(
+          presenterContent,
+          contains('StorePriceFields.depotId'),
+          reason: 'Presenter should reference StorePriceFields.depotId',
+        );
+
+        // Negative: the generated code must NOT reference `StorePriceFields.id`
+        // (which would be an undefined getter on the StorePriceFields class).
+        expect(
+          presenterContent,
+          isNot(contains('StorePriceFields.id')),
+          reason: 'Presenter should NOT reference StorePriceFields.id '
+              '(undefined getter on an entity without `id`)',
+        );
+
+        // Same check for the toggle usecase test file.
+        final toggleTestFile = File(
+          '${workspace.directory.path}/test/domain/usecases/store_price/'
+          'toggle_store_price_usecase_test.dart',
+        );
+        expect(toggleTestFile.existsSync(), isTrue,
+            reason: 'toggle_store_price_usecase_test.dart should be generated');
+        final testContent = toggleTestFile.readAsStringSync();
+
+        expect(
+          testContent,
+          contains('StorePriceFields.depotId'),
+          reason: 'Toggle test should reference StorePriceFields.depotId',
+        );
+        expect(
+          testContent,
+          isNot(contains('StorePriceFields.id')),
+          reason: 'Toggle test should NOT reference StorePriceFields.id',
+        );
+
+        // Same check for the get usecase test file.
+        final getTestFile = File(
+          '${workspace.directory.path}/test/domain/usecases/store_price/'
+          'get_store_price_usecase_test.dart',
+        );
+        expect(getTestFile.existsSync(), isTrue,
+            reason: 'get_store_price_usecase_test.dart should be generated');
+        final getContent = getTestFile.readAsStringSync();
+
+        expect(
+          getContent,
+          contains('StorePriceFields.depotId'),
+          reason: 'Get test should reference StorePriceFields.depotId',
+        );
+        expect(
+          getContent,
+          isNot(contains('StorePriceFields.id')),
+          reason: 'Get test should NOT reference StorePriceFields.id',
+        );
+      },
+    );
+
+    test(
+      'resolver picks the first `*Id` field when multiple exist '
+      '(GroceryPriceResult has storeId + itemName — storeId wins)',
+      () async {
+        await writeEntityStubWithoutId(
+          workspace,
+          name: 'GroceryPriceResult',
+          fields: const [
+            (name: 'storeId', type: 'String'),
+            (name: 'itemName', type: 'String'),
+            (name: 'price', type: 'double'),
+          ],
+        );
+
+        final resolved = EntityFieldResolver.resolveIdField(
+          entityName: 'GroceryPriceResult',
+          projectRoot: workspace.directory.path,
+        );
+
+        expect(resolved, isNotNull);
+        expect(resolved!.name, 'storeId');
+      },
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Gap 2 regression: mock plugin default methods
+  // ---------------------------------------------------------------------------
+
+  group('#294 Gap 2 — mock plugin default methods', () {
+    test(
+      "mock_plugin.generateWithContext emits get/update/toggle methods when "
+      "the user does NOT pass --methods (so the generated mock datasource "
+      "is not an empty class)",
+      () async {
+        // Set up a Product entity file so the workspace looks like a
+        // real `zfa make` invocation. The mock plugin itself does not
+        // read the entity file, but the test is more realistic this way.
+        await writeEntityStub(workspace, name: 'Product');
+
+        // Build a plugin context with NO `methods` entry in `data`,
+        // simulating `zfa make Product --preset=crud --with=mock` without
+        // an explicit `--methods` flag.
+        final context = _buildMockContext(
+          workspace: workspace,
+          entityName: 'Product',
+          methods: null, // simulate "user did not pass --methods"
+        );
+
+        final plugin = MockPlugin(
+          outputDir: workspace.outputDir,
+          options: const GeneratorOptions(
+            dryRun: false,
+            force: true,
+            verbose: false,
+          ),
+        );
+        final files = await plugin.generateWithContext(context);
+
+        // The mock datasource file must be emitted.
+        final mockDataSourceFile = files.firstWhere(
+          (f) => f.path.contains('product_mock_datasource.dart'),
+          orElse: () => throw StateError(
+            'mock datasource file not generated; '
+            'emitted files: ${files.map((f) => f.path).join(', ')}',
+          ),
+        );
+
+        final content = mockDataSourceFile.content;
+
+        // Positive: the class must implement get, update, AND toggle.
+        // The mock datasource builder emits these as `Future<...> get(...)`,
+        // `Future<...> update(...)`, `Future<...> toggle(...)`.
+        expect(
+          content,
+          matches(RegExp(r'Future<\w+>\s+get\s*\(')),
+          reason: 'Mock datasource must implement the `get` method',
+        );
+        expect(
+          content,
+          matches(RegExp(r'Future<\w+>\s+update\s*\(')),
+          reason: 'Mock datasource must implement the `update` method',
+        );
+        expect(
+          content,
+          matches(RegExp(r'Future<\w+>\s+toggle\s*\(')),
+          reason: 'Mock datasource must implement the `toggle` method',
+        );
+      },
+    );
+
+    test(
+      'mock_plugin still respects an explicit `--methods` override '
+      '(backwards compatibility)',
+      () async {
+        await writeEntityStub(workspace, name: 'Order');
+
+        final context = _buildMockContext(
+          workspace: workspace,
+          entityName: 'Order',
+          methods: ['get', 'getList'],
+        );
+
+        final plugin = MockPlugin(
+          outputDir: workspace.outputDir,
+          options: const GeneratorOptions(
+            dryRun: false,
+            force: true,
+            verbose: false,
+          ),
+        );
+        final files = await plugin.generateWithContext(context);
+
+        final mockDataSourceFile = files.firstWhere(
+          (f) => f.path.contains('order_mock_datasource.dart'),
+        );
+
+        final content = mockDataSourceFile.content;
+
+        // Positive: explicitly-requested methods must be present.
+        expect(content, matches(RegExp(r'Future<\w+>\s+get\s*\(')));
+        expect(content, matches(RegExp(r'Future<.+>\s+getList\s*\(')));
+
+        // Negative: `toggle` was NOT in the explicit methods list, so the
+        // mock datasource must NOT implement it (else `implements` would
+        // require it to be present and we'd be back to the original bug).
+        expect(
+          content,
+          isNot(matches(RegExp(r'Future<\w+>\s+toggle\s*\('))),
+          reason: 'toggle should not be emitted when not requested',
+        );
+      },
+    );
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Writes an entity file WITHOUT an `id` field — mimics what
+/// `zfa entity create -n X --field depotId:String` produces (a Zorphy
+/// abstract class with `Type get fieldName;` getters). Also writes a
+/// matching `<Name>Fields` class so the generated code can reference
+/// `<Name>Fields.<fieldName>` constants.
+Future<void> writeEntityStubWithoutId(
+  RegressionWorkspace workspace, {
+  required String name,
+  required List<({String name, String type})> fields,
+}) async {
+  final entitySnake = _toSnake(name);
+  final entityDir = Directory(
+    path.join(workspace.outputDir, 'domain', 'entities', entitySnake),
+  );
+  await entityDir.create(recursive: true);
+  final entityFile = File(path.join(entityDir.path, '$entitySnake.dart'));
+
+  final buffer = StringBuffer()
+    ..writeln('// Auto-generated entity stub for regression test (#294).')
+    ..writeln()
+    ..writeln('abstract class \$$name {');
+
+  for (final f in fields) {
+    buffer.writeln('  ${f.type} get ${f.name};');
+  }
+  buffer
+    ..writeln('}')
+    ..writeln();
+
+  // Stub `<Name>Fields` class with Field constants for each declared field.
+  // The mock datasource / presenter / test generators reference these.
+  buffer.writeln('abstract final class ${name}Fields {');
+  for (final f in fields) {
+    buffer.writeln(
+      "  static const Field<$name, ${f.type}> ${f.name} = "
+      "Field<$name, ${f.type}>(name: '${f.name}');",
+    );
+  }
+  buffer.writeln('}');
+
+  await entityFile.writeAsString(buffer.toString());
+}
+
+/// Builds a minimal `PluginContext` for the mock plugin, mirroring what
+/// `MakeCommand.buildContext` produces. Only the fields the mock plugin
+/// actually reads are populated.
+PluginContext _buildMockContext({
+  required RegressionWorkspace workspace,
+  required String entityName,
+  required List<String>? methods,
+}) {
+  // Build the data map separately to keep the null-aware insert readable.
+  final data = <String, dynamic>{
+    'mock': true,
+    'generate-mock': true,
+    // #294: the mock plugin only emits a mock datasource when at least
+    // one of data/datasource/repository is also requested (otherwise it
+    // has nothing to mock). `--with=mock` in `zfa make` always co-occurs
+    // with at least one of these via `--preset=crud`.
+    'data': true,
+    'datasource': true,
+  };
+  if (methods != null) {
+    data['methods'] = methods;
+  }
+
+  return PluginContext(
+    core: CoreConfig(
+      name: entityName,
+      projectRoot: workspace.directory.path,
+      outputDir: workspace.outputDir,
+      dryRun: false,
+      force: true,
+      verbose: false,
+      revert: false,
+    ),
+    data: data,
+    discovery: DiscoveryEngine(
+      projectRoot: workspace.directory.path,
+    ),
+  );
+}
+
+String _toSnake(String input) {
+  final result = <String>[];
+  for (var i = 0; i < input.length; i += 1) {
+    final char = input[i];
+    if (i > 0 && char.toUpperCase() == char && char != '_') {
+      result.add('_');
+    }
+    result.add(char.toLowerCase());
+  }
+  return result.join('');
+}

--- a/test/utils/entity_field_resolver_test.dart
+++ b/test/utils/entity_field_resolver_test.dart
@@ -1,0 +1,291 @@
+// Tests for EntityFieldResolver (#294 Gap 1).
+//
+// Covers:
+//   - the three id-resolution branches (literal `id`, first ending in `Id`,
+//     first declared field)
+//   - null when the entity file does not exist
+//   - null when the entity file has no parseable field declarations
+//   - nullable types are stripped from the returned type via `nonNullableType`
+//   - parser handles both Zorphy `Type get fieldName;` form and the
+//     hand-written `final Type fieldName;` form
+//   - parser is case-sensitive for the field-name token and tolerant of
+//     block comments
+
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+import 'package:zuraffa/src/utils/entity_field_resolver.dart';
+
+void main() {
+  late Directory tempRoot;
+  late String entitiesDir;
+
+  setUp(() async {
+    tempRoot = await Directory.systemTemp.createTemp('entity_field_resolver_');
+    entitiesDir = p.join(tempRoot.path, 'lib', 'src', 'domain', 'entities');
+    await Directory(entitiesDir).create(recursive: true);
+  });
+
+  tearDown(() async {
+    if (tempRoot.existsSync()) {
+      await tempRoot.delete(recursive: true);
+    }
+  });
+
+  /// Helper: write an entity file with [content] at the conventional path
+  /// `<root>/lib/src/domain/entities/<snake>/<snake>.dart`.
+  Future<void> writeEntity(String name, String content) async {
+    final snake = _toSnake(name);
+    final dir = Directory(p.join(entitiesDir, snake));
+    await dir.create(recursive: true);
+    await File(p.join(dir.path, '$snake.dart')).writeAsString(content);
+  }
+
+  group('resolveIdField', () {
+    test('returns null when the entity file does not exist', () {
+      final resolved = EntityFieldResolver.resolveIdField(
+        entityName: 'NoSuchEntity',
+        projectRoot: tempRoot.path,
+      );
+      expect(resolved, isNull);
+    });
+
+    test(
+      'branch 1 — picks the literal `id` field when present',
+      () async {
+        await writeEntity('Product', '''
+abstract class \$Product {
+  String get id;
+  String get name;
+  double get price;
+}
+''');
+        final resolved = EntityFieldResolver.resolveIdField(
+          entityName: 'Product',
+          projectRoot: tempRoot.path,
+        );
+        expect(resolved, isNotNull);
+        expect(resolved!.name, 'id');
+        expect(resolved.type, 'String');
+        expect(resolved.nonNullableType, 'String');
+      },
+    );
+
+    test(
+      'branch 2 — picks the first field ending in `Id` when there is no `id` '
+      '(issue #294 repro: StorePrice uses depotId)',
+      () async {
+        await writeEntity('StorePrice', '''
+abstract class \$StorePrice {
+  String get depotId;
+  String get storeName;
+  double get price;
+}
+''');
+        final resolved = EntityFieldResolver.resolveIdField(
+          entityName: 'StorePrice',
+          projectRoot: tempRoot.path,
+        );
+        expect(resolved, isNotNull);
+        expect(resolved!.name, 'depotId');
+        expect(resolved.type, 'String');
+      },
+    );
+
+    test(
+      'branch 3 — falls back to the first declared field when there is no '
+      '`id` and no `*Id` field',
+      () async {
+        await writeEntity('GroceryPriceResult', '''
+abstract class \$GroceryPriceResult {
+  String get storeName;
+  double get price;
+}
+''');
+        final resolved = EntityFieldResolver.resolveIdField(
+          entityName: 'GroceryPriceResult',
+          projectRoot: tempRoot.path,
+        );
+        expect(resolved, isNotNull);
+        expect(resolved!.name, 'storeName');
+        expect(resolved.type, 'String');
+      },
+    );
+
+    test(
+      'prefers literal `id` over an earlier `*Id` field when both exist',
+      () async {
+        await writeEntity('Audit', '''
+abstract class \$Audit {
+  String get tenantId;
+  String get id;
+  String get payload;
+}
+''');
+        final resolved = EntityFieldResolver.resolveIdField(
+          entityName: 'Audit',
+          projectRoot: tempRoot.path,
+        );
+        expect(resolved, isNotNull);
+        expect(resolved!.name, 'id');
+      },
+    );
+
+    test('handles non-String id types (int)', () async {
+      await writeEntity('Counter', '''
+abstract class \$Counter {
+  int get id;
+  int get value;
+}
+''');
+      final resolved = EntityFieldResolver.resolveIdField(
+        entityName: 'Counter',
+        projectRoot: tempRoot.path,
+      );
+      expect(resolved, isNotNull);
+      expect(resolved!.name, 'id');
+      expect(resolved.type, 'int');
+      expect(resolved.nonNullableType, 'int');
+    });
+
+    test('strips trailing `?` from nullable field types', () async {
+      await writeEntity('SoftId', '''
+abstract class \$SoftId {
+  String? get maybeId;
+  String get name;
+}
+''');
+      final resolved = EntityFieldResolver.resolveIdField(
+        entityName: 'SoftId',
+        projectRoot: tempRoot.path,
+      );
+      expect(resolved, isNotNull);
+      expect(resolved!.name, 'maybeId');
+      expect(resolved.type, 'String?');
+      expect(resolved.nonNullableType, 'String');
+    });
+
+    test('handles Map<K, V> field types (parse + nonNullableType)', () async {
+      await writeEntity('WithMap', '''
+abstract class \$WithMap {
+  Map<String, dynamic> get metadata;
+  String get name;
+}
+''');
+      final resolved = EntityFieldResolver.resolveIdField(
+        entityName: 'WithMap',
+        projectRoot: tempRoot.path,
+      );
+      expect(resolved, isNotNull);
+      expect(resolved!.name, 'metadata');
+      expect(resolved.type, contains('Map<String, dynamic>'));
+      // nonNullableType strips the trailing `?` if present, but leaves
+      // the rest of the type intact.
+      expect(resolved.nonNullableType, 'Map<String, dynamic>');
+    });
+
+    test('returns null when entity file has no field declarations', () async {
+      await writeEntity('Empty', '''
+abstract class \$Empty {}
+''');
+      final resolved = EntityFieldResolver.resolveIdField(
+        entityName: 'Empty',
+        projectRoot: tempRoot.path,
+      );
+      expect(resolved, isNull);
+    });
+
+    test('parses `final Type fieldName;` form (hand-written entity)', () async {
+      await writeEntity('Handwritten', '''
+class Handwritten {
+  final String slug;
+  final int count;
+  const Handwritten({required this.slug, required this.count});
+}
+''');
+      final resolved = EntityFieldResolver.resolveIdField(
+        entityName: 'Handwritten',
+        projectRoot: tempRoot.path,
+      );
+      expect(resolved, isNotNull);
+      expect(resolved!.name, 'slug');
+      expect(resolved.type, 'String');
+    });
+
+    test(
+      'ignores field-like text inside block comments',
+      () async {
+        await writeEntity('Commented', '''
+abstract class \$Commented {
+  /* was: String get id; */
+  String get realId;
+  String get name;
+}
+''');
+        final resolved = EntityFieldResolver.resolveIdField(
+          entityName: 'Commented',
+          projectRoot: tempRoot.path,
+        );
+        expect(resolved, isNotNull);
+        expect(resolved!.name, 'realId');
+      },
+    );
+
+    test('respects an explicit `Id` suffix (not just `Id` literal)', () async {
+      // `Id` itself (length 2) should NOT match branch 2 — too ambiguous.
+      // Fall through to branch 3 (first field).
+      await writeEntity('Ambiguous', '''
+abstract class \$Ambiguous {
+  String get Id;
+  String get name;
+}
+''');
+      final resolved = EntityFieldResolver.resolveIdField(
+        entityName: 'Ambiguous',
+        projectRoot: tempRoot.path,
+      );
+      expect(resolved, isNotNull);
+      expect(resolved!.name, 'Id'); // first declared field, branch 3
+    });
+  });
+
+  group('parseEntityFields', () {
+    test('returns an empty list for an empty file', () {
+      expect(EntityFieldResolver.parseEntityFields(''), isEmpty);
+    });
+
+    test('returns fields in declaration order', () {
+      final fields = EntityFieldResolver.parseEntityFields(
+        '''
+abstract class \$Order {
+  String get id;
+  DateTime get placedAt;
+  double get total;
+}
+''',
+      );
+      expect(fields.map((f) => f.name).toList(), ['id', 'placedAt', 'total']);
+      expect(fields[0].type, 'String');
+      expect(fields[1].type, 'DateTime');
+      expect(fields[2].type, 'double');
+    });
+  });
+}
+
+String _toSnake(String input) {
+  if (input.isEmpty) return '';
+  var s = input;
+  while (s.startsWith(r'$')) {
+    s = s.substring(1);
+  }
+  final result = <String>[];
+  for (var i = 0; i < s.length; i += 1) {
+    final char = s[i];
+    if (i > 0 && char.toUpperCase() == char && char != '_') {
+      result.add('_');
+    }
+    result.add(char.toLowerCase());
+  }
+  return result.join('');
+}


### PR DESCRIPTION
Closes #294

Gap 1: zfa make now resolves the entity's actual id-like field from the entity source file (literal `id`, else first `*Id` field, else first declared field) via the new EntityFieldResolver, and feeds the resolved name through context.data['id-field']/['query-field']. The test/usecase/repository/datasource/mock plugins now read those keys (they were silently hardcoded to 'id', breaking entities like StorePrice whose id is depotId). Also fixes a silent bug in CodeGenerator which emitted snake_case keys (id_field) that the plugins never read — now normalized to kebab-case to match the MakeCommand path.

Gap 2: mock_plugin now defaults methods to ['get','update','toggle'] (was []) matching the di/usecase/test/state/controller/datasource/repository plugins, and mock_datasource_builder gains a missing 'toggle' case so the mock datasource class is no longer empty.

Tests: 14 unit tests for EntityFieldResolver + 5 regression tests for issue #294 (entity without id field + mock plugin defaults). No regressions in existing plugin/integration/command tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically detects an entity’s identifier field and applies it to generated code.
  * Supports configurable identifier and query fields across generated repositories, use cases, data sources, tests, and mocks.
  * Mock data sources now support asynchronous `toggle` operations.
  * Mock generation defaults to `get`, `update`, and `toggle` methods when no methods are specified.

* **Bug Fixes**
  * Improved generation for entities that do not define a conventional `id` field.
  * Supports equivalent configuration option formats for plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->