### PR TITLE
test(entity create): lock in #308 --allow-forward-refs regression suite + help docs

### DIFF
--- a/CLI_GUIDE.md
+++ b/CLI_GUIDE.md
@@ -106,6 +106,43 @@ zfa entity add-field -n Product --field stock:int
 - The domain root is fixed to `lib/src/domain`.
 - Legacy `--output` values are accepted by some commands for compatibility but are not the public v5 contract.
 
+### Forward references & cyclic entity graphs (`--allow-forward-refs`)
+
+By default, `entity create` and `entity add-field` validate that every
+non-primitive field type resolves to either an existing entity directory or
+an existing enum file on disk (added by #296 — prevents silently writing
+`$InvalidType` placeholders). This guard rejects forward references to
+entities that have not been generated yet.
+
+Real-world GraphQL schemas (Vendure, Shopify, etc.) often contain genuine
+mutual-reference cycles — `Order ↔ Customer`, `Facet ↔ FacetValue`,
+`Fulfillment ↔ FulfillmentLine` — so a schema-driven batch cannot satisfy
+"every referenced entity must already exist" in any ordering.
+
+Pass `--allow-forward-refs` to opt out of the on-disk check for a single
+invocation. The `ImportResolver` already emits correct `$`-prefixed entity
+imports for forward references (e.g. `import '../order/order.dart';` even
+when `order/order.dart` does not exist yet), so the build resolves cleanly
+once every entity in the batch has been generated.
+
+```bash
+# Step 1: Customer references Order (which does not exist yet)
+zfa entity create -n Customer \
+  --field id:String? \
+  --field orders:List<Order> \
+  --allow-forward-refs
+
+# Step 2: Order references Customer back — cycle closed
+zfa entity create -n Order \
+  --field id:String? \
+  --field customer:Customer? \
+  --allow-forward-refs
+```
+
+`--allow-forward-refs` is **opt-in**. The default behaviour (reject unknown
+types) is unchanged — it still guards against typos and genuinely missing
+enums/entities when you are generating a single entity outside a batch.
+
 ---
 
 ## `zfa make`

--- a/lib/src/commands/entity_command.dart
+++ b/lib/src/commands/entity_command.dart
@@ -738,6 +738,15 @@ CREATE COMMAND:
     --allow-forward-refs    Skip on-disk type validation (batch generation of
                             cyclic schemas — referenced entity is created later)
 
+ADD-FIELD COMMAND:
+  zfa entity add-field -n <Name> [options]
+  Options:
+    -n, --name              Entity name (required)
+    --field                 Add field "name:type"
+    -F, --fields            Add multiple fields "name:type,name:type"
+    --allow-forward-refs    Skip on-disk type validation (batch generation of
+                            cyclic schemas — referenced entity is created later)
+
 EXAMPLES:
   zfa entity create -n User --field id:String --field name:String
   zfa entity create -n Product --field name:String --field price:double --filter

