### PR TITLE
fix: address review comments on #297

### DIFF
--- a/lib/src/core/constants/known_types.dart
+++ b/lib/src/core/constants/known_types.dart
@@ -21,7 +21,13 @@ class KnownTypes {
   static const dartCollections = ['List', 'Map', 'Set'];
 
   /// Common Dart types that don't need imports
-  static const dartTypes = ['Duration', 'DateTime'];
+  static const dartTypes = [
+    'Duration',
+    'DateTime',
+    'Uri',
+    'BigInt',
+    'Uint8List',
+  ];
 
   /// Zuraffa parameter types
   static const zuraffaParams = [

--- a/lib/src/utils/entity_type_validator.dart
+++ b/lib/src/utils/entity_type_validator.dart
@@ -24,6 +24,7 @@
 import 'dart:io';
 import 'package:path/path.dart' as p;
 import 'package:zorphy/zorphy.dart' show FieldDefinition;
+import '../core/constants/known_types.dart';
 import 'entity_utils.dart';
 import 'string_utils.dart';
 
@@ -108,22 +109,26 @@ class EntityTypeValidator {
         final entityDir = Directory(p.join(outputDir, typeSnake));
         final enumFile = File(p.join(outputDir, 'enums', '$typeSnake.dart'));
 
-        final entityExists = entityDir.existsSync() &&
+        final entityExists =
+            entityDir.existsSync() &&
             File(p.join(entityDir.path, '$typeSnake.dart')).existsSync();
         final enumExists = enumFile.existsSync();
 
         if (!entityExists && !enumExists) {
-          errors.add(UnresolvedTypeError(
-            fieldName: field.name,
-            typeName: cleanType,
-            message:
-                'Unknown type "$cleanType" for field "${field.name}" — no '
-                'matching entity directory or enum file found under '
-                '$outputDir.\n'
-                '   Create the enum/entity first, for example:\n'
-                '     zfa entity enum -n $cleanType --value <values>\n'
-                '   or check the spelling.',
-          ));
+          errors.add(
+            UnresolvedTypeError(
+              fieldName: field.name,
+              typeName: cleanType,
+              message: KnownTypes.isExcluded(cleanType)
+                  ? _unsupportedTypeMessage(cleanType, field.name)
+                  : 'Unknown type "$cleanType" for field "${field.name}" — no '
+                        'matching entity directory or enum file found under '
+                        '$outputDir.\n'
+                        '   Create the enum/entity first, for example:\n'
+                        '     zfa entity enum -n $cleanType --value <values>\n'
+                        '   or check the spelling.',
+            ),
+          );
         }
       }
     }
@@ -143,5 +148,20 @@ class EntityTypeValidator {
       outputDir: outputDir,
       selfEntityName: selfEntityName,
     ).isEmpty;
+  }
+
+  /// Error message for a type that is known to be a Dart/framework type but
+  /// that zorphy cannot generate as a field type (e.g. `Duration`, `Uri`,
+  /// `BigInt`, `Uint8List`). zorphy's `FieldNormalizer` does not treat these
+  /// as primitives, so it would `$`-prefix them (`$Duration`) and the build
+  /// would fail with `InvalidType` — the exact symptom of issue #296.
+  /// Rejecting here with a clear message is strictly better than writing a
+  /// broken entity.
+  static String _unsupportedTypeMessage(String type, String fieldName) {
+    return 'Type "$type" for field "$fieldName" is not supported as a field '
+        'type by zorphy — it is neither a Dart primitive, an existing '
+        'entity, nor an existing enum.\n'
+        '   Use a primitive (e.g. String, int, double, bool, DateTime) or '
+        'an entity/enum instead.';
   }
 }

