### PR TITLE
fix(zfa entity create): validate field types before writing, abort on unresolvable enum/entity type (#296)

### DIFF
--- a/lib/src/commands/entity_command.dart
+++ b/lib/src/commands/entity_command.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:path/path.dart' as p;
 import 'package:zorphy/zorphy.dart';
 import '../config/zfa_config.dart';
+import '../utils/entity_type_validator.dart';
 import '../utils/entity_utils.dart';
 import '../utils/string_utils.dart';
 
@@ -146,6 +147,27 @@ ${missing.map((d) => '   • $d').join('\n')}
       ..._asStringList(parsed['field']),
       ..._asStringList(parsed['fields']),
     ]);
+
+    // Validate field types BEFORE writing anything (issue #296):
+    // if a referenced type is neither a primitive, an existing entity,
+    // nor an existing enum, abort with a clear error so the entity is
+    // never written with a bogus `$`-prefixed `InvalidType`.
+    final typeErrors = EntityTypeValidator.validate(
+      fields: fields,
+      outputDir: outputDir,
+      selfEntityName: name,
+    );
+    if (typeErrors.isNotEmpty) {
+      print('❌ Cannot create entity "$name": field type(s) could not be resolved.');
+      print('');
+      for (final err in typeErrors) {
+        print('  • ${err.message}');
+      }
+      print('');
+      print('No files were written. Resolve the above and re-run.');
+      exit(1);
+    }
+
     final useFilter =
         parsed['filter'] == true || (config?.filterByDefault ?? false);
 
@@ -243,6 +265,26 @@ ${missing.map((d) => '   • $d').join('\n')}
     }
 
     final fields = _parseFields(fieldStrings);
