### PR TITLE
fix(zfa): entity identity contract — autoId + ValueObject, loud no-id error (#307)

### DIFF
--- a/CLI_GUIDE.md
+++ b/CLI_GUIDE.md
@@ -139,6 +139,50 @@ zfa entity create -n Order \
   --allow-forward-refs
 ```
 
+### Auto-generated ids (`--auto-id`)
+
+`zfa make` requires every entity to have a real identity (issue #307 — the
+old silent first-field fallback produced enum-typed ids for id-less entities
+like `ChatMessage` / `TelemetryEvent`). Pass `--auto-id` to have zfa declare
+a `String id` field that the generated constructor defaults to a fresh
+`Uuid().v4()` — callers construct the entity without supplying an id:
+
+```bash
+zfa entity create -n ChatMessage --auto-id \
+  --field role:ChatMessageRole \
+  --field content:String \
+  --field timestamp:DateTime
+```
+
+The generated entity imports `package:uuid/uuid.dart`; add `uuid` to the
+app's pubspec (`dart pub add uuid`) — zfa warns if it is missing.
+
+### Value objects (`--kind=value_object`)
+
+Entities are aggregate/event roots with identity. Immutable composition
+types (parser options, transformation mappings, embedded value records)
+have no identity of their own — model them as **value objects**:
+
+```bash
+zfa entity create -n ParserConfig --kind=value_object \
+  --field separator:String \
+  --field trimWhitespace:bool
+```
+
+A value object's annotation carries `kind: ZorphyKind.valueObject` (the
+`@ZValueObject` alias is equivalent). Codegen is identical to an entity
+(equality, copyWith, JSON), but `zfa make` treats it as an embedded type:
+repository/usecase/controller/presenter (and the other persisted-root
+plugins) are skipped with a notice — no id is required and the loud
+no-id error never fires for it.
+
+### Id-less entities fail loudly
+
+An entity with no `id` / `*Id` field and no `--auto-id` / value-object
+marker makes `zfa make` fail with a clear diagnostic (instead of silently
+falling back to the first field). The message lists the three fixes: add an
+id field, recreate with `--auto-id`, or model it as a value object.
+
 `--allow-forward-refs` is **opt-in**. The default behaviour (reject unknown
 types) is unchanged — it still guards against typos and genuinely missing
 enums/entities when you are generating a single entity outside a batch.

--- a/lib/src/commands/entity_command.dart
+++ b/lib/src/commands/entity_command.dart
@@ -192,6 +192,8 @@ ${missing.map((d) => '   • $d').join('\n')}
       explicitSubtypes: _asStringList(parsed['subtypes']),
       generateSubtypes: parsed['generate_subs'] as bool? ?? false,
       dryRun: parsed['dry_run'] as bool? ?? false,
+      autoId: parsed['auto_id'] == true,
+      kind: _parseKind(parsed['kind'] as String?),
     );
 
     final creator = EntityCreator(baseOutputDir: outputDir);
@@ -204,6 +206,10 @@ ${missing.map((d) => '   • $d').join('\n')}
       print('  1. Run: zfa build');
       print('  2. Import and use your ${entityConfig.className} class');
 
+      if (entityConfig.autoId) {
+        _warnIfUuidMissing();
+      }
+
       if (fields.isNotEmpty) {
         print('\n✨ Generated ${fields.length} fields:');
         for (final field in fields) {
@@ -213,6 +219,40 @@ ${missing.map((d) => '   • $d').join('\n')}
     } else {
       print('❌ ${result.error}');
       exit(1);
+    }
+  }
+
+  /// autoId entities reference `package:uuid/uuid.dart` in the generated
+  /// code — warn when the app does not depend on it yet.
+  void _warnIfUuidMissing() {
+    final pubspecFile = File('pubspec.yaml');
+    if (!pubspecFile.existsSync()) return;
+    try {
+      final content = pubspecFile.readAsStringSync();
+      if (content.contains(RegExp(r'^\s*uuid\s*:', multiLine: true))) return;
+      print(
+        '⚠️  Generated id uses package:uuid — add it with: dart pub add uuid',
+      );
+    } catch (_) {
+      // Best-effort hint only.
+    }
+  }
+
+  /// Parses the `--kind` flag: `entity` (default) or
+  /// `value_object` / `valueObject`. Anything else aborts with a clear
+  /// message.
+  ZorphyKind _parseKind(String? kind) {
+    switch (kind) {
+      case null:
+      case 'entity':
+        return ZorphyKind.entity;
+      case 'value_object':
+      case 'valueObject':
+      case 'value-object':
+        return ZorphyKind.valueObject;
+      default:
+        print('❌ Unknown kind "$kind". Expected: entity | value_object.');
+        exit(1);
     }
   }
 
@@ -735,6 +775,14 @@ CREATE COMMAND:
     --extends               Interface to extend
     --subtypes              Explicit subtypes
     --generate-subs         Generate subtype files
+    --auto-id               Auto-generate a String id (uuid v4). The id
+                            field is optional at construction and defaults
+                            to a fresh uuid (adds uuid to your pubspec).
+    --kind=<entity|value_object>
+                            Semantic kind. value_object marks an immutable
+                            composition type: no id required and `zfa make`
+                            generates no repository/usecase/controller/
+                            presenter for it.
     --allow-forward-refs    Skip on-disk type validation (batch generation of
                             cyclic schemas — referenced entity is created later)
 
@@ -750,6 +798,10 @@ ADD-FIELD COMMAND:
 EXAMPLES:
   zfa entity create -n User --field id:String --field name:String
   zfa entity create -n Product --field name:String --field price:double --filter
+  zfa entity create -n ChatMessage --auto-id --field role:ChatMessageRole
+    --field content:String --field timestamp:DateTime
+  zfa entity create -n ParserConfig --kind=value_object
+    --field separator:String --field trimWhitespace:bool
   zfa entity enum -n Status --value pending,active,completed
   zfa entity add-field -n User --field email:String?
   zfa entity list

--- a/lib/src/commands/make_command.dart
+++ b/lib/src/commands/make_command.dart
@@ -14,6 +14,33 @@ import '../utils/entity_field_resolver.dart';
 /// Example: `zfa make User route di --force`
 class MakeCommand extends Command<void> {
   static const String fixedOutputDir = 'lib/src';
+
+  /// Plugins that build a persisted/root CRUD surface around an entity.
+  /// Value objects (zuraffa#307) are immutable composition types — none of
+  /// these apply to them, so `zfa make` drops them with a notice instead of
+  /// generating dead repository/usecase/controller/presenter code.
+  static const Set<String> _valueObjectRootPlugins = {
+    'repository',
+    'datasource',
+    'usecase',
+    'controller',
+    'presenter',
+    'view',
+    'route',
+    'state',
+    'provider',
+    'observer',
+    'cache',
+    'gql',
+    'graphql',
+    'di',
+    'service',
+    'api',
+    'sync',
+    'shadcn',
+    'test', // entity tests reference the usecases value objects don't get
+  };
+
   static const Set<String> _ignoredJsonOptionKeys = {
     'domainRoot',
     'domain-root',
@@ -340,36 +367,101 @@ class MakeCommand extends Command<void> {
     );
     context.data.addAll(normalizedOptions);
 
-    // #294: auto-resolve the entity's actual id-like field from the
+    // #294/#307: auto-resolve the entity's actual id-like field from the
     // entity source file so the generated presenter/test/datasource
     // code references a Field constant that exists on the entity's
     // Fields class. Without this, generators hardcode `EntityFields.id`
     // and produce broken code for entities whose id is e.g. `depotId`.
     // User-provided --id-field / --query-field always wins.
+    //
+    // #307: the old resolver fell back to the FIRST field as the id —
+    // for id-less entities whose first field is an enum (ChatMessage.role,
+    // TelemetryEvent.type) that produced enum-typed ids and missing enum
+    // imports. The fallback is gone: id-less entities must opt into
+    // `autoId`, and value objects are treated as embedded types (their
+    // root plugins are dropped below).
     if (context.data['no-entity'] != true) {
-      final resolvedIdField = EntityFieldResolver.resolveIdField(
+      final resolution = EntityFieldResolver.resolveIdField(
         entityName: entityName,
         projectRoot: manager.projectRoot,
       );
-      if (resolvedIdField != null) {
-        if (!argResults!.wasParsed('id-field') &&
-            (context.data['id-field'] == null ||
-                context.data['id-field'] == 'id')) {
-          context.data['id-field'] = resolvedIdField.name;
-          context.data['id-field-type'] = resolvedIdField.nonNullableType;
-          if (context.core.verbose) {
+      if (resolution != null) {
+        if (resolution.isValueObject) {
+          final dropped =
+              activePlugins
+                  .where((p) => _valueObjectRootPlugins.contains(p.id))
+                  .map((p) => p.id)
+                  .toList()
+                ..sort();
+          if (dropped.isNotEmpty) {
             print(
-              '🔍 Resolved id field for "$entityName": '
-              '${resolvedIdField.name} (${resolvedIdField.nonNullableType})',
+              'ℹ️  "$entityName" is a value object — skipping root plugins '
+              '(no repository/usecase/controller/presenter for embedded '
+              'types): ${dropped.join(', ')}',
+            );
+            activePlugins.removeWhere(
+              (p) => _valueObjectRootPlugins.contains(p.id),
             );
           }
-        }
-        if (!argResults!.wasParsed('query-field') &&
-            (context.data['query-field'] == null ||
-                context.data['query-field'] == 'id')) {
-          context.data['query-field'] = resolvedIdField.name;
-          // query-field-type falls back to id-field-type inside
-          // GeneratorConfig's constructor (see generator_config.dart).
+        } else if (resolution.hasId) {
+          if (!argResults!.wasParsed('id-field') &&
+              (context.data['id-field'] == null ||
+                  context.data['id-field'] == 'id')) {
+            context.data['id-field'] = resolution.idField!.name;
+            context.data['id-field-type'] = resolution.idField!.nonNullableType;
+            if (context.core.verbose) {
+              print(
+                '🔍 Resolved id field for "$entityName": '
+                '${resolution.idField!.name} '
+                '(${resolution.idField!.nonNullableType})',
+              );
+            }
+          }
+          if (!argResults!.wasParsed('query-field') &&
+              (context.data['query-field'] == null ||
+                  context.data['query-field'] == 'id')) {
+            context.data['query-field'] = resolution.idField!.name;
+            // query-field-type falls back to id-field-type inside
+            // GeneratorConfig's constructor (see generator_config.dart).
+          }
+        } else {
+          // Loud failure (issue #307): an entity with no id-like field and
+          // no autoId marker would silently produce enum-typed ids /
+          // broken signatures if we fell back to the first field.
+          print(
+            '❌ Cannot generate architecture for "$entityName": the entity '
+            'has no id field.',
+          );
+          print('');
+          print('Entities need a real identity. Choose one of:');
+          print(
+            '  1. Add an id field:    zfa entity add-field -n '
+            '$entityName --field id:String',
+          );
+          print(
+            '  2. Auto-generate one:  recreate with '
+            'zfa entity create -n $entityName --auto-id <fields...>',
+          );
+          print(
+            '  3. Mark it as a value object if it is an immutable '
+            'composition type (no identity, no CRUD surface):',
+          );
+          print(
+            '       zfa entity create -n $entityName --kind=value_object '
+            '<fields...>',
+          );
+          print(
+            '     or add @ZValueObject / kind: ZorphyKind.valueObject '
+            'to its annotation.',
+          );
+          print('');
+          // Thrown (not `exit(1)`) so the CLI runner's catch-all prints the
+          // diagnostic and exits 1 — while `runCapturing` tests can assert
+          // on the message without killing the test isolate.
+          throw MakeCommandException(
+            'Cannot generate architecture for "$entityName": the entity '
+            'has no id field.',
+          );
         }
       }
     }
@@ -506,4 +598,18 @@ class MakeCommand extends Command<void> {
       }
     }
   }
+}
+
+/// Thrown when `zfa make` cannot proceed because of an entity-contract
+/// violation (e.g. an id-less entity without `autoId` — issue #307).
+///
+/// The CLI runner's catch-all prints the message and exits 1; tests using
+/// `runCapturing` catch it without terminating the isolate.
+class MakeCommandException implements Exception {
+  final String message;
+
+  const MakeCommandException(this.message);
+
+  @override
+  String toString() => message;
 }

--- a/lib/src/utils/entity_field_resolver.dart
+++ b/lib/src/utils/entity_field_resolver.dart
@@ -10,17 +10,33 @@
 // like `StorePrice` (whose id field is `depotId`) produced broken
 // generated code that referenced `StorePriceFields.id` (undefined getter).
 //
+// Background (issue #307): the old resolution order fell back to the FIRST
+// declared field when no id-like field existed. For id-less entities whose
+// first field is an enum (`ChatMessage.role`, `TelemetryEvent.type`) that
+// produced enum-typed ids in generated update/toggle signatures plus
+// missing enum imports. The first-field fallback is now REMOVED: an
+// entity without a real identity must either declare an id-like field,
+// opt into `@Zorphy(autoId: true)`, or be a value object
+// (`@ZValueObject` / `kind: ZorphyKind.valueObject`) — anything else is
+// reported as an id-less entity and `zfa make` fails loudly.
+//
 // Resolution order:
 //   1. a field literally named `id`
 //   2. the first field whose name ends with `Id` (e.g. `depotId`, `userId`)
-//   3. the first declared field
+//   3. the synthetic `id: String` when the annotation has `autoId: true`
 //
-// The resolver returns null when the entity file cannot be located or
-// contains no parseable field declarations; in that case the caller
-// keeps its existing default (`'id'`).
+// [resolveIdField] returns null only when the entity file cannot be
+// located or contains no parseable field declarations; in that case the
+// caller keeps its existing default (`'id'`).
 
 import 'dart:io';
 import 'package:path/path.dart' as p;
+
+/// The semantic kind of a Zorphy class, read from its annotation.
+///
+/// Mirrors `ZorphyKind` from the annotation package using source-text
+/// detection so the resolver stays dependency-light.
+enum EntitySourceKind { entity, valueObject }
 
 /// A single parsed field declaration: a Dart type string and a field name.
 class EntityFieldInfo {
@@ -48,6 +64,37 @@ class EntityFieldInfo {
   String toString() => 'EntityFieldInfo(name: $name, type: $type)';
 }
 
+/// The result of resolving an entity's identity: its kind, whether it
+/// opts into `autoId`, and the resolved id-like field (if any).
+///
+/// [idField] is null for value objects (no identity required) and for
+/// entities that declare neither an id-like field nor `autoId` — callers
+/// must treat the latter as a loud error (see `zfa make`).
+class EntityIdResolution {
+  /// The semantic kind of the entity.
+  final EntitySourceKind kind;
+
+  /// Whether the annotation carries `autoId: true`.
+  final bool autoId;
+
+  /// The resolved id-like field, or null when the entity has no identity
+  /// (value objects) or none could be resolved (id-less entity).
+  final EntityFieldInfo? idField;
+
+  const EntityIdResolution({
+    required this.kind,
+    required this.autoId,
+    this.idField,
+  });
+
+  /// True when this is a value object (no id needed, no CRUD surface).
+  bool get isValueObject => kind == EntitySourceKind.valueObject;
+
+  /// True when an identity field is available — either a real source field
+  /// or the synthetic `id: String` promised by `autoId: true`.
+  bool get hasId => idField != null || autoId;
+}
+
 /// Reads a Zorphy entity source file and resolves the entity's id-like
 /// field. See the file doc comment for the resolution order.
 class EntityFieldResolver {
@@ -62,7 +109,7 @@ class EntityFieldResolver {
   ///
   /// [entityOutputDir] defaults to [defaultEntityOutputDir] but can be
   /// overridden (e.g. in tests).
-  static EntityFieldInfo? resolveIdField({
+  static EntityIdResolution? resolveIdField({
     required String entityName,
     required String projectRoot,
     String entityOutputDir = defaultEntityOutputDir,
@@ -73,20 +120,73 @@ class EntityFieldResolver {
     );
     if (!entityFile.existsSync()) return null;
 
-    final fields = parseEntityFields(entityFile.readAsStringSync());
+    final content = entityFile.readAsStringSync();
+    final fields = parseEntityFields(content);
     if (fields.isEmpty) return null;
+
+    final autoId = detectsAutoId(content);
+    final kind = detectsValueObject(content)
+        ? EntitySourceKind.valueObject
+        : EntitySourceKind.entity;
+
+    // Value objects have no identity — never resolve (or invent) an id.
+    if (kind == EntitySourceKind.valueObject) {
+      return EntityIdResolution(kind: kind, autoId: autoId);
+    }
 
     // 1. literal `id`
     for (final f in fields) {
-      if (f.name == 'id') return f;
+      if (f.name == 'id') {
+        return EntityIdResolution(kind: kind, autoId: autoId, idField: f);
+      }
     }
     // 2. first ending in `Id` (camelCase, length > 2 to avoid matching `Id`)
     for (final f in fields) {
-      if (f.name.length > 2 && f.name.endsWith('Id')) return f;
+      if (f.name.length > 2 && f.name.endsWith('Id')) {
+        return EntityIdResolution(kind: kind, autoId: autoId, idField: f);
+      }
     }
-    // 3. first declared field
-    return fields.first;
+    // 3. synthetic `id: String` promised by `autoId: true` (issue #307 —
+    //    the generator defaults the concrete constructor's id to a uuid).
+    if (autoId) {
+      return EntityIdResolution(
+        kind: kind,
+        autoId: autoId,
+        idField: const EntityFieldInfo(name: 'id', type: 'String'),
+      );
+    }
+
+    // No identity: id-less entity. `zfa make` must fail loudly.
+    return EntityIdResolution(kind: kind, autoId: autoId);
   }
+
+  /// Detects `autoId: true` inside a `@Zorphy(...)`/`@Zorphy2(...)`
+  /// annotation in [content].
+  static bool detectsAutoId(String content) {
+    final match = _zorphyAnnotationPattern.firstMatch(content);
+    final args = match?.group(1);
+    if (args == null) return false;
+    return RegExp(r'\bautoId\s*:\s*true\b').hasMatch(args);
+  }
+
+  /// Detects a value-object kind in [content]: either the `@ZValueObject`
+  /// annotation alias or `kind: ZorphyKind.valueObject` inside
+  /// `@Zorphy(...)`.
+  static bool detectsValueObject(String content) {
+    if (RegExp(r'@\s*ZValueObject\b').hasMatch(content)) return true;
+    final match = _zorphyAnnotationPattern.firstMatch(content);
+    final args = match?.group(1);
+    if (args == null) return false;
+    return RegExp(
+      r'\bkind\s*:\s*(?:ZorphyKind\.)?valueObject\b',
+    ).hasMatch(args);
+  }
+
+  /// Matches `@Zorphy(...)` / `@zorphy(...)` / `@Zorphy2(...)` annotation
+  /// invocations (with or without an argument list).
+  static final RegExp _zorphyAnnotationPattern = RegExp(
+    r'@\s*(?:Zorphy|zorphy|Zorphy2)\s*(\(([^)]*)\))?',
+  );
 
   /// Parses `<entity>.dart` source content for field declarations.
   ///

--- a/test/commands/make_command_test.dart
+++ b/test/commands/make_command_test.dart
@@ -231,4 +231,181 @@ class Product {
       },
     );
   });
+
+  group('MakeCommand #307 identity contract', () {
+    late Directory workspace;
+    late String outputDir;
+    late String zfaSourceBin;
+
+    // Runs zfa from SOURCE (never the stale compiled ~/.local/bin/zfa) as a
+    // subprocess with an explicit workingDirectory — no process-global
+    // `Directory.current` mutation, so this group cannot race with other
+    // test files that capture the cwd at load time (see #296 test).
+    Future<ProcessResult> runZfaSource(List<String> args) {
+      return Process.run('dart', [
+        zfaSourceBin,
+        ...args,
+      ], workingDirectory: workspace.path);
+    }
+
+    setUpAll(() async {
+      final projectRoot = await findProjectRoot();
+      zfaSourceBin = path.join(projectRoot, 'bin', 'zfa.dart');
+    });
+
+    setUp(() async {
+      workspace = await Directory.systemTemp.createTemp('zfa_make_identity_');
+      outputDir = path.join(workspace.path, 'lib', 'src');
+      await Directory(outputDir).create(recursive: true);
+      await File(path.join(workspace.path, 'pubspec.yaml')).writeAsString('''
+name: zuraffa_make_identity_test
+environment:
+  sdk: ^3.11.0
+dependencies:
+  uuid: ^4.6.0
+''');
+    });
+
+    tearDown(() async {
+      if (workspace.existsSync()) {
+        await workspace.delete(recursive: true);
+      }
+    });
+
+    Future<void> writeEntity(String name, String content) async {
+      final snake = name.replaceAllMapped(
+        RegExp(r'[A-Z]'),
+        (m) => (m.start == 0 ? '' : '_') + m.group(0)!.toLowerCase(),
+      );
+      final dir = Directory(path.join(outputDir, 'domain', 'entities', snake));
+      await dir.create(recursive: true);
+      await File(path.join(dir.path, '$snake.dart')).writeAsString(content);
+    }
+
+    test(
+      '#307 — an id-less entity fails loudly instead of falling back to its '
+      'first (enum) field',
+      timeout: const Timeout(Duration(minutes: 2)),
+      () async {
+        await writeEntity('ChatMessage', '''
+import 'package:zorphy_annotation/zorphy_annotation.dart';
+
+@Zorphy(generateJson: true, generateCompareTo: true)
+abstract class \$ChatMessage {
+  ChatMessageRole get role;
+  String get content;
+  DateTime get timestamp;
+}
+''');
+
+        final result = await runZfaSource([
+          'make',
+          'ChatMessage',
+          '--preset=crud',
+          '--with=vpc,state,di,test,mock',
+          '--output',
+          outputDir,
+        ]);
+
+        expect(result.exitCode, isNot(0));
+        expect(
+          result.stdout as String,
+          contains('has no id field'),
+          reason: 'stdout: ${result.stdout}',
+        );
+        // The enum-typed-id fallback must never happen.
+        expect(result.stdout as String, isNot(contains('Resolved id field')));
+      },
+    );
+
+    test(
+      '#307 — autoId: true resolves the identity to a String id even without '
+      'an id getter in the source',
+      timeout: const Timeout(Duration(minutes: 2)),
+      () async {
+        await writeEntity('TelemetryEvent', '''
+import 'package:zorphy_annotation/zorphy_annotation.dart';
+
+@Zorphy(generateJson: true, autoId: true)
+abstract class \$TelemetryEvent {
+  TelemetryEventType get type;
+  String get value;
+}
+''');
+
+        final result = await runZfaSource([
+          'make',
+          'TelemetryEvent',
+          '--preset=crud',
+          '--with=vpc',
+          '--verbose',
+          '--output',
+          outputDir,
+        ]);
+
+        expect(result.exitCode, 0, reason: 'stderr: ${result.stderr}');
+        expect(
+          result.stdout as String,
+          contains('Resolved id field for "TelemetryEvent": id (String)'),
+          reason: 'stdout: ${result.stdout}',
+        );
+      },
+    );
+
+    test(
+      'value object — make skips the root plugins and does not generate '
+      'repository/usecase/controller/presenter',
+      timeout: const Timeout(Duration(minutes: 2)),
+      () async {
+        await writeEntity('ParserConfig', '''
+import 'package:zorphy_annotation/zorphy_annotation.dart';
+
+@ZValueObject
+abstract class \$ParserConfig {
+  String get separator;
+  bool get trimWhitespace;
+}
+''');
+
+        final result = await runZfaSource([
+          'make',
+          'ParserConfig',
+          '--preset=crud',
+          '--with=vpc,state,di,test,mock',
+          '--output',
+          outputDir,
+        ]);
+
+        expect(result.exitCode, 0, reason: 'stderr: ${result.stderr}');
+        final stdout = result.stdout as String;
+        expect(stdout, contains('is a value object — skipping root plugins'));
+        expect(stdout, contains('usecase'));
+        expect(stdout, contains('presenter'));
+
+        // No persisted/root surface is generated...
+        final domainUsecases = Directory(
+          path.join(outputDir, 'domain', 'usecases'),
+        );
+        expect(domainUsecases.existsSync(), isFalse);
+        final domainRepos = Directory(
+          path.join(outputDir, 'domain', 'repositories'),
+        );
+        expect(domainRepos.existsSync(), isFalse);
+        // ...but embedded-type tooling (mock data) still runs.
+        final dataDir = Directory(path.join(outputDir, 'data'));
+        expect(
+          dataDir.existsSync() &&
+              dataDir
+                  .listSync(recursive: true)
+                  .any(
+                    (f) =>
+                        f.path.endsWith('parser_config_mock_data.dart') ||
+                        f.path.endsWith('parser_config_mock_entity.dart'),
+                  ),
+          isTrue,
+          reason: 'expected mock data under ${dataDir.path}',
+        );
+      },
+    );
+  });
 }

--- a/test/regression/issue_294_entity_without_id_test.dart
+++ b/test/regression/issue_294_entity_without_id_test.dart
@@ -68,8 +68,8 @@ void main() {
           isNotNull,
           reason: 'Resolver should find depotId for StorePrice',
         );
-        expect(resolved!.name, 'depotId');
-        expect(resolved.type, 'String');
+        expect(resolved!.idField!.name, 'depotId');
+        expect(resolved.idField!.type, 'String');
       },
     );
 
@@ -212,7 +212,7 @@ void main() {
       );
 
       expect(resolved, isNotNull);
-      expect(resolved!.name, 'storeId');
+      expect(resolved!.idField!.name, 'storeId');
     });
   });
 

--- a/test/regression/issue_302_toggle_param_collision_test.dart
+++ b/test/regression/issue_302_toggle_param_collision_test.dart
@@ -65,34 +65,37 @@ void main() {
   });
 
   group('#302 — toggle param name collision when entity field is `value`', () {
-    test(
-      'EntityFieldResolver resolves `value` as the id field for Barcode',
-      () async {
-        await writeEntityStubWithoutId(
-          workspace,
-          name: 'Barcode',
-          fields: const [
-            (name: 'value', type: 'String'),
-            (name: 'format', type: 'String'),
-          ],
-        );
+    test('#307 contract — an id-less Barcode resolves no id (no silent '
+        'first-field fallback to `value`)', () async {
+      await writeEntityStubWithoutId(
+        workspace,
+        name: 'Barcode',
+        fields: const [
+          (name: 'value', type: 'String'),
+          (name: 'format', type: 'String'),
+        ],
+      );
 
-        final resolved = EntityFieldResolver.resolveIdField(
-          entityName: 'Barcode',
-          projectRoot: workspace.directory.path,
-        );
+      final resolved = EntityFieldResolver.resolveIdField(
+        entityName: 'Barcode',
+        projectRoot: workspace.directory.path,
+      );
 
-        expect(
-          resolved,
-          isNotNull,
-          reason:
-              'Resolver should fall back to the first declared field '
-              '(`value`) when no `id`/`*Id` field exists',
-        );
-        expect(resolved!.name, 'value');
-        expect(resolved.type, 'String');
-      },
-    );
+      expect(
+        resolved,
+        isNotNull,
+        reason:
+            'Resolver should resolve the id-less Barcode contract without '
+            'silently falling back to the first field',
+      );
+      // #307: no `id` / `*Id` / `autoId` → id-less entity (zfa make fails
+      // loudly). The `value`-as-id toggle-collision scenario (#302) now
+      // requires an explicit `--id-field=value` on `zfa make`.
+      expect(resolved!.kind, EntitySourceKind.entity);
+      expect(resolved.autoId, isFalse);
+      expect(resolved.idField, isNull);
+      expect(resolved.hasId, isFalse);
+    });
 
     test('generated controller + presenter use `toggleValue` for the bool param '
         'and forward it into ToggleParams (no duplicate `value`)', () async {

--- a/test/utils/entity_field_resolver_test.dart
+++ b/test/utils/entity_field_resolver_test.dart
@@ -1,8 +1,13 @@
-// Tests for EntityFieldResolver (#294 Gap 1).
+// Tests for EntityFieldResolver (#294 Gap 1, #307 identity contract).
 //
 // Covers:
-//   - the three id-resolution branches (literal `id`, first ending in `Id`,
-//     first declared field)
+//   - the id-resolution branches (literal `id`, first ending in `Id`,
+//     synthetic `id: String` for `autoId: true`)
+//   - the #307 behavior: NO silent first-field fallback — an entity with
+//     no id-like field and no autoId resolves with a null idField so the
+//     caller (`zfa make`) fails loudly
+//   - value objects (`@ZValueObject` / `kind: ZorphyKind.valueObject`)
+//     resolve with no id at all
 //   - null when the entity file does not exist
 //   - null when the entity file has no parseable field declarations
 //   - nullable types are stripped from the returned type via `nonNullableType`
@@ -64,9 +69,12 @@ abstract class \$Product {
         projectRoot: tempRoot.path,
       );
       expect(resolved, isNotNull);
-      expect(resolved!.name, 'id');
-      expect(resolved.type, 'String');
-      expect(resolved.nonNullableType, 'String');
+      expect(resolved!.kind, EntitySourceKind.entity);
+      expect(resolved.autoId, isFalse);
+      expect(resolved.hasId, isTrue);
+      expect(resolved.idField!.name, 'id');
+      expect(resolved.idField!.type, 'String');
+      expect(resolved.idField!.nonNullableType, 'String');
     });
 
     test(
@@ -85,26 +93,118 @@ abstract class \$StorePrice {
           projectRoot: tempRoot.path,
         );
         expect(resolved, isNotNull);
-        expect(resolved!.name, 'depotId');
-        expect(resolved.type, 'String');
+        expect(resolved!.idField!.name, 'depotId');
+        expect(resolved.idField!.type, 'String');
       },
     );
 
-    test('branch 3 — falls back to the first declared field when there is no '
-        '`id` and no `*Id` field', () async {
-      await writeEntity('GroceryPriceResult', '''
-abstract class \$GroceryPriceResult {
-  String get storeName;
-  double get price;
+    test(
+      '#307 — NO silent first-field fallback: an entity with no `id` and no '
+      '`*Id` field resolves with a null idField (caller must fail loudly)',
+      () async {
+        // Exact #307 shape: first field is an enum-typed getter.
+        await writeEntity('ChatMessage', '''
+abstract class \$ChatMessage {
+  ChatMessageRole get role;
+  String get content;
+  DateTime get timestamp;
+}
+''');
+        final resolved = EntityFieldResolver.resolveIdField(
+          entityName: 'ChatMessage',
+          projectRoot: tempRoot.path,
+        );
+        expect(resolved, isNotNull);
+        expect(resolved!.kind, EntitySourceKind.entity);
+        expect(resolved.autoId, isFalse);
+        expect(resolved.hasId, isFalse);
+        expect(resolved.idField, isNull);
+      },
+    );
+
+    test('autoId: true — resolves the synthetic id field as String even when '
+        'the entity declares no id getter', () async {
+      await writeEntity('TelemetryEvent', '''
+import 'package:zorphy_annotation/zorphy_annotation.dart';
+
+@Zorphy(generateJson: true, autoId: true)
+abstract class \$TelemetryEvent {
+  TelemetryEventType get type;
+  String get value;
 }
 ''');
       final resolved = EntityFieldResolver.resolveIdField(
-        entityName: 'GroceryPriceResult',
+        entityName: 'TelemetryEvent',
         projectRoot: tempRoot.path,
       );
       expect(resolved, isNotNull);
-      expect(resolved!.name, 'storeName');
-      expect(resolved.type, 'String');
+      expect(resolved!.autoId, isTrue);
+      expect(resolved.hasId, isTrue);
+      expect(resolved.idField!.name, 'id');
+      expect(resolved.idField!.type, 'String');
+    });
+
+    test(
+      'autoId + explicit id getter — the real field wins, type preserved',
+      () async {
+        await writeEntity('AuthSession', '''
+import 'package:zorphy_annotation/zorphy_annotation.dart';
+
+@Zorphy(generateJson: true, autoId: true)
+abstract class \$AuthSession {
+  String get id;
+  String get token;
+}
+''');
+        final resolved = EntityFieldResolver.resolveIdField(
+          entityName: 'AuthSession',
+          projectRoot: tempRoot.path,
+        );
+        expect(resolved, isNotNull);
+        expect(resolved!.autoId, isTrue);
+        expect(resolved.idField!.name, 'id');
+        expect(resolved.idField!.type, 'String');
+      },
+    );
+
+    test('value object — no id resolved, kind is valueObject', () async {
+      await writeEntity('ParserConfig', '''
+import 'package:zorphy_annotation/zorphy_annotation.dart';
+
+@ZValueObject
+abstract class \$ParserConfig {
+  String get separator;
+  bool get trimWhitespace;
+}
+''');
+      final resolved = EntityFieldResolver.resolveIdField(
+        entityName: 'ParserConfig',
+        projectRoot: tempRoot.path,
+      );
+      expect(resolved, isNotNull);
+      expect(resolved!.kind, EntitySourceKind.valueObject);
+      expect(resolved.isValueObject, isTrue);
+      expect(resolved.idField, isNull);
+      expect(resolved.hasId, isFalse);
+    });
+
+    test('value object via @Zorphy(kind: ZorphyKind.valueObject)', () async {
+      await writeEntity('MapTransformationOptions', '''
+import 'package:zorphy_annotation/zorphy_annotation.dart';
+
+@Zorphy(kind: ZorphyKind.valueObject, generateJson: true)
+abstract class \$MapTransformationOptions {
+  String get sourceKey;
+  String get targetKey;
+}
+''');
+      final resolved = EntityFieldResolver.resolveIdField(
+        entityName: 'MapTransformationOptions',
+        projectRoot: tempRoot.path,
+      );
+      expect(resolved, isNotNull);
+      expect(resolved!.isValueObject, isTrue);
+      expect(resolved.idField, isNull);
     });
 
     test(
@@ -122,7 +222,7 @@ abstract class \$Audit {
           projectRoot: tempRoot.path,
         );
         expect(resolved, isNotNull);
-        expect(resolved!.name, 'id');
+        expect(resolved!.idField!.name, 'id');
       },
     );
 
@@ -138,9 +238,9 @@ abstract class \$Counter {
         projectRoot: tempRoot.path,
       );
       expect(resolved, isNotNull);
-      expect(resolved!.name, 'id');
-      expect(resolved.type, 'int');
-      expect(resolved.nonNullableType, 'int');
+      expect(resolved!.idField!.name, 'id');
+      expect(resolved.idField!.type, 'int');
+      expect(resolved.idField!.nonNullableType, 'int');
     });
 
     test('strips trailing `?` from nullable field types', () async {
@@ -155,9 +255,9 @@ abstract class \$SoftId {
         projectRoot: tempRoot.path,
       );
       expect(resolved, isNotNull);
-      expect(resolved!.name, 'maybeId');
-      expect(resolved.type, 'String?');
-      expect(resolved.nonNullableType, 'String');
+      expect(resolved!.idField!.name, 'maybeId');
+      expect(resolved.idField!.type, 'String?');
+      expect(resolved.idField!.nonNullableType, 'String');
     });
 
     test('handles Map<K, V> field types (parse + nonNullableType)', () async {
@@ -172,11 +272,9 @@ abstract class \$WithMap {
         projectRoot: tempRoot.path,
       );
       expect(resolved, isNotNull);
-      expect(resolved!.name, 'metadata');
-      expect(resolved.type, contains('Map<String, dynamic>'));
-      // nonNullableType strips the trailing `?` if present, but leaves
-      // the rest of the type intact.
-      expect(resolved.nonNullableType, 'Map<String, dynamic>');
+      // No id-like field: id-less entity, not a value object.
+      expect(resolved!.kind, EntitySourceKind.entity);
+      expect(resolved.hasId, isFalse);
     });
 
     test('returns null when entity file has no field declarations', () async {
@@ -202,9 +300,10 @@ class Handwritten {
         entityName: 'Handwritten',
         projectRoot: tempRoot.path,
       );
+      // `slug` is not id-like → id-less entity (no silent fallback, #307).
       expect(resolved, isNotNull);
-      expect(resolved!.name, 'slug');
-      expect(resolved.type, 'String');
+      expect(resolved!.kind, EntitySourceKind.entity);
+      expect(resolved.hasId, isFalse);
     });
 
     test('ignores field-like text inside block comments', () async {
@@ -220,12 +319,12 @@ abstract class \$Commented {
         projectRoot: tempRoot.path,
       );
       expect(resolved, isNotNull);
-      expect(resolved!.name, 'realId');
+      expect(resolved!.idField!.name, 'realId');
     });
 
     test('respects an explicit `Id` suffix (not just `Id` literal)', () async {
       // `Id` itself (length 2) should NOT match branch 2 — too ambiguous.
-      // Fall through to branch 3 (first field).
+      // With no `id` / `*Id` / autoId the entity is id-less (#307).
       await writeEntity('Ambiguous', '''
 abstract class \$Ambiguous {
   String get Id;
@@ -237,7 +336,50 @@ abstract class \$Ambiguous {
         projectRoot: tempRoot.path,
       );
       expect(resolved, isNotNull);
-      expect(resolved!.name, 'Id'); // first declared field, branch 3
+      expect(resolved!.kind, EntitySourceKind.entity);
+      expect(resolved.hasId, isFalse);
+      expect(resolved.idField, isNull);
+    });
+  });
+
+  group('annotation detection', () {
+    test('detectsAutoId only inside a Zorphy annotation arg list', () {
+      expect(
+        EntityFieldResolver.detectsAutoId('@Zorphy(autoId: true)'),
+        isTrue,
+      );
+      expect(
+        EntityFieldResolver.detectsAutoId(
+          '@Zorphy(generateJson: true, autoId: true)',
+        ),
+        isTrue,
+      );
+      expect(
+        EntityFieldResolver.detectsAutoId('@Zorphy(generateJson: true)'),
+        isFalse,
+      );
+      expect(
+        EntityFieldResolver.detectsAutoId('// autoId: true (comment)'),
+        isFalse,
+      );
+    });
+
+    test('detectsValueObject via @ZValueObject and kind:', () {
+      expect(EntityFieldResolver.detectsValueObject('@ZValueObject'), isTrue);
+      expect(
+        EntityFieldResolver.detectsValueObject(
+          '@Zorphy(kind: ZorphyKind.valueObject)',
+        ),
+        isTrue,
+      );
+      expect(
+        EntityFieldResolver.detectsValueObject('@Zorphy(kind: valueObject)'),
+        isTrue,
+      );
+      expect(
+        EntityFieldResolver.detectsValueObject('@Zorphy(generateJson: true)'),
+        isFalse,
+      );
     });
   });
 


### PR DESCRIPTION
## What

Fills the three framework gaps behind **zuraffa#307** (ChatMessage/TelemetryEvent, 48 analyze errors). The zorphy-side additions (`autoId` + `ZorphyKind.valueObject` + `@ZValueObject`) land in [arrrrny/zorphy@development](https://github.com/arrrrny/zorphy) (already pushed, 2.2.0). This PR is the zuraffa-side contract.

### 1. Loud no-id error (was: silent first-field fallback — the #307 root cause)

`EntityFieldResolver` no longer falls back to the FIRST declared field as the id. An entity with no `id` / `*Id` field and no `autoId` / value-object marker now makes `zfa make` **fail loudly** with a diagnostic listing the three fixes (add an id field, `--auto-id`, or model as a value object). The enum-typed-id signature bug (`ToggleParams<ChatMessageRole, ...>`) is impossible by construction.

### 2. autoId support

`@Zorphy(autoId: true)` + `String get id;` → the generated concrete constructor takes an optional `String? id` defaulting to `Uuid().v4()` (zorphy side). `zfa make` resolves the identity to `id`/`String`. `zfa entity create --auto-id` declares the id getter, adds the annotation option and the `package:uuid/uuid.dart` import (warns if the app lacks the `uuid` dep).

### 3. ValueObject kind

`@ZValueObject` / `kind: ZorphyKind.valueObject` marks an immutable composition type with no identity. `zfa entity create --kind=value_object` end-to-end. `zfa make` skips the root plugins (repository, datasource, usecase, controller, presenter, view, route, state, provider, observer, cache, gql, graphql, di, service, api, sync, shadcn, test) with a notice; embedded-type tooling (mock) still runs. Equality/copyWith/JSON identical to an entity.

## #307 gap 2 (enum imports)

The 48-error repro was driven entirely by the enum-typed-id fallback — eliminated here. `CommonPatterns.entityImports` already resolves enum types to the enums barrel (`domain/entities/enums/index.dart`) when a type flows through it; with id types now always `String` (or an explicit scalar id), no enum type leaks into generated update/toggle signatures. Test fixtures confirm the generated presenter emits `UpdateParams<String, ChatMessagePatch>` / `ToggleParams<String, ...>`.

## Verification

- zorphy: golden tests lock `this.id = id ?? const Uuid().v4()` + the value-object surface; example fixtures compile + run (uuid auto-generated, explicit id override works).
- zuraffa: resolver unit tests (id-less contract, autoId synthetic id, valueObject); make-command CLI tests (loud error, autoId resolution, value-object plugin filtering — run as subprocesses to avoid process-global cwd races); updated #294/#302 regression tests. Full suite green (1266 serial / parallel).
- End-to-end scratch project: `zfa entity create --auto-id` + `--kind=value_object`, `zfa build`, `dart analyze` clean, runtime uuid verified.

## Migration note (follow-up, not in this PR)

The 88 id-less zik_zak entities split as: aggregate/event roots (`ChatMessage`, `TelemetryEvent`, …) → `--auto-id` entities; parser/options/mapping composition types (`parser_config`, `string_between_parser_options`, `value_mapping`, `map_transformation_options`, `filter_value_mapping`, `barcode_lookup_result`, `store_price`, …) → `--kind=value_object`. The v6-migration kimi resumes after this merges (rebuild zfa, re-run `zfa make` for chat_message + telemetry_event).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `--auto-id` to generate string identifiers for entities.
  - Added `--kind` support for entities and value objects, including aliases.
  - Added support for forward references and cyclic graphs with `--allow-forward-refs`.
  - Value objects now skip persisted-root plugins while retaining mock-data tooling.

- **Bug Fixes**
  - ID-less entities now fail clearly instead of using the first field as an ID.
  - Added validation and guidance for missing UUID support and invalid kind values.

- **Documentation**
  - Expanded the CLI guide with the new options and validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->