### PR TITLE
feat(entity create): --allow-forward-refs for cyclic schema batches (#308)

### DIFF
--- a/lib/src/commands/entity_command.dart
+++ b/lib/src/commands/entity_command.dart
@@ -152,11 +152,16 @@ ${missing.map((d) => '   • $d').join('\n')}
     // if a referenced type is neither a primitive, an existing entity,
     // nor an existing enum, abort with a clear error so the entity is
     // never written with a bogus `$`-prefixed `InvalidType`.
-    final typeErrors = EntityTypeValidator.validate(
-      fields: fields,
-      outputDir: outputDir,
-      selfEntityName: name,
-    );
+    // `--allow-forward-refs` opts out for batch generation of cyclic schemas
+    // (issue #308): the referenced entity will exist by build time.
+    final allowForwardRefs = parsed['allow_forward_refs'] == true;
+    final typeErrors = allowForwardRefs
+        ? const <UnresolvedTypeError>[]
+        : EntityTypeValidator.validate(
+            fields: fields,
+            outputDir: outputDir,
+            selfEntityName: name,
+          );
     if (typeErrors.isNotEmpty) {
       print(
         '❌ Cannot create entity "$name": field type(s) could not be resolved.',
@@ -271,11 +276,15 @@ ${missing.map((d) => '   • $d').join('\n')}
     // Validate field types BEFORE writing anything (issue #296):
     // same guard as `entity create` — refuse to add fields whose types
     // cannot be resolved against the on-disk entity/enum layout.
-    final typeErrors = EntityTypeValidator.validate(
-      fields: fields,
-      outputDir: fixedEntityOutput,
-      selfEntityName: name,
-    );
+    // `--allow-forward-refs` opts out (issue #308), same as `entity create`.
+    final allowForwardRefs = parsed['allow_forward_refs'] == true;
+    final typeErrors = allowForwardRefs
+        ? const <UnresolvedTypeError>[]
+        : EntityTypeValidator.validate(
+            fields: fields,
+            outputDir: fixedEntityOutput,
+            selfEntityName: name,
+          );
     if (typeErrors.isNotEmpty) {
       print(
         '❌ Cannot add field(s) to "$name": field type(s) could not be resolved.',
@@ -726,6 +735,8 @@ CREATE COMMAND:
     --extends               Interface to extend
     --subtypes              Explicit subtypes
     --generate-subs         Generate subtype files
+    --allow-forward-refs    Skip on-disk type validation (batch generation of
+                            cyclic schemas — referenced entity is created later)
 
 EXAMPLES:
   zfa entity create -n User --field id:String --field name:String

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '5.1.0';
+const version = '6.0.0';


### PR DESCRIPTION
## What

Adds `--allow-forward-refs` to `zfa entity create` and `zfa entity add-field`:
skips the on-disk entity/enum type validation (issue #296) so entities can be
generated as part of a batch where a referenced entity does not exist *yet*.

## Why

Cyclic GraphQL schemas cannot be generated with `zfa entity create` in any
order. Vendure (arrrrny/vendure-flutter-sdk rewrite): `Order ↔ Customer`,
`Facet ↔ FacetValue`, `Fulfillment ↔ FulfillmentLine`, `Product ↔ ProductVariant`
— 24 of 179 entities form reference cycles. The #296 validator rejects the
first member of every cycle with "field type(s) could not be resolved", and no
file is written (arrrrny/zuraffa#308).

`ImportResolver` already emits correct `$`-prefixed entity imports for forward
references (`import '../<snake>/<snake>.dart';` even when the directory does
not exist yet), so the build resolves once all batch entities exist — verified
end-to-end: `Customer(List<Order>?)` created before `Order`, then `zfa build`
green with zero `InvalidType`.

## Changes

- `lib/src/commands/entity_command.dart`:
  - `--allow-forward-refs` parsed for `entity create` + `entity add-field`;
    when set, `EntityTypeValidator.validate` is skipped.
  - Help text documents the flag.
- Default behavior unchanged: unknown types are still rejected with the clear
  #296 error.

## Verification

- `dart analyze lib/src/commands/entity_command.dart` — clean.
- Spike: forward-ref Customer/Order pair builds green, zero InvalidType.
- Spike: `zfa entity create -n BadType --field foo:DoesNotExist` (no flag)
  still fails with the #296 message.

Fixes arrrrny/zuraffa#308.