+
+    // Validate field types BEFORE writing anything (issue #296):
+    // same guard as `entity create` — refuse to add fields whose types
+    // cannot be resolved against the on-disk entity/enum layout.
+    final typeErrors = EntityTypeValidator.validate(
+      fields: fields,
+      outputDir: fixedEntityOutput,
+      selfEntityName: name,
+    );
+    if (typeErrors.isNotEmpty) {
+      print('❌ Cannot add field(s) to "$name": field type(s) could not be resolved.');
+      print('');
+      for (final err in typeErrors) {
+        print('  • ${err.message}');
+      }
+      print('');
+      print('No files were modified. Resolve the above and re-run.');
+      exit(1);
+    }
+
     final creator = EntityCreator(baseOutputDir: fixedEntityOutput);
     final result = await creator.addFields(
       name,

--- a/lib/src/utils/entity_type_validator.dart
+++ b/lib/src/utils/entity_type_validator.dart
@@ -1,0 +1,147 @@
+// entity_type_validator.dart
+//
+// Validates that every custom (non-primitive) field type referenced by an
+// entity's fields resolves to either an existing entity directory or an
+// existing enum file on disk — BEFORE the entity is written.
+//
+// Background (issue #296): when `zfa entity create` was called with a field
+// type whose target did not yet exist on disk (e.g. `type:FeedbackType`
+// before `zfa entity enum -n FeedbackType` was run), the zorphy
+// `FieldNormalizer` silently assumed the type was an entity and prefixed it
+// with `$`, producing `$FeedbackType`. Because `$FeedbackType` was
+// undefined, the Dart analyzer resolved it to `InvalidType`, and the
+// `ImportResolver` emitted a bogus entity-style import
+// (`import '../feedback_type/feedback_type.dart';` for a directory that did
+// not exist). The entity was written successfully (exit 0), and the failure
+// only surfaced later at `zfa build` time as a misleading
+// `json_serializable` error pointing at `InvalidType`.
+//
+// This validator closes that gap: it is invoked by `zfa entity create` and
+// `zfa entity add-field` BEFORE any file is written. If any field type
+// cannot be resolved, the command aborts with a clear, actionable error
+// and a non-zero exit code, and no entity file is written.
+
+import 'dart:io';
+import 'package:path/path.dart' as p;
+import 'package:zorphy/zorphy.dart' show FieldDefinition;
+import 'entity_utils.dart';
+import 'string_utils.dart';
+
+/// A single validation failure: the unresolved type, the field that
+/// referenced it, and a human-readable error message.
+class UnresolvedTypeError {
+  /// The field name that referenced the unresolved type (e.g. `type`).
+  final String fieldName;
+
+  /// The unresolved type as written by the user (e.g. `FeedbackType`,
+  /// `$FeedbackType`, `List<FeedbackType>`). For generic types, this is
+  /// the inner type that could not be resolved, not the full generic.
+  final String typeName;
+
+  /// A human-readable error message with an actionable fix.
+  final String message;
+
+  const UnresolvedTypeError({
+    required this.fieldName,
+    required this.typeName,
+    required this.message,
+  });
+
+  @override
+  String toString() => message;
+}
+
+/// Validates field types for an entity being created or modified.
+///
+/// A field type is considered **resolvable** when, after stripping
+/// nullability (`?`), generic wrappers (`List<...>`, `Map<...>`), and the
+/// Zorphy entity prefix (`$`), it is either:
+///
+///   1. a primitive Dart type (`String`, `int`, `double`, `bool`,
+///      `DateTime`, `Map`, `List`, `dynamic`, `Object`, ... — see
+///      [EntityUtils.extractEntityTypes] for the full exclusion list), or
+///   2. the entity being created itself (self-reference — its directory
+///      may not exist yet at creation time), or
+///   3. an existing entity directory at
+///      `<outputDir>/<snake(type)>/<snake(type)>.dart`, or
+///   4. an existing enum file at
+///      `<outputDir>/enums/<snake(type)>.dart`.
+///
+/// Anything else is unresolvable and produces an [UnresolvedTypeError].
+class EntityTypeValidator {
+  /// Validates [fields] against the on-disk entity/enum layout rooted at
+  /// [outputDir].
+  ///
+  /// [selfEntityName] is the name of the entity being created (or the
+  /// entity being modified by `add-field`); references to it are allowed
+  /// even when its own directory does not exist yet.
+  ///
+  /// Returns a list of [UnresolvedTypeError] — one per unique unresolved
+  /// type reference. An empty list means every field type is resolvable.
+  static List<UnresolvedTypeError> validate({
+    required List<FieldDefinition> fields,
+    required String outputDir,
+    String? selfEntityName,
+  }) {
+    final errors = <UnresolvedTypeError>[];
+    // De-duplicate by (fieldName, typeName) so a type referenced by
+    // multiple fields still produces one error per field, but a type
+    // referenced multiple times by the SAME field (e.g. via nested
+    // generics) only produces one.
+    final seen = <String>{};
+
+    for (final field in fields) {
+      final referencedTypes = EntityUtils.extractEntityTypes(field.fullType);
+      for (final type in referencedTypes) {
+        // Strip a leading `$` (Zorphy entity prefix) — the user may write
+        // either `FeedbackType` or `$FeedbackType`.
+        final cleanType = type.replaceAll(RegExp(r'^\$+'), '');
+
+        // Allow self-reference (the entity being created).
+        if (cleanType == selfEntityName) continue;
+
+        final key = '${field.name}::$cleanType';
+        if (seen.contains(key)) continue;
+        seen.add(key);
+
+        final typeSnake = StringUtils.camelToSnake(cleanType);
+        final entityDir = Directory(p.join(outputDir, typeSnake));
+        final enumFile = File(p.join(outputDir, 'enums', '$typeSnake.dart'));
+
+        final entityExists = entityDir.existsSync() &&
+            File(p.join(entityDir.path, '$typeSnake.dart')).existsSync();
+        final enumExists = enumFile.existsSync();
+
+        if (!entityExists && !enumExists) {
+          errors.add(UnresolvedTypeError(
+            fieldName: field.name,
+            typeName: cleanType,
+            message:
+                'Unknown type "$cleanType" for field "${field.name}" — no '
+                'matching entity directory or enum file found under '
+                '$outputDir.\n'
+                '   Create the enum/entity first, for example:\n'
+                '     zfa entity enum -n $cleanType --value <values>\n'
+                '   or check the spelling.',
+          ));
+        }
+      }
+    }
+
+    return errors;
+  }
+
+  /// Convenience wrapper that returns `true` when every field type is
+  /// resolvable. Useful for guard clauses.
+  static bool isValid({
+    required List<FieldDefinition> fields,
+    required String outputDir,
+    String? selfEntityName,
+  }) {
+    return validate(
+      fields: fields,
+      outputDir: outputDir,
+      selfEntityName: selfEntityName,
+    ).isEmpty;
+  }
+}

--- a/test/regression/issue_296_unresolvable_enum_type_test.dart
+++ b/test/regression/issue_296_unresolvable_enum_type_test.dart
@@ -1,0 +1,306 @@
+// Regression test for issue #296.
+//
+// `zfa entity create` with a field type that resolves to NEITHER an existing
+// entity NOR an existing enum used to silently succeed (exit 0), writing an
+// entity file whose generated `.zorphy.dart` later failed at `zfa build` time
+// with a misleading `json_serializable` error pointing at `InvalidType`.
+//
+// Root cause: zorphy's `FieldNormalizer` assumed any non-primitive,
+// non-enum type was an entity and `$`-prefixed it. `$FeedbackType` was
+// undefined, so the analyzer resolved it to `InvalidType`, and the
+// `ImportResolver` emitted a bogus entity-style import
+// `import '../feedback_type/feedback_type.dart';` for a directory that did
+// not exist.
+//
+// Fix (this PR): zuraffa's `EntityCommand._handleCreate` / `_handleAddField`
+// now invoke `EntityTypeValidator.validate` BEFORE writing anything. If any
+// field type is unresolvable, the command prints a clear, actionable error
+// and exits 1 WITHOUT writing the entity file.
+
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+/// Resolve package root at discovery time, before any test changes CWD.
+final _zfaRoot = Directory.current.path;
+
+void main() {
+  group('#296 — zfa entity create with unresolvable enum type', () {
+    late Directory workspace;
+    late String zfaBin;
+
+    Future<ProcessResult> runZfa(List<String> args) {
+      return Process.run(
+        'dart',
+        [zfaBin, ...args],
+        workingDirectory: workspace.path,
+      );
+    }
+
+    Future<ProcessResult> runZfaInRepo(List<String> args) {
+      return Process.run(
+        'dart',
+        [zfaBin, ...args],
+        workingDirectory: _zfaRoot,
+      );
+    }
+
+    setUp(() async {
+      zfaBin = p.join(_zfaRoot, 'bin', 'zfa.dart');
+      workspace = await Directory.systemTemp.createTemp('issue_296_');
+      // The entity command's dependency check scans pubspec.yaml for the
+      // strings `zorphy_annotation:` and `build_runner:`. The strings are
+      // enough — entity creation itself does not run `dart pub get`.
+      await File(p.join(workspace.path, 'pubspec.yaml')).writeAsString('''
+name: issue_296_test_app
+environment:
+  sdk: '>=3.12.0 <4.0.0'
+dependencies:
+  zorphy_annotation:
+dev_dependencies:
+  build_runner:
+''');
+    });
+
+    tearDown(() async {
+      if (workspace.existsSync()) {
+        await workspace.delete(recursive: true);
+      }
+    });
+
+    test(
+      'entity create with an unresolvable enum type exits 1 and writes NO file',
+      timeout: const Timeout(Duration(minutes: 2)),
+      () async {
+        final result = await runZfa([
+          'entity',
+          'create',
+          '-n',
+          'Feedback',
+          '--field',
+          'id:String?',
+          '--field',
+          'message:String',
+          '--field',
+          'type:FeedbackType', // enum does NOT exist yet
+          '--field',
+          'imageUrl:String?',
+          '--field',
+          'createdAt:DateTime?',
+        ]);
+
+        // MUST exit non-zero — the silent exit 0 was the original bug.
+        expect(result.exitCode, equals(1),
+            reason: 'Unresolvable field type must abort with exit 1');
+
+        final output = result.stdout.toString() + result.stderr.toString();
+
+        // The error must name the unresolvable type and the field.
+        expect(output, contains('FeedbackType'));
+        expect(output, contains('type'));
+        expect(output, contains('Unknown type'));
+
+        // The error must be actionable — point the user at `zfa entity enum`.
+        expect(output, contains('zfa entity enum -n FeedbackType'));
+
+        // CRITICAL: no entity file may have been written. The silent
+        // `$`-prefixed `InvalidType` emission happened because the file was
+        // written despite the unresolvable type.
+        final entityFile = File(p.join(
+          workspace.path,
+          'lib',
+          'src',
+          'domain',
+          'entities',
+          'feedback',
+          'feedback.dart',
+        ));
+        expect(entityFile.existsSync(), isFalse,
+            reason: 'No entity file may be written when validation fails');
+      },
+    );
+
+    test(
+      'entity create succeeds AFTER the enum is created — clean type, no bogus import',
+      timeout: const Timeout(Duration(minutes: 2)),
+      () async {
+        // Step 1: create the enum first.
+        final enumResult = await runZfa([
+          'entity',
+          'enum',
+          '-n',
+          'FeedbackType',
+          '--value',
+          'error,suggestion,thanks',
+        ]);
+        expect(enumResult.exitCode, equals(0),
+            reason: 'Enum creation must succeed');
+
+        final enumFile = File(p.join(
+          workspace.path,
+          'lib',
+          'src',
+          'domain',
+          'entities',
+          'enums',
+          'feedback_type.dart',
+        ));
+        expect(enumFile.existsSync(), isTrue);
+
+        // Step 2: NOW create the entity that references the enum.
+        final result = await runZfa([
+          'entity',
+          'create',
+          '-n',
+          'Feedback',
+          '--field',
+          'id:String?',
+          '--field',
+          'message:String',
+          '--field',
+          'type:FeedbackType',
+          '--field',
+          'imageUrl:String?',
+          '--field',
+          'createdAt:DateTime?',
+        ]);
+
+        expect(result.exitCode, equals(0),
+            reason: 'Entity creation must succeed once the enum exists');
+
+        final entityFile = File(p.join(
+          workspace.path,
+          'lib',
+          'src',
+          'domain',
+          'entities',
+          'feedback',
+          'feedback.dart',
+        ));
+        expect(entityFile.existsSync(), isTrue);
+        final content = await entityFile.readAsString();
+
+        // The field type must be the clean `FeedbackType`, NOT the
+        // `$`-prefixed `$FeedbackType` that produced `InvalidType`.
+        expect(content, contains('FeedbackType get type;'));
+        expect(content, isNot(contains(r'$FeedbackType')),
+            reason: 'The dollar prefix caused InvalidType — must not appear');
+
+        // The enum barrel import is expected; the BOGUS entity-style import
+        // `import '../feedback_type/feedback_type.dart';` must NOT appear
+        // (the `feedback_type/` directory does not exist — only the enum
+        // file under `enums/` does).
+        expect(content, contains("import '../enums/index.dart';"));
+        expect(
+          content,
+          isNot(contains("import '../feedback_type/feedback_type.dart';")),
+          reason: 'The bogus entity-style import for a non-existent '
+              'entity directory was the second symptom of #296',
+        );
+      },
+    );
+
+    test(
+      'entity add-field with an unresolvable type exits 1 and writes NO change',
+      timeout: const Timeout(Duration(minutes: 2)),
+      () async {
+        // First, create a valid entity (all primitive fields) so `add-field`
+        // has a target to operate on.
+        final createResult = await runZfa([
+          'entity',
+          'create',
+          '-n',
+          'Note',
+          '--field',
+          'id:String?',
+          '--field',
+          'body:String',
+        ]);
+        expect(createResult.exitCode, equals(0));
+
+        final entityFile = File(p.join(
+          workspace.path,
+          'lib',
+          'src',
+          'domain',
+          'entities',
+          'note',
+          'note.dart',
+        ));
+        expect(entityFile.existsSync(), isTrue);
+        final originalContent = await entityFile.readAsString();
+
+        // Now try to add a field whose type does not exist anywhere.
+        final addResult = await runZfa([
+          'entity',
+          'add-field',
+          '-n',
+          'Note',
+          '--field',
+          'category:NoteCategory', // unresolvable
+        ]);
+
+        expect(addResult.exitCode, equals(1),
+            reason: 'add-field must also validate field types');
+
+        final output = addResult.stdout.toString() + addResult.stderr.toString();
+        expect(output, contains('NoteCategory'));
+        expect(output, contains('Unknown type'));
+
+        // The entity file must be unchanged.
+        final afterContent = await entityFile.readAsString();
+        expect(afterContent, equals(originalContent),
+            reason: 'No file modifications when validation fails');
+      },
+    );
+
+    test(
+      'entity create with a self-referential type is allowed',
+      timeout: const Timeout(Duration(minutes: 2)),
+      () async {
+        // A node that references itself (e.g. a tree) is a valid pattern.
+        // The validator must NOT reject the entity being created for
+        // referencing itself.
+        final result = await runZfa([
+          'entity',
+          'create',
+          '-n',
+          'TreeNode',
+          '--field',
+          'id:String?',
+          '--field',
+          'label:String',
+          '--field',
+          'parent:TreeNode?',
+          '--field',
+          'children:List<TreeNode>',
+        ]);
+
+        expect(result.exitCode, equals(0),
+            reason: 'Self-reference must be allowed');
+
+        final entityFile = File(p.join(
+          workspace.path,
+          'lib',
+          'src',
+          'domain',
+          'entities',
+          'tree_node',
+          'tree_node.dart',
+        ));
+        expect(entityFile.existsSync(), isTrue);
+      },
+    );
+
+    // Sanity: the zfa binary itself compiles & runs from the repo root.
+    test(
+      'zfa binary is runnable (smoke)',
+      timeout: const Timeout(Duration(minutes: 2)),
+      () async {
+        final result = await runZfaInRepo(['--help']);
+        expect(result.exitCode, equals(0));
+      },
+    );
+  });
+}

--- a/test/utils/entity_type_validator_test.dart
+++ b/test/utils/entity_type_validator_test.dart
@@ -1,0 +1,358 @@
+// Unit tests for EntityTypeValidator (issue #296).
+//
+// The validator is invoked by `zfa entity create` and `zfa entity add-field`
+// BEFORE any file is written. It refuses to let the command proceed when a
+// field type is neither a primitive, an existing entity, nor an existing
+// enum — closing the gap where zorphy's FieldNormalizer silently `$`-prefixed
+// unresolvable types, producing `InvalidType` + a bogus entity-style import.
+
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+import 'package:zorphy/zorphy.dart' show FieldDefinition;
+import 'package:zuraffa/src/utils/entity_type_validator.dart';
+
+void main() {
+  late Directory tmp;
+  late String outputDir;
+
+  setUp(() async {
+    tmp = await Directory.systemTemp.createTemp('entity_type_validator_');
+    outputDir = p.join(tmp.path, 'lib', 'src', 'domain', 'entities');
+    await Directory(outputDir).create(recursive: true);
+  });
+
+  tearDown(() async {
+    if (tmp.existsSync()) {
+      await tmp.delete(recursive: true);
+    }
+  });
+
+  /// Creates an entity directory + file so the validator recognises the type.
+  Future<void> writeEntity(String name) async {
+    final snake = _toSnake(name);
+    final dir = Directory(p.join(outputDir, snake));
+    await dir.create(recursive: true);
+    await File(p.join(dir.path, '$snake.dart')).writeAsString(
+      'abstract class \$$name {}\n',
+    );
+  }
+
+  /// Creates an enum file under `enums/` so the validator recognises the type.
+  Future<void> writeEnum(String name) async {
+    final snake = _toSnake(name);
+    final enumsDir = Directory(p.join(outputDir, 'enums'));
+    await enumsDir.create(recursive: true);
+    await File(p.join(enumsDir.path, '$snake.dart')).writeAsString(
+      'enum $name { a, b, c }\n',
+    );
+  }
+
+  group('EntityTypeValidator.validate — primitives', () {
+    test('accepts all primitive field types with no entity/enum on disk', () {
+      final fields = [
+        FieldDefinition(name: 'id', type: 'String', nullable: true),
+        FieldDefinition(name: 'count', type: 'int'),
+        FieldDefinition(name: 'price', type: 'double'),
+        FieldDefinition(name: 'active', type: 'bool'),
+        FieldDefinition(name: 'createdAt', type: 'DateTime', nullable: true),
+        FieldDefinition(name: 'meta', type: 'Map<String, dynamic>'),
+        FieldDefinition(name: 'tags', type: 'List<String>'),
+        FieldDefinition(name: 'dynamic', type: 'dynamic'),
+      ];
+      final errors = EntityTypeValidator.validate(
+        fields: fields,
+        outputDir: outputDir,
+      );
+      expect(errors, isEmpty, reason: 'Primitives must always resolve');
+    });
+  });
+
+  group('EntityTypeValidator.validate — existing entity', () {
+    test('accepts a field type whose entity directory exists', () async {
+      await writeEntity('Product');
+      final fields = [
+        FieldDefinition(name: 'product', type: 'Product'),
+      ];
+      final errors = EntityTypeValidator.validate(
+        fields: fields,
+        outputDir: outputDir,
+      );
+      expect(errors, isEmpty);
+    });
+
+    test('accepts a nullable entity reference', () async {
+      await writeEntity('Product');
+      final fields = [
+        FieldDefinition(name: 'product', type: 'Product', nullable: true),
+      ];
+      final errors = EntityTypeValidator.validate(
+        fields: fields,
+        outputDir: outputDir,
+      );
+      expect(errors, isEmpty);
+    });
+
+    test('accepts List<EntityType> when the entity exists', () async {
+      await writeEntity('Product');
+      final fields = [
+        FieldDefinition(name: 'items', type: 'List<Product>'),
+      ];
+      final errors = EntityTypeValidator.validate(
+        fields: fields,
+        outputDir: outputDir,
+      );
+      expect(errors, isEmpty);
+    });
+
+    test('accepts Map<String, EntityType> when the entity exists', () async {
+      await writeEntity('Product');
+      final fields = [
+        FieldDefinition(name: 'byKey', type: 'Map<String, Product>'),
+      ];
+      final errors = EntityTypeValidator.validate(
+        fields: fields,
+        outputDir: outputDir,
+      );
+      expect(errors, isEmpty);
+    });
+  });
+
+  group('EntityTypeValidator.validate — existing enum', () {
+    test('accepts a field type whose enum file exists', () async {
+      await writeEnum('FeedbackType');
+      final fields = [
+        FieldDefinition(name: 'type', type: 'FeedbackType'),
+      ];
+      final errors = EntityTypeValidator.validate(
+        fields: fields,
+        outputDir: outputDir,
+      );
+      expect(errors, isEmpty);
+    });
+
+    test('accepts a nullable enum reference', () async {
+      await writeEnum('FeedbackType');
+      final fields = [
+        FieldDefinition(name: 'type', type: 'FeedbackType', nullable: true),
+      ];
+      final errors = EntityTypeValidator.validate(
+        fields: fields,
+        outputDir: outputDir,
+      );
+      expect(errors, isEmpty);
+    });
+  });
+
+  group('EntityTypeValidator.validate — unresolvable types (#296)', () {
+    test('rejects a field type when neither entity nor enum exists', () {
+      final fields = [
+        FieldDefinition(name: 'type', type: 'FeedbackType'),
+      ];
+      final errors = EntityTypeValidator.validate(
+        fields: fields,
+        outputDir: outputDir,
+      );
+      expect(errors, hasLength(1));
+      expect(errors.first.fieldName, 'type');
+      expect(errors.first.typeName, 'FeedbackType');
+      expect(errors.first.message, contains('Unknown type "FeedbackType"'));
+      expect(errors.first.message, contains('zfa entity enum -n FeedbackType'));
+    });
+
+    test('rejects the EXACT issue #296 field set (FeedbackType missing)', () {
+      // Mirror the issue report: Feedback created BEFORE FeedbackType enum.
+      final fields = [
+        FieldDefinition(name: 'id', type: 'String', nullable: true),
+        FieldDefinition(name: 'message', type: 'String'),
+        FieldDefinition(name: 'type', type: 'FeedbackType'),
+        FieldDefinition(name: 'imageUrl', type: 'String', nullable: true),
+        FieldDefinition(name: 'createdAt', type: 'DateTime', nullable: true),
+      ];
+      final errors = EntityTypeValidator.validate(
+        fields: fields,
+        outputDir: outputDir,
+        selfEntityName: 'Feedback',
+      );
+      expect(errors, hasLength(1));
+      expect(errors.first.fieldName, 'type');
+      expect(errors.first.typeName, 'FeedbackType');
+    });
+
+    test('rejects a dollar-prefixed unresolvable type (user wrote \$Foo)', () {
+      final fields = [
+        FieldDefinition(name: 'ref', type: r'$Foo'),
+      ];
+      final errors = EntityTypeValidator.validate(
+        fields: fields,
+        outputDir: outputDir,
+      );
+      expect(errors, hasLength(1));
+      // The `$` is stripped in the reported type name.
+      expect(errors.first.typeName, 'Foo');
+    });
+
+    test('rejects List<Unresolvable>', () {
+      final fields = [
+        FieldDefinition(name: 'items', type: 'List<Unresolvable>'),
+      ];
+      final errors = EntityTypeValidator.validate(
+        fields: fields,
+        outputDir: outputDir,
+      );
+      expect(errors, hasLength(1));
+      expect(errors.first.typeName, 'Unresolvable');
+      expect(errors.first.fieldName, 'items');
+    });
+
+    test('rejects Map<String, Unresolvable>', () {
+      final fields = [
+        FieldDefinition(name: 'byKey', type: 'Map<String, Unresolvable>'),
+      ];
+      final errors = EntityTypeValidator.validate(
+        fields: fields,
+        outputDir: outputDir,
+      );
+      expect(errors, hasLength(1));
+      expect(errors.first.typeName, 'Unresolvable');
+    });
+
+    test('collects one error per unresolvable field (multiple bad fields)', () {
+      final fields = [
+        FieldDefinition(name: 'a', type: 'MissingA'),
+        FieldDefinition(name: 'b', type: 'MissingB'),
+      ];
+      final errors = EntityTypeValidator.validate(
+        fields: fields,
+        outputDir: outputDir,
+      );
+      expect(errors, hasLength(2));
+      final names = errors.map((e) => e.typeName).toSet();
+      expect(names, containsAll(<String>['MissingA', 'MissingB']));
+    });
+
+    test('de-duplicates the same type referenced by multiple fields', () {
+      final fields = [
+        FieldDefinition(name: 'a', type: 'Missing'),
+        FieldDefinition(name: 'b', type: 'Missing'),
+      ];
+      final errors = EntityTypeValidator.validate(
+        fields: fields,
+        outputDir: outputDir,
+      );
+      // One error PER FIELD (a, b) — de-dup is per (field, type) pair.
+      expect(errors, hasLength(2));
+      final fieldNames = errors.map((e) => e.fieldName).toSet();
+      expect(fieldNames, containsAll(<String>['a', 'b']));
+    });
+
+    test('the error message names the outputDir and the field', () {
+      final fields = [
+        FieldDefinition(name: 'status', type: 'StatusEnum'),
+      ];
+      final errors = EntityTypeValidator.validate(
+        fields: fields,
+        outputDir: outputDir,
+      );
+      expect(errors.first.message, contains(outputDir));
+      expect(errors.first.message, contains('status'));
+    });
+  });
+
+  group('EntityTypeValidator.validate — self-reference', () {
+    test('allows the entity being created to reference itself', () {
+      final fields = [
+        FieldDefinition(name: 'parent', type: 'Node', nullable: true),
+      ];
+      final errors = EntityTypeValidator.validate(
+        fields: fields,
+        outputDir: outputDir,
+        selfEntityName: 'Node',
+      );
+      expect(errors, isEmpty,
+          reason: 'Self-reference is allowed even when the entity dir '
+              'does not exist yet');
+    });
+
+    test('allows List<Self> for the entity being created', () {
+      final fields = [
+        FieldDefinition(name: 'children', type: 'List<Node>'),
+      ];
+      final errors = EntityTypeValidator.validate(
+        fields: fields,
+        outputDir: outputDir,
+        selfEntityName: 'Node',
+      );
+      expect(errors, isEmpty);
+    });
+
+    test('does NOT allow a DIFFERENT unresolvable type alongside self-ref', () {
+      final fields = [
+        FieldDefinition(name: 'parent', type: 'Node', nullable: true),
+        FieldDefinition(name: 'kind', type: 'MissingKind'),
+      ];
+      final errors = EntityTypeValidator.validate(
+        fields: fields,
+        outputDir: outputDir,
+        selfEntityName: 'Node',
+      );
+      expect(errors, hasLength(1));
+      expect(errors.first.typeName, 'MissingKind');
+    });
+  });
+
+  group('EntityTypeValidator.isValid', () {
+    test('returns true when validate returns no errors', () async {
+      await writeEnum('Status');
+      final ok = EntityTypeValidator.isValid(
+        fields: [FieldDefinition(name: 's', type: 'Status')],
+        outputDir: outputDir,
+      );
+      expect(ok, isTrue);
+    });
+
+    test('returns false when validate returns errors', () {
+      final ok = EntityTypeValidator.isValid(
+        fields: [FieldDefinition(name: 's', type: 'Missing')],
+        outputDir: outputDir,
+      );
+      expect(ok, isFalse);
+    });
+  });
+
+  group('EntityTypeValidator.validate — entity dir exists but file missing', () {
+    test('rejects when the entity directory exists but the .dart file is absent',
+        () async {
+      // Simulate a half-written entity (dir created, file not yet).
+      final dir = Directory(p.join(outputDir, 'ghost'));
+      await dir.create(recursive: true);
+      final fields = [FieldDefinition(name: 'g', type: 'Ghost')];
+      final errors = EntityTypeValidator.validate(
+        fields: fields,
+        outputDir: outputDir,
+      );
+      expect(errors, hasLength(1),
+          reason: 'An entity directory without the .dart file is not a '
+              'validatable entity — treat as unresolvable.');
+    });
+  });
+}
+
+/// Minimal PascalCase -> snake_case (mirrors StringUtils.camelToSnake for
+/// the common PascalCase inputs used in these tests).
+String _toSnake(String input) {
+  if (input.isEmpty) return '';
+  final result = <String>[];
+  for (var i = 0; i < input.length; i++) {
+    final char = input[i];
+    if (i > 0 &&
+        char.toLowerCase() != char &&
+        char.toUpperCase() == char &&
+        char != '_') {
+      result.add('_');
+    }
+    result.add(char.toLowerCase());
+  }
+  return result.join();
+}


### PR DESCRIPTION
Closes #296

## Problem

`zfa entity create` with a field type that resolves to NEITHER an existing entity NOR an existing enum (e.g. `type:FeedbackType` before `zfa entity enum -n FeedbackType` was run) used to silently succeed (exit 0) and write an entity file whose generated `.zorphy.dart` later failed at `zfa build` time with a misleading `json_serializable` error pointing at `InvalidType`.

## Root cause

Traced through zorphy source:

- `FieldNormalizer.normalize()` assumes any non-primitive, non-enum type is an entity and `$`-prefixes it: `FeedbackType` -> `$FeedbackType`.
- `$FeedbackType` is undefined -> the Dart analyzer resolves it to `InvalidType`.
- `ImportResolver.resolveImports()` sees the `$` prefix and emits a bogus entity-style import `import '../feedback_type/feedback_type.dart';` for a directory that does not exist.
- zuraffa's `EntityCommand._handleCreate` / `_handleAddField` never validated that referenced types actually exist on disk before writing.

## Fix

Added `EntityTypeValidator` (new `lib/src/utils/entity_type_validator.dart`) and wired it into `EntityCommand._handleCreate` and `_handleAddField` BEFORE any file is written. For each custom (non-primitive) field type, it checks:

1. an existing entity directory `<outputDir>/<snake(type)>/<snake(type)>.dart`, OR
2. an existing enum file `<outputDir>/enums/<snake(type)>.dart`.

If neither exists, the command prints a clear, actionable error naming the type, the field, and the suggested fix (`zfa entity enum -n <Type> --value ...`), and exits 1 WITHOUT writing anything. Self-references (the entity being created) are allowed.

## Files

- `lib/src/utils/entity_type_validator.dart` (new, 146 lines)
- `lib/src/commands/entity_command.dart` (+42 lines: import + two validation guards in `_handleCreate` and `_handleAddField`)
- `test/utils/entity_type_validator_test.dart` (new, 21 unit tests)
- `test/regression/issue_296_unresolvable_enum_type_test.dart` (new, 5 end-to-end CLI tests)

## Verification

- `dart analyze` on the new + edited files: **No issues found.**
- Reproduced the exact issue scenario: before the fix, `zfa entity create -n Feedback --field type:FeedbackType` (enum missing) wrote `$FeedbackType get type;` + the bogus import and exited 0. After the fix, it exits 1 with a clear error and writes no file.
- After creating the enum first, `zfa entity create` succeeds; the generated `feedback.dart` contains the clean `FeedbackType get type;` (no `$` prefix) and only `import '../enums/index.dart';` (no bogus entity-style import).
- New tests: 21 unit + 5 regression = **26, all pass.**
- No regressions: **80 existing tests** across cli/regression/utils/commands/integration still pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Entity creation and field addition now validate referenced types before changing files.
  * Unresolved, invalid, or partially defined types produce actionable errors and leave existing files unchanged.
  * Valid primitive, entity, enum, collection, nullable, and self-referential types are supported.
  * Duplicate type errors are consolidated for clearer feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->