--- a/lib/src/utils/entity_utils.dart
+++ b/lib/src/utils/entity_utils.dart
@@ -1,53 +1,119 @@
 class EntityUtils {
-  /// Extracts entity types from a field type string (e.g. List Product -> [Product])
+  /// Extracts entity type references from a field type string, recursing
+  /// through generic type arguments.
+  ///
+  /// Examples:
+  ///   `Product`                    -> [Product]
+  ///   `List<Product>`              -> [Product]
+  ///   `Map<String, Product>`       -> [Product]
+  ///   `List<Map<String, Product>>` -> [Product]
+  ///   `Set<String>`                -> []
+  ///   `List<Map<String, dynamic>>` -> []
+  ///   `Iterable<Product>`          -> [Product]
   static List<String> extractEntityTypes(String fieldType) {
     final types = <String>[];
-    var baseType = fieldType.replaceAll('?', '');
+    _collectTypes(fieldType.replaceAll('?', ''), types);
+    return types;
+  }
 
-    if (baseType.startsWith('List<') && baseType.endsWith('>')) {
-      baseType = baseType.substring(5, baseType.length - 1);
-    } else if (baseType.startsWith('Map<') && baseType.endsWith('>')) {
-      final innerTypes = baseType.substring(4, baseType.length - 1);
-      final typeParts = innerTypes.split(',').map((s) => s.trim()).toList();
-      if (typeParts.length == 2) {
-        baseType = typeParts[1];
-      } else {
-        return types;
+  /// Container/collection wrappers — only their type arguments can
+  /// reference entities; the wrapper name itself is never an entity.
+  static const _containerTypes = {
+    'List',
+    'Set',
+    'Map',
+    'Iterable',
+    'Future',
+    'Stream',
+  };
+
+  /// Primitive / framework types that never resolve to an entity. Note this
+  /// intentionally does NOT include `Duration`, `Uri`, `BigInt`, `Uint8List`:
+  /// zorphy's `FieldNormalizer` does not treat them as primitives, so it
+  /// `$`-prefixes them (`$Duration`) and the build fails with `InvalidType`.
+  /// They must stay candidates so `EntityTypeValidator` rejects them with a
+  /// clear error instead of writing a broken entity (issue #296).
+  static const _nonEntityTypes = {
+    'String',
+    'int',
+    'double',
+    'bool',
+    'DateTime',
+    'Object',
+    'dynamic',
+    'void',
+    'Null',
+    'num',
+    'NoParams',
+    'Params',
+    'QueryParams',
+    'ListQueryParams',
+    'UpdateParams',
+    'DeleteParams',
+    'InitializationParams',
+  };
+
+  static void _collectTypes(String type, List<String> out) {
+    final trimmed = type.trim();
+    if (trimmed.isEmpty) return;
+
+    final genericMatch = RegExp(r'^([^<]+?)(?:<(.+)>)?$').firstMatch(trimmed);
+    if (genericMatch == null) return;
+
+    final baseType = genericMatch.group(1)!.trim();
+    final generics = genericMatch.group(2);
+
+    if (_containerTypes.contains(baseType)) {
+      if (generics != null) {
+        for (final arg in _splitGenericArgs(generics)) {
+          _collectTypes(arg, out);
+        }
+      }
+      return;
+    }
+
+    final isExplicitEntity = baseType.startsWith(r'$');
+    final cleanType = isExplicitEntity
+        ? baseType.replaceAll(RegExp(r'^\$+'), '')
+        : baseType;
+
+    if (cleanType.isNotEmpty &&
+        !_nonEntityTypes.contains(cleanType) &&
+        cleanType[0].toUpperCase() == cleanType[0]) {
+      out.add(cleanType);
+    }
+
+    // Recurse into type arguments of non-container generics too, e.g.
+    // `SomeWrapper<Product>` references both `SomeWrapper` and `Product`.
+    if (generics != null) {
+      for (final arg in _splitGenericArgs(generics)) {
+        _collectTypes(arg, out);
       }
     }
+  }
 
-    if (baseType.startsWith('\$')) {
-      baseType = baseType.substring(1);
+  /// Splits a generic argument list on top-level commas, respecting nesting
+  /// (e.g. `String, List<Product>` -> ['String', 'List<Product>']).
+  static List<String> _splitGenericArgs(String inner) {
+    final parts = <String>[];
+    var depth = 0;
+    final current = StringBuffer();
+    for (final char in inner.split('')) {
+      if (char == '<') {
+        depth++;
+      } else if (char == '>') {
+        depth--;
+      }
+      if (char == ',' && depth == 0) {
+        final part = current.toString().trim();
+        if (part.isNotEmpty) parts.add(part);
+        current.clear();
+        continue;
+      }
+      current.write(char);
     }
-
-    baseType = baseType
-        .replaceAll('<', '')
-        .replaceAll('>', '')
-        .split(',')[0]
-        .trim();
-
-    if (baseType.isNotEmpty &&
-        ![
-          'String',
-          'int',
-          'double',
-          'bool',
-          'DateTime',
-          'Object',
-          'dynamic',
-          'void',
-          'NoParams',
-          'Params',
-          'QueryParams',
-          'ListQueryParams',
-          'UpdateParams',
-          'DeleteParams',
-          'InitializationParams',
-        ].contains(baseType) &&
-        baseType[0].toUpperCase() == baseType[0]) {
-      types.add(baseType);
-    }
-
-    return types;
+    final last = current.toString().trim();
+    if (last.isNotEmpty) parts.add(last);
+    return parts;
   }
 }

--- a/test/utils/entity_type_validator_test.dart
+++ b/test/utils/entity_type_validator_test.dart
@@ -34,9 +34,9 @@ void main() {
     final snake = _toSnake(name);
     final dir = Directory(p.join(outputDir, snake));
     await dir.create(recursive: true);
-    await File(p.join(dir.path, '$snake.dart')).writeAsString(
-      'abstract class \$$name {}\n',
-    );
+    await File(
+      p.join(dir.path, '$snake.dart'),
+    ).writeAsString('abstract class \$$name {}\n');
   }
 
   /// Creates an enum file under `enums/` so the validator recognises the type.
@@ -44,9 +44,9 @@ void main() {
     final snake = _toSnake(name);
     final enumsDir = Directory(p.join(outputDir, 'enums'));
     await enumsDir.create(recursive: true);
-    await File(p.join(enumsDir.path, '$snake.dart')).writeAsString(
-      'enum $name { a, b, c }\n',
-    );
+    await File(
+      p.join(enumsDir.path, '$snake.dart'),
+    ).writeAsString('enum $name { a, b, c }\n');
   }
 
   group('EntityTypeValidator.validate — primitives', () {
@@ -72,9 +72,7 @@ void main() {
   group('EntityTypeValidator.validate — existing entity', () {
     test('accepts a field type whose entity directory exists', () async {
       await writeEntity('Product');
-      final fields = [
-        FieldDefinition(name: 'product', type: 'Product'),
-      ];
+      final fields = [FieldDefinition(name: 'product', type: 'Product')];
       final errors = EntityTypeValidator.validate(
         fields: fields,
         outputDir: outputDir,
@@ -96,9 +94,7 @@ void main() {
 
     test('accepts List<EntityType> when the entity exists', () async {
       await writeEntity('Product');
-      final fields = [
-        FieldDefinition(name: 'items', type: 'List<Product>'),
-      ];
+      final fields = [FieldDefinition(name: 'items', type: 'List<Product>')];
       final errors = EntityTypeValidator.validate(
         fields: fields,
         outputDir: outputDir,
@@ -119,12 +115,90 @@ void main() {
     });
   });
 
+  group('EntityTypeValidator.validate — nested generics (#296 review)', () {
+    test(
+      'accepts Map<String, List<EntityType>> when the entity exists',
+      () async {
+        await writeEntity('Product');
+        final fields = [
+          FieldDefinition(name: 'byKey', type: 'Map<String, List<Product>>'),
+        ];
+        final errors = EntityTypeValidator.validate(
+          fields: fields,
+          outputDir: outputDir,
+        );
+        expect(
+          errors,
+          isEmpty,
+          reason: 'Nested generic wrappers must not be treated as types',
+        );
+      },
+    );
+
+    test('accepts List<List<EntityType>> when the entity exists', () async {
+      await writeEntity('Product');
+      final fields = [
+        FieldDefinition(name: 'matrix', type: 'List<List<Product>>'),
+      ];
+      final errors = EntityTypeValidator.validate(
+        fields: fields,
+        outputDir: outputDir,
+      );
+      expect(errors, isEmpty);
+    });
+
+    test('accepts Iterable<EntityType> when the entity exists', () async {
+      await writeEntity('Product');
+      final fields = [
+        FieldDefinition(name: 'items', type: 'Iterable<Product>'),
+      ];
+      final errors = EntityTypeValidator.validate(
+        fields: fields,
+        outputDir: outputDir,
+      );
+      expect(errors, isEmpty);
+    });
+
+    test(
+      'accepts List<Map<String, EntityType>> when the entity exists',
+      () async {
+        await writeEntity('Product');
+        final fields = [
+          FieldDefinition(name: 'matrix', type: 'List<Map<String, Product>>'),
+        ];
+        final errors = EntityTypeValidator.validate(
+          fields: fields,
+          outputDir: outputDir,
+        );
+        expect(errors, isEmpty);
+      },
+    );
+
+    test(
+      'accepts pure-primitive nested collections with no entity/enum on disk',
+      () {
+        final fields = [
+          FieldDefinition(name: 'meta', type: 'List<Map<String, dynamic>>'),
+          FieldDefinition(name: 'tags', type: 'Set<String>'),
+          FieldDefinition(name: 'lookup', type: 'Map<String, List<String>>'),
+        ];
+        final errors = EntityTypeValidator.validate(
+          fields: fields,
+          outputDir: outputDir,
+        );
+        expect(
+          errors,
+          isEmpty,
+          reason: 'Pure-primitive nested collections must resolve',
+        );
+      },
+    );
+  });
+
   group('EntityTypeValidator.validate — existing enum', () {
     test('accepts a field type whose enum file exists', () async {
       await writeEnum('FeedbackType');
-      final fields = [
-        FieldDefinition(name: 'type', type: 'FeedbackType'),
-      ];
+      final fields = [FieldDefinition(name: 'type', type: 'FeedbackType')];
       final errors = EntityTypeValidator.validate(
         fields: fields,
         outputDir: outputDir,
@@ -147,9 +221,7 @@ void main() {
 
   group('EntityTypeValidator.validate — unresolvable types (#296)', () {
     test('rejects a field type when neither entity nor enum exists', () {
-      final fields = [
-        FieldDefinition(name: 'type', type: 'FeedbackType'),
-      ];
+      final fields = [FieldDefinition(name: 'type', type: 'FeedbackType')];
       final errors = EntityTypeValidator.validate(
         fields: fields,
         outputDir: outputDir,
@@ -181,9 +253,7 @@ void main() {
     });
 
     test('rejects a dollar-prefixed unresolvable type (user wrote \$Foo)', () {
-      final fields = [
-        FieldDefinition(name: 'ref', type: r'$Foo'),
-      ];
+      final fields = [FieldDefinition(name: 'ref', type: r'$Foo')];
       final errors = EntityTypeValidator.validate(
         fields: fields,
         outputDir: outputDir,
@@ -248,9 +318,7 @@ void main() {
     });
 
     test('the error message names the outputDir and the field', () {
-      final fields = [
-        FieldDefinition(name: 'status', type: 'StatusEnum'),
-      ];
+      final fields = [FieldDefinition(name: 'status', type: 'StatusEnum')];
       final errors = EntityTypeValidator.validate(
         fields: fields,
         outputDir: outputDir,
@@ -259,6 +327,63 @@ void main() {
       expect(errors.first.message, contains('status'));
     });
   });
+
+  group(
+    'EntityTypeValidator.validate — unsupported Dart types (#296 review)',
+    () {
+      // zorphy's FieldNormalizer does NOT treat these as primitives, so it
+      // would `$`-prefix them (`$Duration`) and the build would fail with
+      // InvalidType. The validator must reject them fail-fast, with a message
+      // that does NOT suggest creating an enum for a standard Dart type.
+      test(
+        'rejects Duration with a "not supported" message (no enum hint)',
+        () {
+          final fields = [FieldDefinition(name: 'ttl', type: 'Duration')];
+          final errors = EntityTypeValidator.validate(
+            fields: fields,
+            outputDir: outputDir,
+          );
+          expect(errors, hasLength(1));
+          expect(errors.first.typeName, 'Duration');
+          expect(
+            errors.first.message,
+            contains('not supported as a field type'),
+          );
+          expect(errors.first.message, isNot(contains('zfa entity enum')));
+        },
+      );
+
+      test('rejects Uri, BigInt and Uint8List the same way', () {
+        final fields = [
+          FieldDefinition(name: 'link', type: 'Uri'),
+          FieldDefinition(name: 'amount', type: 'BigInt'),
+          FieldDefinition(name: 'bytes', type: 'Uint8List'),
+        ];
+        final errors = EntityTypeValidator.validate(
+          fields: fields,
+          outputDir: outputDir,
+        );
+        expect(errors, hasLength(3));
+        for (final err in errors) {
+          expect(err.message, contains('not supported as a field type'));
+          expect(err.message, isNot(contains('zfa entity enum')));
+        }
+      });
+
+      test('rejects List<Duration> with the "not supported" message', () {
+        final fields = [
+          FieldDefinition(name: 'durations', type: 'List<Duration>'),
+        ];
+        final errors = EntityTypeValidator.validate(
+          fields: fields,
+          outputDir: outputDir,
+        );
+        expect(errors, hasLength(1));
+        expect(errors.first.typeName, 'Duration');
+        expect(errors.first.message, contains('not supported as a field type'));
+      });
+    },
+  );
 
   group('EntityTypeValidator.validate — self-reference', () {
     test('allows the entity being created to reference itself', () {
@@ -270,15 +395,17 @@ void main() {
         outputDir: outputDir,
         selfEntityName: 'Node',
       );
-      expect(errors, isEmpty,
-          reason: 'Self-reference is allowed even when the entity dir '
-              'does not exist yet');
+      expect(
+        errors,
+        isEmpty,
+        reason:
+            'Self-reference is allowed even when the entity dir '
+            'does not exist yet',
+      );
     });
 
     test('allows List<Self> for the entity being created', () {
-      final fields = [
-        FieldDefinition(name: 'children', type: 'List<Node>'),
-      ];
+      final fields = [FieldDefinition(name: 'children', type: 'List<Node>')];
       final errors = EntityTypeValidator.validate(
         fields: fields,
         outputDir: outputDir,
@@ -321,22 +448,31 @@ void main() {
     });
   });
 
-  group('EntityTypeValidator.validate — entity dir exists but file missing', () {
-    test('rejects when the entity directory exists but the .dart file is absent',
+  group(
+    'EntityTypeValidator.validate — entity dir exists but file missing',
+    () {
+      test(
+        'rejects when the entity directory exists but the .dart file is absent',
         () async {
-      // Simulate a half-written entity (dir created, file not yet).
-      final dir = Directory(p.join(outputDir, 'ghost'));
-      await dir.create(recursive: true);
-      final fields = [FieldDefinition(name: 'g', type: 'Ghost')];
-      final errors = EntityTypeValidator.validate(
-        fields: fields,
-        outputDir: outputDir,
+          // Simulate a half-written entity (dir created, file not yet).
+          final dir = Directory(p.join(outputDir, 'ghost'));
+          await dir.create(recursive: true);
+          final fields = [FieldDefinition(name: 'g', type: 'Ghost')];
+          final errors = EntityTypeValidator.validate(
+            fields: fields,
+            outputDir: outputDir,
+          );
+          expect(
+            errors,
+            hasLength(1),
+            reason:
+                'An entity directory without the .dart file is not a '
+                'validatable entity — treat as unresolvable.',
+          );
+        },
       );
-      expect(errors, hasLength(1),
-          reason: 'An entity directory without the .dart file is not a '
-              'validatable entity — treat as unresolvable.');
-    });
-  });
+    },
+  );
 }
 
 /// Minimal PascalCase -> snake_case (mirrors StringUtils.camelToSnake for


### PR DESCRIPTION
## Summary

Addresses the review comments posted on #297 (my review + CodeRabbit's overlapping findings). Fixes the regressions the `EntityTypeValidator` introduced in #296's fix — purely additive to the validator behavior, no API changes.

## Review threads addressed

| # | Thread | Resolution |
|---|---|---|
| 1 | 🟠 Major — nested-generic field types falsely rejected (`List<Map<String, dynamic>>`, `Set<String>`, `Iterable<Product>`, `Map<String, List<String>>`) | **Fixed.** `EntityUtils.extractEntityTypes` now parses generic type arguments recursively. Containers (`List`/`Set`/`Map`/`Iterable`/`Future`/`Stream`) recurse into their args only; non-container generics (`SomeWrapper<Product>`) yield the base + args. `List<Map<String, Product>>` → `[Product]`, `Set<String>` → `[]`, `List<Map<String, dynamic>>` → `[]`. Verified end-to-end: the exact commands that were falsely rejected on the PR head now generate clean entities (previously-valid fields no longer abort creation). |
| 2 | 🟡 Minor — `Duration`/`Uri`/`BigInt`/`Uint8List` blocked with a misleading "create an enum" suggestion | **Fixed (message accuracy).** Empirically verified that zorphy's `FieldNormalizer` `$`-prefixes these (`$Duration get ttl;` → build fails with `InvalidType`) — so accepting them would reintroduce the exact #296 symptom. The validator keeps rejecting them fail-fast, but the error now says "not supported as a field type by zorphy" instead of suggesting `zfa entity enum -n Duration`. `KnownTypes.dartTypes` gains `Uri`/`BigInt`/`Uint8List` for the classification. |
| 3 | 🟡 Minor — no nested-generic test coverage | **Fixed.** Added 8 unit tests: nested-generic acceptance (`Map<String, List<Product>>`, `List<List<Product>>`, `Iterable<Product>`, `List<Map<String, Product>>`, pure-primitive `List<Map<String, dynamic>>`/`Set<String>`/`Map<String, List<String>>`) and unsupported-Dart-type rejection with message assertions (`Duration`, `Uri`, `BigInt`, `Uint8List`, `List<Duration>`). |

## Files changed

- `lib/src/utils/entity_utils.dart` — recursive generic type extraction (+ container handling, `Null`/`num` primitives)
- `lib/src/utils/entity_type_validator.dart` — distinct "not supported" error for known Dart types
- `lib/src/core/constants/known_types.dart` — `Uri`/`BigInt`/`Uint8List` added to `dartTypes`
- `test/utils/entity_type_validator_test.dart` — 8 new tests (29 total)

## Validation

- `dart analyze` on changed files: clean
- `dart format --set-exit-if-changed`: clean
- `dart test test/utils/entity_type_validator_test.dart`: 29/29
- `dart test test/regression/issue_296_unresolvable_enum_type_test.dart`: 5/5
- `dart test test/utils/`: 43/43
- `dart test test/regression/`: 44/44
- `dart test test/integration/`: 28/28
- `dart test test/plugins/`: 176/176
- Manual CLI verification: `List<Map<String, dynamic>>`, `Set<String>`, `Iterable<Product>`, `List<Map<String, Product>>` all create clean entities; `Duration` rejected with the new message; missing enum still gets the actionable hint.
