### PR TITLE
fix(zfa route create): emit go_router import in generated routing files (#325)

### DIFF
--- a/lib/src/plugins/route/builders/app_routes_builder.dart
+++ b/lib/src/plugins/route/builders/app_routes_builder.dart
@@ -48,6 +48,7 @@ class AppRoutesBuilder {
     );
 
     final directives = <Directive>[
+      Directive.import('package:go_router/go_router.dart'),
       Directive.import('package:flutter/material.dart'),
       Directive.import('package:zuraffa/zuraffa.dart'),
       if (entityRouteImport != null) Directive.import('./index.dart'),

--- a/lib/src/plugins/route/builders/route_builder.dart
+++ b/lib/src/plugins/route/builders/route_builder.dart
@@ -486,6 +486,7 @@ class RouteBuilder {
     ];
 
     final imports = [
+      'package:go_router/go_router.dart',
       'package:zuraffa/zuraffa.dart',
       '../presentation/pages/$domainSnake/${entitySnake}_view.dart',
       if (hasListView && hasDetailView)
@@ -850,6 +851,7 @@ class RouteBuilder {
 
     final exports = <Directive>[Directive.export('app_routes.dart')];
     final imports = <Directive>[
+      Directive.import('package:go_router/go_router.dart'),
       Directive.import('package:zuraffa/zuraffa.dart'),
     ];
     final routeElements = <Expression>[];
@@ -1063,6 +1065,9 @@ class RouteBuilder {
 
   String _ensureAppRoutesImports(String source) {
     var content = source;
+    if (!content.contains("import 'package:go_router/go_router.dart';")) {
+      content = "import 'package:go_router/go_router.dart';\n$content";
+    }
     if (!content.contains("import 'package:flutter/material.dart';")) {
       content = "import 'package:flutter/material.dart';\n$content";
     }

--- a/test/plugins/route/route_builder_test.dart
+++ b/test/plugins/route/route_builder_test.dart
@@ -45,9 +45,14 @@ void main() {
     final entityRoutes = File('$outputDir/routing/product_routes.dart');
     expect(appRoutes.existsSync(), isTrue);
     expect(entityRoutes.existsSync(), isTrue);
+    // Regression #325: app_routes.dart must import go_router
+    final appContent = appRoutes.readAsStringSync();
+    expect(appContent.contains('package:go_router/go_router.dart'), isTrue);
     final content = entityRoutes.readAsStringSync();
     expect(content.contains('/product'), isTrue);
     expect(content.contains('/product/create'), isTrue);
+    // Regression #325: go_router import must be present
+    expect(content.contains('package:go_router/go_router.dart'), isTrue);
   });
 
   test('generates routes for custom usecase with domain', () async {
@@ -289,6 +294,8 @@ void main() {
     // Verify it doesn't contain getListingRoutes() or getProductRoutes()
     expect(content.contains("getListingRoutes()"), isFalse);
     expect(content.contains("getProductRoutes()"), isFalse);
+    // Regression #325: index.dart must import go_router (for List<GoRoute>)
+    expect(content.contains('package:go_router/go_router.dart'), isTrue);
   });
 
   test('generates extension methods with leading slash', () async {


### PR DESCRIPTION
## Problem

`zfa route create` emits `GoRoute` and `go()` references in generated routing code but never imports `package:go_router/go_router.dart`, causing 425 analyze errors across the generated routing layer.

Affected generated files:
- `*_routes.dart` (per-entity): uses `GoRoute` without importing go_router
- `app_routes.dart`: uses `go()` (go_router BuildContext extension) without importing go_router
- `index.dart`: uses `List<GoRoute>` return type without importing go_router

## Root Cause

The route generator builders (`AppRoutesBuilder`, `EntityRoutesBuilder`) and the `_ensureAppRoutesImports` helper in `RouteBuilder` only emitted imports for `package:flutter/material.dart` and `package:zuraffa/zuraffa.dart`, omitting `package:go_router/go_router.dart` which is required for `GoRoute`, `go()`, and related symbols.

## Fix

Add `package:go_router/go_router.dart` import to all four generation paths:

1. **`app_routes_builder.dart`**: Add go_router import to the directives list (for `go()` extension and `GoRoute`)
2. **`route_builder.dart` entity imports**: Add go_router to the entity route imports list (for `GoRoute`)
3. **`route_builder.dart` index imports**: Add go_router to index.dart imports (for `List<GoRoute>` return type)
4. **`route_builder.dart` `_ensureAppRoutesImports()`**: Add go_router import check for update/append path

## Testing

- All 7 route builder tests pass
- All 11 route plugin tests pass  
- All 12 DDA route golden tests pass
- Added regression assertions verifying go_router import presence in:
  - Entity routes file
  - App routes file
  - Index file
- `dart analyze` on route plugin code: 0 issues

Fixes #325

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated generated routing files to include the required `go_router` import.
  * Improved compatibility and reliability when using generated application and entity routes.
  * Ensured generated routing indexes and app routes consistently include the necessary routing dependency.

* **Tests**
  * Added regression coverage to verify required imports remain present in all generated route files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->