--- a/test/regression/issue_308_forward_refs_cyclic_test.dart
+++ b/test/regression/issue_308_forward_refs_cyclic_test.dart
@@ -1,0 +1,389 @@
+// Regression test for issue #308.
+//
+// `zfa entity create` and `zfa entity add-field` rejected forward references
+// — field types that resolve to an entity which does NOT yet exist on disk
+// but will be created later in the same batch. Real-world GraphQL schemas
+// (Vendure, etc.) have genuine mutual-reference cycles:
+//
+//   Order ↔ Customer           (Customer.orders: List<Order>,
+//                               Order.customer: Customer?)
+//   Facet ↔ FacetValue
+//   Fulfillment ↔ FulfillmentLine
+//
+// The strict on-disk validator (added by #296 / PR #297) aborted with
+// `Unknown type "X" for field "y"` whenever the referenced entity directory
+// did not yet exist, so a cyclic batch could not be generated in any order.
+//
+// Fix (PR #299 → actually PR #309, merged into development as 7f21e31):
+// `entity create` and `entity add-field` accept a `--allow-forward-refs`
+// flag that opts out of on-disk type validation for the duration of that
+// single command. `ImportResolver` already emits correct `$`-prefixed
+// entity imports for forward references (e.g. `import '../order/order.dart';`
+// even when `order/order.dart` does not exist yet), so the build resolves
+// once every entity in the batch has been generated.
+//
+// This test locks in the fix end-to-end by spawning the `zfa` CLI binary
+// against a temp workspace. It covers:
+//
+//   1. Without --allow-forward-refs: a forward reference is rejected (the
+//      #296 guard still fires — `--allow-forward-refs` is OPT-IN, never
+//      the default).
+//   2. With --allow-forward-refs: the same forward reference is accepted,
+//      the entity file is written, and the forward import is emitted.
+//   3. Cyclic batch (the actual issue scenario): Customer(List<Order>) is
+//      created first, then Order(Customer?) — both succeed, the two files
+//      reference each other via the correct `$`-prefixed imports.
+//   4. `add-field` without --allow-forward-refs: forward reference rejected.
+//   5. `add-field` with --allow-forward-refs: forward reference accepted,
+//      the new field is written with the correct `$`-prefixed type.
+
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+/// Resolve package root at discovery time, before any test changes CWD.
+final _zfaRoot = Directory.current.path;
+
+void main() {
+  group('#308 — zfa entity create/add-field with --allow-forward-refs', () {
+    late Directory workspace;
+    late String zfaBin;
+
+    Future<ProcessResult> runZfa(List<String> args) {
+      return Process.run(
+        'dart',
+        [zfaBin, ...args],
+        workingDirectory: workspace.path,
+      );
+    }
+
+    setUp(() async {
+      zfaBin = p.join(_zfaRoot, 'bin', 'zfa.dart');
+      workspace = await Directory.systemTemp.createTemp('issue_308_');
+      // The entity command's dependency check scans pubspec.yaml for the
+      // strings `zorphy_annotation:` and `build_runner:`. The strings are
+      // enough — entity creation itself does not run `dart pub get`.
+      await File(p.join(workspace.path, 'pubspec.yaml')).writeAsString('''
+name: issue_308_test_app
+environment:
+  sdk: '>=3.12.0 <4.0.0'
+dependencies:
+  zorphy_annotation:
+dev_dependencies:
+  build_runner:
+''');
+    });
+
+    tearDown(() async {
+      if (workspace.existsSync()) {
+        await workspace.delete(recursive: true);
+      }
+    });
+
+    test(
+      'entity create WITHOUT --allow-forward-refs rejects a forward reference (opt-in)',
+      timeout: const Timeout(Duration(minutes: 2)),
+      () async {
+        // Customer references Order, which does NOT exist on disk yet.
+        // Without --allow-forward-refs, the #296 validator must still
+        // fire and abort. This proves the flag is OPT-IN and the default
+        // behaviour is unchanged from #296.
+        final result = await runZfa([
+          'entity',
+          'create',
+          '-n',
+          'Customer',
+          '--field',
+          'id:String?',
+          '--field',
+          'orders:List<Order>', // forward reference
+        ]);
+
+        expect(
+          result.exitCode,
+          equals(1),
+          reason: 'Forward refs must be rejected by default (#296 guard)',
+        );
+
+        final output = result.stdout.toString() + result.stderr.toString();
+        expect(output, contains('Unknown type "Order"'));
+        expect(output, contains('orders'));
+        expect(output, contains('could not be resolved'));
+
+        // No file may be written when validation fails.
+        final entityFile = File(
+          p.join(
+            workspace.path,
+            'lib',
+            'src',
+            'domain',
+            'entities',
+            'customer',
+            'customer.dart',
+          ),
+        );
+        expect(entityFile.existsSync(), isFalse);
+      },
+    );
+
+    test(
+      'entity create WITH --allow-forward-refs accepts a forward reference and writes the file',
+      timeout: const Timeout(Duration(minutes: 2)),
+      () async {
+        final result = await runZfa([
+          'entity',
+          'create',
+          '-n',
+          'Customer',
+          '--field',
+          'id:String?',
+          '--field',
+          'orders:List<Order>', // forward reference — Order created later
+          '--allow-forward-refs',
+        ]);
+
+        expect(
+          result.exitCode,
+          equals(0),
+          reason: '--allow-forward-refs must skip the on-disk check',
+        );
+
+        final entityFile = File(
+          p.join(
+            workspace.path,
+            'lib',
+            'src',
+            'domain',
+            'entities',
+            'customer',
+            'customer.dart',
+          ),
+        );
+        expect(entityFile.existsSync(), isTrue);
+
+        final content = await entityFile.readAsString();
+
+        // The field type must be the `$`-prefixed entity type `$Order`
+        // (Zorphy entity convention) wrapped in `List<...>`.
+        expect(
+          content,
+          contains('List<\$Order>'),
+          reason: 'Forward entity ref must be emitted as `List<\$Order>`',
+        );
+
+        // The ImportResolver must emit the forward entity-style import
+        // `import '../order/order.dart';` even though order/ does not
+        // exist yet — that is the whole point of #308.
+        expect(
+          content,
+          contains("import '../order/order.dart';"),
+          reason:
+              'ImportResolver must emit the forward import so the build '
+              'resolves once Order is created',
+        );
+      },
+    );
+
+    test(
+      'cyclic batch: Customer(List<Order>) then Order(Customer?) — both succeed, cross-imports correct',
+      timeout: const Timeout(Duration(minutes: 2)),
+      () async {
+        // Step 1: create Customer first, referencing Order (which does
+        // not exist yet) via --allow-forward-refs.
+        final step1 = await runZfa([
+          'entity',
+          'create',
+          '-n',
+          'Customer',
+          '--field',
+          'id:String?',
+          '--field',
+          'orders:List<Order>',
+          '--allow-forward-refs',
+        ]);
+        expect(step1.exitCode, equals(0));
+
+        // Step 2: now create Order, referencing Customer back. Customer
+        // already exists on disk by now, but using --allow-forward-refs
+        // again is the natural batch-mode usage and must also succeed.
+        final step2 = await runZfa([
+          'entity',
+          'create',
+          '-n',
+          'Order',
+          '--field',
+          'id:String?',
+          '--field',
+          'customer:Customer?',
+          '--allow-forward-refs',
+        ]);
+        expect(step2.exitCode, equals(0));
+
+        final customerFile = File(
+          p.join(
+            workspace.path,
+            'lib',
+            'src',
+            'domain',
+            'entities',
+            'customer',
+            'customer.dart',
+          ),
+        );
+        final orderFile = File(
+          p.join(
+            workspace.path,
+            'lib',
+            'src',
+            'domain',
+            'entities',
+            'order',
+            'order.dart',
+          ),
+        );
+        expect(customerFile.existsSync(), isTrue);
+        expect(orderFile.existsSync(), isTrue);
+
+        final customerSrc = await customerFile.readAsString();
+        final orderSrc = await orderFile.readAsString();
+
+        // Customer references Order.
+        expect(customerSrc, contains('List<\$Order>'));
+        expect(customerSrc, contains("import '../order/order.dart';"));
+
+        // Order references Customer back — the cycle is closed.
+        expect(orderSrc, contains('\$Customer?'));
+        expect(orderSrc, contains("import '../customer/customer.dart';"));
+      },
+    );
+
+    test(
+      'add-field WITHOUT --allow-forward-refs rejects a forward reference',
+      timeout: const Timeout(Duration(minutes: 2)),
+      () async {
+        // First create a valid entity (all primitives).
+        final create = await runZfa([
+          'entity',
+          'create',
+          '-n',
+          'Note',
+          '--field',
+          'id:String?',
+          '--field',
+          'body:String',
+        ]);
+        expect(create.exitCode, equals(0));
+
+        final noteFile = File(
+          p.join(
+            workspace.path,
+            'lib',
+            'src',
+            'domain',
+            'entities',
+            'note',
+            'note.dart',
+          ),
+        );
+        expect(noteFile.existsSync(), isTrue);
+        final before = await noteFile.readAsString();
+
+        // Now try to add a field whose type does not exist anywhere.
+        final add = await runZfa([
+          'entity',
+          'add-field',
+          '-n',
+          'Note',
+          '--field',
+          'category:NoteCategory', // forward reference
+        ]);
+
+        expect(
+          add.exitCode,
+          equals(1),
+          reason: 'add-field must also validate field types by default',
+        );
+
+        final output = add.stdout.toString() + add.stderr.toString();
+        expect(output, contains('Unknown type "NoteCategory"'));
+        expect(output, contains('could not be resolved'));
+
+        // File must be unchanged.
+        final after = await noteFile.readAsString();
+        expect(after, equals(before));
+      },
+    );
+
+    test(
+      'add-field WITH --allow-forward-refs accepts a forward reference and writes the field',
+      timeout: const Timeout(Duration(minutes: 2)),
+      () async {
+        // Create a valid entity first.
+        final create = await runZfa([
+          'entity',
+          'create',
+          '-n',
+          'Note',
+          '--field',
+          'id:String?',
+          '--field',
+          'body:String',
+        ]);
+        expect(create.exitCode, equals(0));
+
+        // Add a forward-referencing field with --allow-forward-refs.
+        final add = await runZfa([
+          'entity',
+          'add-field',
+          '-n',
+          'Note',
+          '--field',
+          'category:NoteCategory', // forward reference — NoteCategory created later
+          '--allow-forward-refs',
+        ]);
+        expect(
+          add.exitCode,
+          equals(0),
+          reason: '--allow-forward-refs must skip the on-disk check for add-field',
+        );
+
+        final noteFile = File(
+          p.join(
+            workspace.path,
+            'lib',
+            'src',
+            'domain',
+            'entities',
+            'note',
+            'note.dart',
+          ),
+        );
+        expect(noteFile.existsSync(), isTrue);
+
+        final content = await noteFile.readAsString();
+
+        // The new field must be present with the $-prefixed type.
+        expect(
+          content,
+          contains('\$NoteCategory get category'),
+          reason: 'Forward entity ref must be emitted as `\$NoteCategory`',
+        );
+      },
+    );
+
+    // Sanity: the zfa binary itself compiles & runs from the repo root.
+    test(
+      'zfa binary is runnable (smoke)',
+      timeout: const Timeout(Duration(minutes: 2)),
+      () async {
+        final result = await Process.run(
+          'dart',
+          [zfaBin, '--help'],
+          workingDirectory: _zfaRoot,
+        );
+        expect(result.exitCode, equals(0));
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Closes #308. Locks in the `--allow-forward-refs` fix shipped in #309 (commit `7f21e31`) with an end-to-end CLI regression suite and fills the documentation gap left by #309 (which added the flag but no tests and no `add-field` help entry).

### Background

Issue #308 reported that `zfa entity create` (and `zfa entity add-field`) rejected forward references — field types resolving to an entity that does **not yet exist on disk** but will be created later in the same batch. Real-world GraphQL schemas (Vendure, Shopify) contain genuine mutual-reference cycles — `Order ↔ Customer`, `Facet ↔ FacetValue`, `Fulfillment ↔ FulfillmentLine` — so a schema-driven batch cannot satisfy "every referenced entity must already exist" in any ordering.

PR #309 fixed this by adding an opt-in `--allow-forward-refs` flag to `entity create` and `entity add-field` that skips the on-disk type validation (added by #296) for a single invocation. The `ImportResolver` already emits correct `$`-prefixed entity imports for forward references, so the build resolves cleanly once every entity in the batch has been generated.

**However, #309 shipped no regression test coverage**: `test/utils/entity_type_validator_test.dart` only tested the validator in isolation, and `test/regression/issue_296_unresolvable_enum_type_test.dart` covered only the negative case and the self-reference case. No test exercised the `--allow-forward-refs` flag end-to-end, and no test covered the cyclic `Order ↔ Customer` batch scenario from the issue.

### Changes

| File | Change |
|------|--------|
| `test/regression/issue_308_forward_refs_cyclic_test.dart` (new, 6 tests, 389 LOC) | End-to-end CLI regression suite spawning the `zfa` binary against a temp workspace. Covers: (1) forward ref rejected by default (opt-in), (2) forward ref accepted with flag + file written + forward import emitted, (3) **cyclic batch** — Customer(List\<Order\>) then Order(Customer?) — both succeed, cross-imports correct, (4) add-field rejected by default, (5) add-field accepted with flag, (6) smoke test. |
| `lib/src/commands/entity_command.dart` (+9 LOC) | New `ADD-FIELD COMMAND` section in `_printHelp` documenting `--allow-forward-refs` for `add-field` (previously only listed under `CREATE COMMAND`). |
| `CLI_GUIDE.md` (+37 LOC) | New "Forward references & cyclic entity graphs" section under `zfa entity create` with rationale, examples, and the opt-in semantics. |

### Verification

- `dart analyze lib/src/commands/entity_command.dart test/regression/issue_308_forward_refs_cyclic_test.dart` → **No issues found!**
- `dart test test/regression/issue_308_forward_refs_cyclic_test.dart` → **6/6 passed** (4 min 39 s)
- `dart test test/regression/issue_296_unresolvable_enum_type_test.dart` → **5/5 passed** (no regression)
- `dart test test/utils/entity_type_validator_test.dart` → **21/21 passed** (no regression)

### Reproduction (verified on `development` HEAD = `7f21e31`)

```bash
# Step 1: Customer references Order (which does not exist yet)
zfa entity create -n Customer \
  --field id:String? \
  --field orders:List<Order> \
  --allow-forward-refs
# ✓ Created entity: lib/src/domain/entities/customer/customer.dart
#   Contains: List<$Order> get orders;
#             import '../order/order.dart';

# Step 2: Order references Customer back — cycle closed
zfa entity create -n Order \
  --field id:String? \
  --field customer:Customer? \
  --allow-forward-refs
# ✓ Created entity: lib/src/domain/entities/order/order.dart
#   Contains: $Customer? get customer;
#             import '../customer/customer.dart';
```

### Notes

- This PR is **test + docs only** — no production code changes. The fix itself was shipped in #309.
- The `--allow-forward-refs` flag is **opt-in**. Default behaviour (reject unknown types, #296 guard) is unchanged — it still catches typos and genuinely missing enums/entities when generating a single entity outside a batch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for creating entities with forward references and cyclic relationships.
  * Documented the `--allow-forward-refs` option for entity creation and field additions.
  * Added examples showing how to define interconnected entities in multiple steps.
* **CLI Improvements**
  * Expanded `entity` command help to explain field options and forward-reference handling.
* **Bug Fixes**
  * Improved support for forward references and cyclic entity creation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->