### PR TITLE
fix(zfa make): rename toggle-value param to toggleValue to avoid collision with entity field named value (#302)

### DIFF
--- a/lib/src/plugins/controller/controller_plugin_bodies.dart
+++ b/lib/src/plugins/controller/controller_plugin_bodies.dart
@@ -505,9 +505,13 @@ extension ControllerPluginBodies on ControllerPlugin {
     String entityCamel,
     bool hasListMethod,
   ) {
+    // #302: forward `toggleValue` (not `value`) — matches the renamed
+    // parameter in `_buildToggleMethod`. When `config.idField == 'value'`
+    // (e.g. Barcode entity), forwarding `value` would resolve to the String
+    // id param instead of the bool toggle-value param.
     final resultCall = refer('_presenter')
         .property('toggle$entityName')
-        .call(_callArgsExpressions('${config.idField}, field, value'))
+        .call(_callArgsExpressions('${config.idField}, field, toggleValue'))
         .awaited;
     final updateArgs = <String, Expression>{
       'isToggling': literalBool(false),
@@ -567,9 +571,11 @@ extension ControllerPluginBodies on ControllerPlugin {
     GeneratorConfig config,
     String entityName,
   ) {
+    // #302: forward `toggleValue` (not `value`) — see
+    // `_buildToggleWithStateBody` for the rationale.
     final resultCall = refer('_presenter')
         .property('toggle$entityName')
-        .call(_callArgsExpressions('${config.idField}, field, value'))
+        .call(_callArgsExpressions('${config.idField}, field, toggleValue'))
         .awaited;
     return Block(
       (b) => b

--- a/lib/src/plugins/controller/controller_plugin_methods.dart
+++ b/lib/src/plugins/controller/controller_plugin_methods.dart
@@ -296,6 +296,15 @@ extension ControllerPluginMethods on ControllerPlugin {
           )
         : _buildToggleWithoutStateBody(config, entityName);
 
+    // #302: The toggle-value parameter must NOT be named after the entity's
+    // id field. Entities like `Barcode` declare a field literally named
+    // `value` (and `EntityFieldResolver.resolveIdField` then resolves the
+    // id field to `value` because it's the first declared field), which
+    // would make the id param `String value` collide with the toggle-value
+    // param `bool value` → duplicate_definition + argument_type_not_assignable.
+    // Use the fixed reserved name `toggleValue` for the bool toggle-value
+    // parameter so it can never collide with `config.idField`, `field`, or
+    // `cancelToken` regardless of the entity's field names.
     return Method(
       (m) => m
         ..name = 'toggle$entityName'
@@ -314,7 +323,7 @@ extension ControllerPluginMethods on ControllerPlugin {
           ),
           Parameter(
             (p) => p
-              ..name = 'value'
+              ..name = 'toggleValue'
               ..type = refer('bool'),
           ),
         ])

--- a/lib/src/plugins/presenter/presenter_plugin.dart
+++ b/lib/src/plugins/presenter/presenter_plugin.dart
@@ -639,11 +639,17 @@ class PresenterPlugin extends FileGeneratorPlugin implements CliAwarePlugin {
     String entityName,
   ) {
     final fieldEnum = 'Field<$entityName, dynamic>';
+    // #302: forward `toggleValue` (not `value`) into the ToggleParams.value
+    // field. The toggle-value parameter is renamed to `toggleValue` below so
+    // it can never collide with `config.idField` (which resolves to `value`
+    // for entities like Barcode whose first declared field is `value`).
+    // The ToggleParams constructor's `value:` named field is unaffected — it
+    // is a class field name, not a parameter name.
     final toggleParams =
         refer('ToggleParams<${config.idFieldType}, $fieldEnum>').call([], {
           'id': refer(config.idField),
           'field': refer('field'),
-          'value': refer('value'),
+          'value': refer('toggleValue'),
         });
 
     final callExpression = refer('_${info.fieldName}')
@@ -667,7 +673,7 @@ class PresenterPlugin extends FileGeneratorPlugin implements CliAwarePlugin {
           ),
           Parameter(
             (p) => p
-              ..name = 'value'
+              ..name = 'toggleValue'
               ..type = refer('bool'),
           ),
         ])

--- a/test/regression/issue_302_toggle_param_collision_test.dart
+++ b/test/regression/issue_302_toggle_param_collision_test.dart
@@ -1,0 +1,389 @@
+// Regression tests for issue #302.
+//
+// `zfa make`'s toggle method generator (controller + presenter) declared
+// three positional parameters:
+//
+//   1. `<idType> <config.idField>`  (the id)
+//   2. `Field<Entity, dynamic> field`  (the field to toggle)
+//   3. `bool value`  (the new toggle value)
+//
+// The third parameter was hardcoded to the name `value`. When the entity
+// has a field literally named `value` (Barcode: `String get value;
+// BarcodeFormat get format;`), `EntityFieldResolver.resolveIdField`
+// resolves the id field to `value` (no `id`/`*Id` field → first declared
+// field). That made the id parameter `String value` collide with the
+// toggle-value parameter `bool value`:
+//
+//   Future<void> toggleBarcode(
+//     String value,                       // <-- id param named `value`
+//     Field<Barcode, dynamic> field,
+//     bool value, [                       // <-- toggle-value param ALSO `value`
+//     CancelToken? cancelToken,
+//   ]) ...
+//
+// → `duplicate_definition` (two `value` params) and
+//   `argument_type_not_assignable` (the String `value` shadows the bool
+//   `value` when forwarded to `_presenter.toggleBarcode(...)` and
+//   `ToggleParams(...)`).
+//
+// The fix renames the toggle-value parameter to `toggleValue` (a fixed
+// reserved name that can never collide with `config.idField`, `field`, or
+// `cancelToken` regardless of the entity's field names). The
+// `ToggleParams` constructor's `value:` named field is unaffected — it
+// is a class field name, not a parameter name — so the params object is
+// still constructed as `ToggleParams(id: ..., field: ..., value: ...)`.
+//
+// These tests:
+//   - Reproduce the Barcode scenario from the issue (entity with a field
+//     literally named `value`, no `id`/`*Id` field).
+//   - Assert the generated controller + presenter use `toggleValue` for
+//     the bool param and forward `toggleValue` into `ToggleParams.value`.
+//   - Assert no `duplicate_definition` exists in the generated code.
+//   - Re-test the canonical `Todo` (id=`id`) case to lock in that the
+//     rename doesn't break the standard id-field scenario.
+
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
+import 'package:test/test.dart';
+import 'package:zuraffa/src/core/generator_options.dart';
+import 'package:zuraffa/src/generator/code_generator.dart';
+import 'package:zuraffa/src/models/generator_config.dart';
+import 'package:zuraffa/src/utils/entity_field_resolver.dart';
+
+import 'regression_test_utils.dart';
+
+void main() {
+  late RegressionWorkspace workspace;
+  late String outputDir;
+
+  setUp(() async {
+    workspace = await createWorkspace('issue_302_toggle_param_collision');
+    await writePubspec(workspace);
+    await runFlutterPubGet(workspace);
+    outputDir = workspace.outputDir;
+  });
+
+  group('#302 — toggle param name collision when entity field is `value`', () {
+    test(
+      'EntityFieldResolver resolves `value` as the id field for Barcode',
+      () async {
+        await writeEntityStubWithoutId(
+          workspace,
+          name: 'Barcode',
+          fields: const [
+            (name: 'value', type: 'String'),
+            (name: 'format', type: 'String'),
+          ],
+        );
+
+        final resolved = EntityFieldResolver.resolveIdField(
+          entityName: 'Barcode',
+          projectRoot: workspace.directory.path,
+        );
+
+        expect(
+          resolved,
+          isNotNull,
+          reason:
+              'Resolver should fall back to the first declared field '
+              '(`value`) when no `id`/`*Id` field exists',
+        );
+        expect(resolved!.name, 'value');
+        expect(resolved.type, 'String');
+      },
+    );
+
+    test('generated controller + presenter use `toggleValue` for the bool param '
+        'and forward it into ToggleParams (no duplicate `value`)', () async {
+      await writeEntityStubWithoutId(
+        workspace,
+        name: 'Barcode',
+        fields: const [
+          (name: 'value', type: 'String'),
+          (name: 'format', type: 'String'),
+        ],
+      );
+
+      // Simulate what MakeCommand.run() does after the resolver resolves
+      // `value` as the id field for Barcode.
+      final generator = CodeGenerator(
+        config: GeneratorConfig(
+          name: 'Barcode',
+          methods: const ['get', 'update', 'toggle', 'delete'],
+          idField: 'value',
+          idFieldType: 'String',
+          queryField: 'value',
+          generateData: true,
+          generateLocal: true,
+          generateUseCase: true,
+          generateVpcs: true,
+          generateState: true,
+          generateDi: true,
+          generateTest: true,
+          outputDir: outputDir,
+        ),
+        outputDir: outputDir,
+        options: const GeneratorOptions(
+          dryRun: false,
+          force: true,
+          verbose: false,
+        ),
+      );
+
+      final result = await generator.generate();
+      expect(
+        result.success,
+        isTrue,
+        reason: 'Generation failed: ${result.errors.join('; ')}',
+      );
+
+      // ---- Controller ----
+      final controllerFile = File(
+        path.join(
+          outputDir,
+          'presentation',
+          'pages',
+          'barcode',
+          'barcode_controller.dart',
+        ),
+      );
+      expect(
+        controllerFile.existsSync(),
+        isTrue,
+        reason: 'barcode_controller.dart should be generated',
+      );
+      final controllerSrc = controllerFile.readAsStringSync();
+
+      // Positive: toggle method uses `toggleValue` for the bool param.
+      expect(
+        controllerSrc,
+        contains('bool toggleValue'),
+        reason:
+            'Controller toggleBarcode must name the bool toggle-value '
+            'parameter `toggleValue`, not `value`',
+      );
+      // Positive: the id parameter keeps the entity's id-field name (`value`).
+      expect(
+        controllerSrc,
+        contains('String value,'),
+        reason:
+            'Controller toggleBarcode must keep the id parameter named '
+            'after the entity\'s id field (`value` for Barcode)',
+      );
+      // Negative: NO duplicate `bool value` declaration.
+      expect(
+        controllerSrc,
+        isNot(contains('bool value,')),
+        reason:
+            'Controller toggleBarcode must NOT declare `bool value` — '
+            'it collides with the id parameter `String value`',
+      );
+      // Negative: NO duplicate_definition smoke check — the literal
+      // substring `String value,\n  Field<Barcode, dynamic> field,\n  bool value`
+      // is the exact pattern that triggered #302.
+      expect(
+        controllerSrc,
+        isNot(contains('bool value,')),
+        reason: 'Controller must not contain `bool value,` anywhere',
+      );
+      // Positive: forwards `toggleValue` (not `value`) to the presenter.
+      expect(
+        controllerSrc,
+        contains('_presenter.toggleBarcode('),
+        reason: 'Controller should forward to _presenter.toggleBarcode',
+      );
+      // The forward call args come from `_callArgsExpressions('<idField>, '
+      // 'field, toggleValue')` — verify the resolved arg string.
+      expect(
+        controllerSrc,
+        contains('toggleValue'),
+        reason: 'Controller body should reference `toggleValue`',
+      );
+
+      // ---- Presenter ----
+      final presenterFile = File(
+        path.join(
+          outputDir,
+          'presentation',
+          'pages',
+          'barcode',
+          'barcode_presenter.dart',
+        ),
+      );
+      expect(
+        presenterFile.existsSync(),
+        isTrue,
+        reason: 'barcode_presenter.dart should be generated',
+      );
+      final presenterSrc = presenterFile.readAsStringSync();
+
+      // Positive: presenter uses `toggleValue` for the bool param.
+      expect(
+        presenterSrc,
+        contains('bool toggleValue'),
+        reason:
+            'Presenter toggleBarcode must name the bool toggle-value '
+            'parameter `toggleValue`, not `value`',
+      );
+      // Negative: NO `bool value` declaration.
+      expect(
+        presenterSrc,
+        isNot(contains('bool value,')),
+        reason: 'Presenter toggleBarcode must NOT declare `bool value`',
+      );
+      // Positive: `ToggleParams` constructor still uses the `value:` named
+      // field (it's a class field name, not a parameter name), but it
+      // receives `toggleValue` as the value.
+      expect(
+        presenterSrc,
+        contains('value: toggleValue'),
+        reason: 'Presenter must forward `toggleValue` into ToggleParams.value',
+      );
+      // Positive: `id:` still receives the id param (`value` for Barcode).
+      expect(
+        presenterSrc,
+        contains('id: value,'),
+        reason:
+            'Presenter must forward the id parameter (`value`) into '
+            'ToggleParams.id',
+      );
+    });
+
+    test('REGRESSION: canonical Todo (id=`id`) case still uses `toggleValue` '
+        'for the bool param — no behavioural break', () async {
+      // Use the standard writeEntityStub helper (writes an entity WITH an
+      // `id` field) to confirm the rename doesn't break the canonical
+      // id-field scenario.
+      await writeEntityStub(workspace, name: 'Todo');
+
+      final generator = CodeGenerator(
+        config: GeneratorConfig(
+          name: 'Todo',
+          methods: const ['get', 'update', 'toggle'],
+          idField: 'id',
+          idFieldType: 'String',
+          queryField: 'id',
+          generateData: true,
+          generateLocal: true,
+          generateUseCase: true,
+          generateVpcs: true,
+          generateState: true,
+          generateDi: true,
+          generateTest: true,
+          outputDir: outputDir,
+        ),
+        outputDir: outputDir,
+        options: const GeneratorOptions(
+          dryRun: false,
+          force: true,
+          verbose: false,
+        ),
+      );
+
+      final result = await generator.generate();
+      expect(
+        result.success,
+        isTrue,
+        reason: 'Generation failed: ${result.errors.join('; ')}',
+      );
+
+      final controllerFile = File(
+        path.join(
+          outputDir,
+          'presentation',
+          'pages',
+          'todo',
+          'todo_controller.dart',
+        ),
+      );
+      expect(controllerFile.existsSync(), isTrue);
+      final controllerSrc = controllerFile.readAsStringSync();
+
+      // The canonical case: id param `String id`, field param
+      // `Field<Todo, dynamic> field`, toggle-value param `bool toggleValue`.
+      expect(controllerSrc, contains('String id,'));
+      expect(controllerSrc, contains('bool toggleValue'));
+      expect(controllerSrc, isNot(contains('bool value,')));
+
+      final presenterFile = File(
+        path.join(
+          outputDir,
+          'presentation',
+          'pages',
+          'todo',
+          'todo_presenter.dart',
+        ),
+      );
+      expect(presenterFile.existsSync(), isTrue);
+      final presenterSrc = presenterFile.readAsStringSync();
+
+      expect(presenterSrc, contains('bool toggleValue'));
+      expect(presenterSrc, contains('value: toggleValue'));
+      expect(presenterSrc, isNot(contains('bool value,')));
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Writes an entity file WITHOUT an `id` field — mimics what
+/// `zfa entity create -n X --field value:String` produces (a Zorphy
+/// abstract class with `Type get fieldName;` getters). Also writes a
+/// matching `<Name>Fields` class so the generated code can reference
+/// `<Name>Fields.<fieldName>` constants.
+///
+/// Mirrors the helper in `issue_294_entity_without_id_test.dart` — kept
+/// local to this test so #294 and #302 can evolve independently if their
+/// entity-stub needs ever diverge.
+Future<void> writeEntityStubWithoutId(
+  RegressionWorkspace workspace, {
+  required String name,
+  required List<({String name, String type})> fields,
+}) async {
+  final entitySnake = _toSnake(name);
+  final entityDir = Directory(
+    path.join(workspace.outputDir, 'domain', 'entities', entitySnake),
+  );
+  await entityDir.create(recursive: true);
+  final entityFile = File(path.join(entityDir.path, '$entitySnake.dart'));
+
+  final buffer = StringBuffer()
+    ..writeln('// Auto-generated entity stub for regression test (#302).')
+    ..writeln()
+    ..writeln('abstract class \$$name {');
+
+  for (final f in fields) {
+    buffer.writeln('  ${f.type} get ${f.name};');
+  }
+  buffer
+    ..writeln('}')
+    ..writeln();
+
+  // Stub `<Name>Fields` class with Field constants for each declared field.
+  // The mock datasource / presenter / test generators reference these.
+  buffer.writeln('abstract final class ${name}Fields {');
+  for (final f in fields) {
+    buffer.writeln(
+      "  static const Field<$name, ${f.type}> ${f.name} = "
+      "Field<$name, ${f.type}>(name: '${f.name}');",
+    );
+  }
+  buffer.writeln('}');
+
+  await entityFile.writeAsString(buffer.toString());
+}
+
+String _toSnake(String input) {
+  final result = <String>[];
+  for (var i = 0; i < input.length; i += 1) {
+    final char = input[i];
+    if (i > 0 && char.toUpperCase() == char && char != '_') {
+      result.add('_');
+    }
+    result.add(char.toLowerCase());
+  }
+  return result.join();
+}


### PR DESCRIPTION
Closes #302

## Summary

The toggle-method generators in `controller_plugin_methods.dart` and `presenter_plugin.dart` declared three positional parameters:

1. `<idType> <config.idField>` (the id)
2. `Field<Entity, dynamic> field` (the field to toggle)
3. `bool value` (the new toggle value — hardcoded name)

When an entity has a field literally named `value` (e.g. `Barcode` with `String get value; BarcodeFormat get format;`), `EntityFieldResolver.resolveIdField` resolves the id field to `value` (no `id`/`*Id` field → first declared field). That made the id parameter `String value` collide with the toggle-value parameter `bool value`:

```dart
Future<void> toggleBarcode(
  String value,                       // <-- id param named `value`
  Field<Barcode, dynamic> field,
  bool value, [                       // <-- toggle-value param ALSO `value` → duplicate_definition
  CancelToken? cancelToken,
]) ...
```

→ `duplicate_definition` (two `value` params) and `argument_type_not_assignable` (the String `value` shadows the bool `value` when forwarded to `_presenter.toggleBarcode(...)` and `ToggleParams(...)`).

## Root cause

The toggle-value parameter name was hardcoded to `value`, which can collide with `config.idField` (the entity's actual id-like field name, resolved from the entity source — not always `id`).

## Fix

Rename the toggle-value parameter to `toggleValue` (a fixed reserved name that can never collide with `config.idField`, `field`, or `cancelToken` regardless of the entity's field names). The `ToggleParams` constructor's `value:` named field is unaffected — it is a class field name, not a parameter name — so the params object is still constructed as `ToggleParams(id: ..., field: ..., value: ...)`.

### Files changed

- `lib/src/plugins/controller/controller_plugin_methods.dart` — rename 3rd toggle param `value` → `toggleValue` in `_buildToggleMethod`
- `lib/src/plugins/controller/controller_plugin_bodies.dart` — forward `toggleValue` (not `value`) in `_buildToggleWithStateBody` + `_buildToggleWithoutStateBody`
- `lib/src/plugins/presenter/presenter_plugin.dart` — rename 3rd toggle param `value` → `toggleValue` + update `ToggleParams` construction to `value: refer('toggleValue')` in `_buildToggleMethod`
- `test/regression/issue_302_toggle_param_collision_test.dart` — new regression test (3 cases)

## Audit (per issue suggestion)

Other generators (usecase, mock, test, datasource, repository) all pass `ToggleParams` as a single object — no param-name collision possible. Only controller + presenter unpack the params, so only those two needed patching.

## Verification

- `dart analyze` on the 3 edited files + new test: clean (no issues)
- `dart test test/regression/issue_302_toggle_param_collision_test.dart`: 3/3 PASS
  - EntityFieldResolver resolves `value` as the id field for Barcode (no `id`/`*Id` → first declared)
  - Generated controller + presenter use `toggleValue` (not `value`) and forward it correctly into `ToggleParams.value`
  - REGRESSION: canonical `Todo` (id=`id`) case still works (no behavioural break)
- `dart test test/plugins/controller/ test/plugins/presenter/`: 16/16 PASS
- `dart test test/integration/toggle_method_test.dart test/regression/issue_294_entity_without_id_test.dart test/regression/issue_299_findusecasedomain_list_substring_test.dart`: all PASS
- `dart format --set-exit-if-changed` on all 4 files: clean

Pre-existing failures in `issue_296_unresolvable_enum_type_test.dart` are unrelated (they test entity-create type validation, fail on pure `development` too — not introduced by this PR).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed generated toggle actions for entities with an identifier named `value`.
  * Toggle operations now reliably receive and forward the intended boolean state.

* **Tests**
  * Added regression coverage for toggle parameter collisions.
  * Verified behavior for entities with and without explicit identifiers, including standard entity generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->