### PR TITLE
fix(zfa make --revert): deep-clean orphan architecture after VO re-model (#323)

### DIFF
--- a/lib/src/core/plugin_system/plugin_manager.dart
+++ b/lib/src/core/plugin_system/plugin_manager.dart
@@ -1,6 +1,7 @@
 import 'package:args/args.dart';
 import 'package:path/path.dart' as path;
 import '../../config/zfa_config.dart';
+import '../../utils/string_utils.dart';
 import '../../cli/plugin_loader.dart';
 import '../context/file_system.dart';
 import '../context/progress_reporter.dart';
@@ -239,6 +240,23 @@ class PluginManager {
   }
 
   Future<List<GeneratedFile>> _handleRevert(PluginContext context) async {
+    final files = <GeneratedFile>[];
+
+    // 1. Deep revert (issue #323): delete the canonical entity-snake-keyed
+    //    architecture files for this entity, regardless of what the current
+    //    or last run produced. This handles the re-modeled-as-value_object
+    //    case where the saved plan was overwritten by an empty run and the
+    //    historical CRUD orphans remain on disk. It also makes
+    //    `zfa make <Entity> --revert` mean "remove the entity's generated
+    //    architecture" uniformly — whether the entity is currently an
+    //    entity, a value object, or anything else.
+    files.addAll(await _deepRevertEntityArchitecture(context));
+
+    // 2. Plan-based revert: restore shared files (route registrations, DI
+    //    aggregators) to their previous content. This complements the deep
+    //    revert, which only deletes entity-keyed files. For `create`
+    //    actions on entity-keyed files, the deep revert has already removed
+    //    them — the existence check below naturally skips those.
     final planId = 'last_run_${context.core.name}';
     final report = await PlanStore.instance.loadPlan(
       planId,
@@ -248,16 +266,18 @@ class PluginManager {
     if (report == null) {
       if (context.core.verbose) {
         print(
-          '  ⚠️ No saved plan found for ${context.core.name} in $projectRoot. Falling back to heuristic revert.',
+          '  ⚠️ No saved plan found for ${context.core.name} in $projectRoot. '
+          'Relying on deep revert only.',
         );
       }
-      return []; // Return empty to let legacy revert handle it or just fail gracefully
+      // Still return the deep-revert deletions (previously this returned
+      // `[]`, which silently swallowed the orphan-architecture case).
+      return files;
     }
 
-    final files = <GeneratedFile>[];
     if (context.core.verbose) {
       print(
-        '  🔄 Reverting ${report.changes.length} changes from plan in $projectRoot...',
+        '  🔄 Reverting ${report.changes.length} tracked changes from plan in $projectRoot...',
       );
     }
 
@@ -305,6 +325,179 @@ class PluginManager {
 
     await PlanStore.instance.deletePlan(planId, baseDir: projectRoot);
     return files;
+  }
+
+  /// Deletes all canonical generated-architecture files for the entity
+  /// named [context.core.name], regardless of whether the current run
+  /// generated them.
+  ///
+  /// This is the "deep revert" path (issue #323): when an entity is
+  /// re-modeled as a value object, the previously generated CRUD
+  /// architecture stays on disk as orphans because `zfa make` for a
+  /// value object generates nothing and overwrites the saved plan with
+  /// an empty one. Deep revert walks the canonical entity-snake-keyed
+  /// paths the generators would produce and deletes those that exist,
+  /// so `zfa make <Entity> --revert` cleans up the entity's generated
+  /// architecture uniformly.
+  ///
+  /// The entity source file itself
+  /// (`lib/src/domain/entities/<snake>/<snake>.dart`) is NEVER touched —
+  /// the entity is the source of truth, not generated architecture.
+  /// Re-modeling the entity (entity ↔ value_object, field changes) is
+  /// the user's job; `--revert` only removes generated architecture.
+  ///
+  /// Dry-run mode lists files that would be deleted without touching
+  /// the filesystem, mirroring the plan-based revert's dry-run behavior.
+  Future<List<GeneratedFile>> _deepRevertEntityArchitecture(
+    PluginContext context,
+  ) async {
+    final entityName = context.core.name;
+    final snake = StringUtils.camelToSnake(entityName);
+    final fs = context.fileSystem;
+    final dryRun = context.core.dryRun;
+    final verbose = context.core.verbose;
+    final deleted = <GeneratedFile>[];
+
+    if (verbose) {
+      print(
+        '  🧹 Deep revert: removing generated architecture for '
+        '"$entityName" (snake: $snake)...',
+      );
+    }
+
+    // Directories fully owned by this entity's generation: every .dart
+    // file under them was produced by the generator for THIS entity (the
+    // directory itself is snake-named after the entity). Delete every
+    // .dart file inside, then prune the directory if it becomes empty.
+    final entityScopedDirs = <String>[
+      path.join('lib', 'src', 'data', 'datasources', snake),
+      path.join('lib', 'src', 'domain', 'usecases', snake),
+      path.join('lib', 'src', 'presentation', 'pages', snake),
+      path.join('test', 'domain', 'usecases', snake),
+      path.join('test', 'presentation', 'pages', snake),
+    ];
+
+    for (final dir in entityScopedDirs) {
+      if (!await fs.exists(dir)) continue;
+      if (!await fs.isDirectory(dir)) continue;
+      final entries = await fs.list(dir, recursive: true);
+      for (final entry in entries) {
+        if (!entry.endsWith('.dart')) continue;
+        final base = path.basename(entry);
+        // Skip keep-file markers — they're not Dart source.
+        if (base == '.gitkeep' || base == '.keep') continue;
+        if (!dryRun) {
+          await fs.delete(entry);
+        }
+        deleted.add(
+          GeneratedFile(
+            path: entry,
+            type: 'deep_revert',
+            action: 'deleted',
+          ),
+        );
+        if (verbose) print('    🗑 Deleted file: $entry');
+      }
+      // Prune the directory if it is now empty (or only keeps markers).
+      if (!dryRun) {
+        final remaining = await fs.list(dir);
+        final onlyMarkers = remaining.isEmpty ||
+            remaining.every((e) {
+              final b = path.basename(e);
+              return b == '.gitkeep' || b == '.keep';
+            });
+        if (onlyMarkers) {
+          await fs.delete(dir);
+          if (verbose) print('    🗑 Pruned empty directory: $dir');
+        }
+      }
+    }
+
+    // Entity-keyed files in shared directories: exact paths the generators
+    // write for this entity. Delete those that exist. These live alongside
+    // other entities' files, so we never delete the parent directory.
+    final entityKeyedFiles = <String>[
+      // data layer
+      path.join('lib', 'src', 'data', 'repositories',
+          'data_${snake}_repository.dart'),
+      path.join('lib', 'src', 'data', 'mock', '${snake}_mock_data.dart'),
+      path.join('lib', 'src', 'data', 'cache', '${snake}_cache.dart'),
+      path.join('lib', 'src', 'data', 'sync', '${snake}_sync.dart'),
+      path.join('lib', 'src', 'data', 'providers', '${snake}_provider.dart'),
+      // domain layer (excluding the entity source directory — never touch)
+      path.join('lib', 'src', 'domain', 'repositories',
+          '${snake}_repository.dart'),
+      path.join('lib', 'src', 'domain', 'services', '${snake}_service.dart'),
+      // di layer
+      path.join('lib', 'src', 'di', 'repositories',
+          '${snake}_repository_di.dart'),
+      path.join('lib', 'src', 'di', 'datasources',
+          '${snake}_datasource_di.dart'),
+      path.join('lib', 'src', 'di', 'services', '${snake}_service_di.dart'),
+      path.join('lib', 'src', 'di', 'providers', '${snake}_provider_di.dart'),
+      // presentation layer
+      path.join('lib', 'src', 'presentation', 'routes',
+          '${snake}_route.dart'),
+      path.join('lib', 'src', 'presentation', 'observers',
+          '${snake}_observer.dart'),
+      path.join('lib', 'src', 'presentation', 'providers',
+          '${snake}_provider.dart'),
+      // shared-directory tests (entity-scoped test dirs handled above)
+      path.join('test', 'data', 'repositories',
+          'data_${snake}_repository_test.dart'),
+      path.join('test', 'domain', 'repositories',
+          '${snake}_repository_test.dart'),
+    ];
+
+    for (final file in entityKeyedFiles) {
+      if (!await fs.exists(file)) continue;
+      // Safety: never recursively delete a path that turned out to be a
+      // directory (shouldn't happen for these canonical file paths, but
+      // guard against name collisions anyway).
+      if (await fs.isDirectory(file)) continue;
+      if (!dryRun) {
+        await fs.delete(file);
+      }
+      deleted.add(
+        GeneratedFile(path: file, type: 'deep_revert', action: 'deleted'),
+      );
+      if (verbose) print('    🗑 Deleted file: $file');
+    }
+
+    // Glob-keyed files in shared directories: per-method DI registrations
+    // (`<op>_<snake>_usecase_di.dart`). The method prefix varies
+    // (get_/create_/update_/delete_/toggle_/watch_/...), so we glob by
+    // suffix. The shared directory itself is never deleted.
+    final diUsecasesDir = path.join('lib', 'src', 'di', 'usecases');
+    final usecaseDiSuffix = '_${snake}_usecase_di.dart';
+    if (await fs.exists(diUsecasesDir) &&
+        await fs.isDirectory(diUsecasesDir)) {
+      final entries = await fs.list(diUsecasesDir);
+      for (final entry in entries) {
+        if (!entry.endsWith('.dart')) continue;
+        if (!path.basename(entry).endsWith(usecaseDiSuffix)) continue;
+        if (!dryRun) {
+          await fs.delete(entry);
+        }
+        deleted.add(
+          GeneratedFile(
+            path: entry,
+            type: 'deep_revert',
+            action: 'deleted',
+          ),
+        );
+        if (verbose) print('    🗑 Deleted file: $entry');
+      }
+    }
+
+    if (verbose && deleted.isNotEmpty) {
+      print('  🧹 Deep revert: removed ${deleted.length} file(s).');
+    } else if (verbose) {
+      print('  🧹 Deep revert: no generated architecture found for '
+          '"$entityName".');
+    }
+
+    return deleted;
   }
 
   /// Executes the full generation lifecycle for the active plugins.

--- a/test/regression/issue_323_revert_cleans_orphan_architecture_test.dart
+++ b/test/regression/issue_323_revert_cleans_orphan_architecture_test.dart
@@ -1,0 +1,569 @@
+// Regression tests for issue #323.
+//
+// `zfa make: re-modeling entity as value_object orphans previously
+// generated CRUD architecture — no zfa cleanup path (revert only tracks
+// current run)`.
+//
+// Repro (from the issue):
+//   1. Originally (pre-#322): created ChatMessage as a plain entity with
+//      an id field, generated full CRUD via
+//      `zfa make ChatMessage --preset=crud --with=vpc,state,di,test,mock`.
+//   2. After #322 merged: re-modeled ChatMessage as a value object
+//      (`@ZValueObject`, no id). `zfa make` correctly skips the root
+//      plugins and generates nothing for the VO.
+//   3. Tried to clean up the old CRUD via
+//      `zfa make ChatMessage --preset=crud --with=vpc,state,di,test,mock --revert`
+//      — `zfa make --revert` only removed files from the CURRENT
+//      generation run. Since the VO make generated nothing, the saved
+//      plan was empty and `--revert` reported "No files generated",
+//      leaving ~50 orphaned CRUD files on disk (54 analyze errors).
+//
+// The fix (this issue): `zfa make <Entity> --revert` now performs a
+// "deep revert" that walks the canonical entity-snake-keyed paths the
+// generators would produce (datasources dir, usecases dir, presentation
+// pages dir, repository file, DI registrations, mock data, tests, ...)
+// and deletes those that exist — regardless of whether the current run
+// generated them. This makes `--revert` mean "remove the entity's
+// generated architecture" uniformly, for entities AND value objects.
+//
+// The entity source file itself
+// (`lib/src/domain/entities/<snake>/<snake>.dart`) is NEVER touched by
+// deep revert — the entity is the source of truth, not generated
+// architecture. Re-modeling is the user's job.
+//
+// These tests exercise:
+//   - Part A: basic `--revert` after a successful CRUD generation still
+//     works (no regression on the existing plan-based path).
+//   - Part B: the #323 regression — re-model as value object, then
+//     `--revert` cleans the orphaned CRUD architecture.
+//   - Part C: `--revert --dry-run` lists but does not delete.
+//   - Part D: `--revert` preserves the entity source file.
+//   - Part E: `--revert` on an entity with no generated architecture is
+//     a graceful no-op (exit 0, "No files generated" or empty deleted
+//     list).
+//   - Part F: `--revert` only deletes the named entity's architecture —
+//     other entities' files in shared directories are untouched.
+
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
+import 'package:test/test.dart';
+
+/// Resolve package root at discovery time, before any test changes CWD.
+final _zfaRoot = Directory.current.path;
+
+void main() {
+  group('#323 — zfa make --revert deep-cleans orphan architecture', () {
+    late Directory workspace;
+    late String zfaBin;
+    late String outputDir;
+
+    Future<ProcessResult> runZfa(List<String> args) {
+      return Process.run(
+        'dart',
+        [zfaBin, ...args],
+        workingDirectory: workspace.path,
+      );
+    }
+
+    setUp(() async {
+      zfaBin = path.join(_zfaRoot, 'bin', 'zfa.dart');
+      workspace = await Directory.systemTemp.createTemp('issue_323_');
+      outputDir = path.join(workspace.path, 'lib', 'src');
+      await Directory(outputDir).create(recursive: true);
+      // Minimal pubspec — `zfa make` only needs the package to exist.
+      await File(path.join(workspace.path, 'pubspec.yaml')).writeAsString('''
+name: issue_323_test_app
+environment:
+  sdk: ^3.11.0
+dependencies:
+  zuraffa:
+    path: ${path.normalize(_zfaRoot)}
+''');
+    });
+
+    tearDown(() async {
+      if (workspace.existsSync()) {
+        await workspace.delete(recursive: true);
+      }
+    });
+
+    /// Writes a plain entity with a real `id: String` field — the
+    /// pre-#322 shape that `zfa make` generates full CRUD for.
+    Future<void> writeEntityWithId(String name) async {
+      final snake = _toSnake(name);
+      final entityDir = Directory(
+        path.join(outputDir, 'domain', 'entities', snake),
+      );
+      await entityDir.create(recursive: true);
+      await File(path.join(entityDir.path, '$snake.dart')).writeAsString('''
+class $name {
+  final String id;
+  final String label;
+
+  const $name({required this.id, required this.label});
+}
+
+class ${name}Fields {
+  static const Field<$name, String> id = Field<$name, String>(name: 'id');
+  static const Field<$name, String> label =
+      Field<$name, String>(name: 'label');
+}
+''');
+    }
+
+    /// Re-writes the entity source as a `@ZValueObject` (no id) — the
+    /// #322 re-model that orphans the previously generated CRUD.
+    Future<void> rewriteEntityAsValueObject(String name) async {
+      final snake = _toSnake(name);
+      final entityDir = Directory(
+        path.join(outputDir, 'domain', 'entities', snake),
+      );
+      await entityDir.create(recursive: true);
+      await File(path.join(entityDir.path, '$snake.dart')).writeAsString('''
+import 'package:zorphy_annotation/zorphy_annotation.dart';
+
+@ZValueObject
+abstract class \$$name {
+  String get label;
+  DateTime get timestamp;
+}
+''');
+    }
+
+    /// Generates full CRUD for [name] (the same preset the issue repro
+    /// uses). Returns the zfa exit code so tests can assert on it.
+    Future<ProcessResult> generateCrud(String name) {
+      return runZfa([
+        'make',
+        name,
+        '--preset=crud',
+        '--with=vpc,state,di,test,mock',
+        '--methods=get,getList,create,update,delete,toggle',
+        '--output',
+        outputDir,
+      ]);
+    }
+
+    /// Reverts the generated architecture for [name].
+    Future<ProcessResult> revertEntity(String name,
+        {bool dryRun = false, bool verbose = false}) {
+      final args = <String>[
+        'make',
+        name,
+        '--preset=crud',
+        '--with=vpc,state,di,test,mock',
+        '--revert',
+        '--output',
+        outputDir,
+      ];
+      if (dryRun) args.add('--dry-run');
+      if (verbose) args.add('--verbose');
+      return runZfa(args);
+    }
+
+    /// The canonical architecture paths the generators produce for an
+    /// entity — used to assert presence/absence after revert.
+    List<String> expectedArchitecturePaths(String name) {
+      final snake = _toSnake(name);
+      return <String>[
+        // data layer
+        path.join(outputDir, 'data', 'datasources', snake,
+            '${snake}_datasource.dart'),
+        path.join(outputDir, 'data', 'datasources', snake,
+            '${snake}_mock_datasource.dart'),
+        path.join(outputDir, 'data', 'datasources', snake,
+            '${snake}_remote_datasource.dart'),
+        path.join(outputDir, 'data', 'repositories',
+            'data_${snake}_repository.dart'),
+        path.join(outputDir, 'data', 'mock', '${snake}_mock_data.dart'),
+        // domain layer
+        path.join(outputDir, 'domain', 'repositories',
+            '${snake}_repository.dart'),
+        path.join(outputDir, 'domain', 'usecases', snake,
+            'get_${snake}_usecase.dart'),
+        path.join(outputDir, 'domain', 'usecases', snake,
+            'update_${snake}_usecase.dart'),
+        // di layer
+        path.join(outputDir, 'di', 'repositories',
+            '${snake}_repository_di.dart'),
+        path.join(outputDir, 'di', 'usecases',
+            'get_${snake}_usecase_di.dart'),
+        path.join(outputDir, 'di', 'usecases',
+            'update_${snake}_usecase_di.dart'),
+        // presentation layer
+        path.join(outputDir, 'presentation', 'pages', snake,
+            '${snake}_presenter.dart'),
+        path.join(outputDir, 'presentation', 'pages', snake,
+            '${snake}_controller.dart'),
+        path.join(outputDir, 'presentation', 'pages', snake,
+            '${snake}_state.dart'),
+        path.join(outputDir, 'presentation', 'pages', snake,
+            '${snake}_view.dart'),
+      ];
+    }
+
+    /// The entity source path — must NEVER be deleted by `--revert`.
+    String entitySourcePath(String name) {
+      final snake = _toSnake(name);
+      return path.join(
+        outputDir,
+        'domain',
+        'entities',
+        snake,
+        '$snake.dart',
+      );
+    }
+
+    // ---------------------------------------------------------------------
+    // Part A — basic `--revert` after a successful CRUD generation
+    // ---------------------------------------------------------------------
+
+    group('Part A — basic revert after CRUD generation', () {
+      test('`zfa make <Entity> --revert` removes all generated '
+          'architecture files for the entity', () async {
+        await writeEntityWithId('Product');
+        final gen = await generateCrud('Product');
+        expect(gen.exitCode, equals(0),
+            reason: 'precondition: CRUD generation must succeed\n'
+                'stdout: ${gen.stdout}\nstderr: ${gen.stderr}');
+
+        // Sanity check: at least the presenter + repository + a usecase
+        // were generated (so we know revert has something to delete).
+        final archPaths = expectedArchitecturePaths('Product');
+        final presentBefore = archPaths.where((p) => File(p).existsSync());
+        expect(
+          presentBefore.isNotEmpty,
+          isTrue,
+          reason: 'precondition: some architecture files must exist before '
+              'revert. Looked for:\n${archPaths.join("\n")}',
+        );
+
+        // Revert.
+        final rev = await revertEntity('Product');
+        expect(rev.exitCode, equals(0),
+            reason: 'revert must exit 0\nstdout: ${rev.stdout}\nstderr: '
+                '${rev.stderr}');
+
+        // Assert every canonical architecture path is gone.
+        final stillPresent =
+            archPaths.where((p) => File(p).existsSync()).toList();
+        expect(
+          stillPresent,
+          isEmpty,
+          reason: 'after --revert, no canonical architecture files should '
+              'remain. Still present:\n${stillPresent.join("\n")}',
+        );
+
+        // Entity-scoped directories should be gone (or empty) too.
+        final snake = _toSnake('Product');
+        final scopedDirs = [
+          path.join(outputDir, 'data', 'datasources', snake),
+          path.join(outputDir, 'domain', 'usecases', snake),
+          path.join(outputDir, 'presentation', 'pages', snake),
+        ];
+        for (final dir in scopedDirs) {
+          if (Directory(dir).existsSync()) {
+            final dartFiles = Directory(dir)
+                .listSync(recursive: true)
+                .whereType<File>()
+                .where((f) => f.path.endsWith('.dart'))
+                .toList();
+            expect(
+              dartFiles,
+              isEmpty,
+              reason: 'after --revert, entity-scoped directory $dir should '
+                  'have no .dart files. Still contains:\n'
+                  '${dartFiles.map((f) => f.path).join("\n")}',
+            );
+          }
+        }
+      });
+    });
+
+    // ---------------------------------------------------------------------
+    // Part B — #323 regression: VO re-model orphans CRUD, revert cleans it
+    // ---------------------------------------------------------------------
+
+    group('Part B — #323 regression (VO re-model orphans CRUD)', () {
+      test('re-modeling an entity as a value object leaves CRUD orphans '
+          'on disk; `zfa make <Entity> --revert` cleans them up', () async {
+        // 1. Originally: ChatMessage is a plain entity with an id.
+        await writeEntityWithId('ChatMessage');
+        final gen = await generateCrud('ChatMessage');
+        expect(gen.exitCode, equals(0),
+            reason: 'precondition: original CRUD generation must succeed\n'
+                'stdout: ${gen.stdout}\nstderr: ${gen.stderr}');
+
+        final archPaths = expectedArchitecturePaths('ChatMessage');
+        final presentAfterGen =
+            archPaths.where((p) => File(p).existsSync()).toList();
+        expect(
+          presentAfterGen.isNotEmpty,
+          isTrue,
+          reason: 'precondition: CRUD generation must produce architecture '
+              'files. None of these were found:\n${archPaths.join("\n")}',
+        );
+
+        // 2. Re-model as a value object (no id). `zfa make` should skip
+        //    the root plugins and generate nothing — leaving the previous
+        //    CRUD architecture on disk as orphans (#323).
+        await rewriteEntityAsValueObject('ChatMessage');
+        final voGen = await generateCrud('ChatMessage');
+        expect(voGen.exitCode, equals(0),
+            reason: 'VO make must exit 0 (skips root plugins cleanly)\n'
+                'stdout: ${voGen.stdout}\nstderr: ${voGen.stderr}');
+        expect(
+          (voGen.stdout as String).contains('is a value object'),
+          isTrue,
+          reason: 'VO make must announce it is skipping root plugins',
+        );
+
+        // The orphans are STILL there — that is the bug. We don't assert
+        // on this for the fix (the fix is in revert, not in VO make), but
+        // we log it for diagnostic clarity.
+        final orphansBeforeRevert =
+            archPaths.where((p) => File(p).existsSync()).toList();
+        expect(
+          orphansBeforeRevert.isNotEmpty,
+          isTrue,
+          reason: 'precondition for #323: the VO re-model must leave the '
+              'previous CRUD architecture on disk as orphans. None found:\n'
+              '${archPaths.join("\n")}',
+        );
+
+        // 3. `zfa make <Entity> --revert` must now clean up the orphans.
+        final rev = await revertEntity('ChatMessage', verbose: true);
+        expect(rev.exitCode, equals(0),
+            reason: 'revert must exit 0 even when the saved plan is empty '
+                '(the deep-revert path handles orphans)\n'
+                'stdout: ${rev.stdout}\nstderr: ${rev.stderr}');
+
+        final stillPresent =
+            archPaths.where((p) => File(p).existsSync()).toList();
+        expect(
+          stillPresent,
+          isEmpty,
+          reason: 'after --revert on a re-modeled entity, all orphan CRUD '
+              'architecture must be gone. Still present:\n'
+              '${stillPresent.join("\n")}\n'
+              'revert stdout was:\n${rev.stdout}',
+        );
+      });
+    });
+
+    // ---------------------------------------------------------------------
+    // Part C — --dry-run does not delete
+    // ---------------------------------------------------------------------
+
+    group('Part C — --dry-run does not delete', () {
+      test('`zfa make <Entity> --revert --dry-run` leaves all architecture '
+          'files on disk', () async {
+        await writeEntityWithId('Order');
+        final gen = await generateCrud('Order');
+        expect(gen.exitCode, equals(0),
+            reason: 'precondition: CRUD generation must succeed\n'
+                'stdout: ${gen.stdout}\nstderr: ${gen.stderr}');
+
+        final archPaths = expectedArchitecturePaths('Order');
+        final presentBefore =
+            archPaths.where((p) => File(p).existsSync()).toList();
+        expect(presentBefore.isNotEmpty, isTrue,
+            reason: 'precondition: architecture files must exist before '
+                'the dry-run revert');
+
+        final rev = await revertEntity('Order', dryRun: true);
+        expect(rev.exitCode, equals(0),
+            reason: 'dry-run revert must exit 0\nstdout: ${rev.stdout}\n'
+                'stderr: ${rev.stderr}');
+
+        final stillPresent =
+            archPaths.where((p) => File(p).existsSync()).toList();
+        expect(
+          stillPresent,
+          equals(presentBefore),
+          reason: 'dry-run must not delete any files. Files missing after '
+              'dry-run (should still be there):\n'
+              '${presentBefore.where((p) => !stillPresent.contains(p)).join("\n")}',
+        );
+      });
+    });
+
+    // ---------------------------------------------------------------------
+    // Part D — entity source is preserved
+    // ---------------------------------------------------------------------
+
+    group('Part D — entity source is preserved', () {
+      test('`zfa make <Entity> --revert` does NOT delete the entity source '
+          'file', () async {
+        await writeEntityWithId('Inventory');
+        await generateCrud('Inventory');
+        final entityFile = File(entitySourcePath('Inventory'));
+        expect(entityFile.existsSync(), isTrue,
+            reason: 'precondition: entity source must exist before revert');
+
+        final rev = await revertEntity('Inventory');
+        expect(rev.exitCode, equals(0),
+            reason: 'revert must exit 0\nstdout: ${rev.stdout}\nstderr: '
+                '${rev.stderr}');
+
+        expect(
+          entityFile.existsSync(),
+          isTrue,
+          reason: 'the entity source file is the source of truth, not '
+              'generated architecture — `--revert` must never delete it. '
+              'Missing after revert: ${entityFile.path}',
+        );
+
+        // The entity directory should still exist (with the source file).
+        final snake = _toSnake('Inventory');
+        final entityDir = Directory(
+          path.join(outputDir, 'domain', 'entities', snake),
+        );
+        expect(entityDir.existsSync(), isTrue,
+            reason: 'entity directory must survive revert');
+      });
+
+      test('`zfa make <Entity> --revert` preserves the entity source even '
+          'after VO re-model (#323 repro entity)', () async {
+        await writeEntityWithId('TelemetryEvent');
+        await generateCrud('TelemetryEvent');
+        await rewriteEntityAsValueObject('TelemetryEvent');
+        await generateCrud('TelemetryEvent'); // VO make — generates nothing
+
+        final entityFile = File(entitySourcePath('TelemetryEvent'));
+        expect(entityFile.existsSync(), isTrue,
+            reason: 'precondition: VO entity source must exist');
+
+        final rev = await revertEntity('TelemetryEvent');
+        expect(rev.exitCode, equals(0),
+            reason: 'revert must exit 0\nstdout: ${rev.stdout}\nstderr: '
+                '${rev.stderr}');
+
+        expect(
+          entityFile.existsSync(),
+          isTrue,
+          reason: 'the (re-modeled) entity source file must survive revert. '
+              'Missing: ${entityFile.path}',
+        );
+        // And the entity file should still contain the @ZValueObject
+        // annotation we wrote — revert must not rewrite it.
+        final content = await entityFile.readAsString();
+        expect(
+          content.contains('@ZValueObject'),
+          isTrue,
+          reason: 'entity source content must be untouched by revert',
+        );
+      });
+    });
+
+    // ---------------------------------------------------------------------
+    // Part E — no architecture to revert is a graceful no-op
+    // ---------------------------------------------------------------------
+
+    group('Part E — graceful no-op', () {
+      test('`zfa make <Entity> --revert` on an entity with no generated '
+          'architecture exits 0 and does not delete the entity source',
+          () async {
+        await writeEntityWithId('BrandNew');
+        // No generateCrud call — no architecture exists.
+
+        final rev = await revertEntity('BrandNew');
+        expect(rev.exitCode, equals(0),
+            reason: 'revert on a fresh entity must exit 0\nstdout: '
+                '${rev.stdout}\nstderr: ${rev.stderr}');
+
+        // Entity source untouched.
+        expect(
+          File(entitySourcePath('BrandNew')).existsSync(),
+          isTrue,
+          reason: 'fresh entity source must survive a no-op revert',
+        );
+        // No architecture magically created.
+        final archPaths = expectedArchitecturePaths('BrandNew');
+        final present =
+            archPaths.where((p) => File(p).existsSync()).toList();
+        expect(
+          present,
+          isEmpty,
+          reason: 'revert must not create files. Found:\n'
+              '${present.join("\n")}',
+        );
+      });
+    });
+
+    // ---------------------------------------------------------------------
+    // Part F — revert only touches the named entity
+    // ---------------------------------------------------------------------
+
+    group('Part F — revert only touches the named entity', () {
+      test('`zfa make <EntityA> --revert` does not delete EntityB '
+          'architecture in shared directories', () async {
+        await writeEntityWithId('Alpha');
+        await writeEntityWithId('Beta');
+        final genA = await generateCrud('Alpha');
+        expect(genA.exitCode, equals(0),
+            reason: 'precondition: Alpha generation must succeed\n'
+                'stdout: ${genA.stdout}\nstderr: ${genA.stderr}');
+        final genB = await generateCrud('Beta');
+        expect(genB.exitCode, equals(0),
+            reason: 'precondition: Beta generation must succeed\n'
+                'stdout: ${genB.stdout}\nstderr: ${genB.stderr}');
+
+        final betaArchBefore =
+            expectedArchitecturePaths('Beta').where((p) => File(p).existsSync()).toList();
+        expect(betaArchBefore.isNotEmpty, isTrue,
+            reason: 'precondition: Beta architecture must exist before '
+                'Alpha revert');
+
+        // Revert ONLY Alpha.
+        final rev = await revertEntity('Alpha');
+        expect(rev.exitCode, equals(0),
+            reason: 'Alpha revert must exit 0\nstdout: ${rev.stdout}\n'
+                'stderr: ${rev.stderr}');
+
+        // Alpha architecture is gone.
+        final alphaStillPresent = expectedArchitecturePaths('Alpha')
+            .where((p) => File(p).existsSync())
+            .toList();
+        expect(
+          alphaStillPresent,
+          isEmpty,
+          reason: 'Alpha architecture must be gone after Alpha revert. '
+              'Still present:\n${alphaStillPresent.join("\n")}',
+        );
+
+        // Beta architecture is intact.
+        final betaStillPresent = expectedArchitecturePaths('Beta')
+            .where((p) => File(p).existsSync())
+            .toList();
+        expect(
+          betaStillPresent,
+          equals(betaArchBefore),
+          reason: 'Beta architecture must be untouched by Alpha revert. '
+              'Missing (should still be there):\n'
+              '${betaArchBefore.where((p) => !betaStillPresent.contains(p)).join("\n")}',
+        );
+      });
+    });
+  });
+}
+
+/// Converts a PascalCase name to snake_case — mirrors the generator's
+/// `StringUtils.camelToSnake` so the test asserts on the exact paths the
+/// generator produces.
+String _toSnake(String input) {
+  if (input.isEmpty) return '';
+  final result = <String>[];
+  for (var i = 0; i < input.length; i++) {
+    final char = input[i];
+    if (i > 0 &&
+        char.toLowerCase() != char &&
+        char.toUpperCase() == char &&
+        char != '_') {
+      result.add('_');
+    }
+    result.add(char.toLowerCase());
+  }
+  return result.join();
+}


### PR DESCRIPTION
Closes #323

## Problem

When an entity is re-modeled as a `value_object` (the #322 identity contract — VOs have no `id`), the previously generated CRUD architecture for that entity stays on disk as orphans. `zfa make --revert` only removed files from the current generation run — and because a value_object make generates nothing, revert reported "No files generated" and left the historical CRUD in place (~50 orphan files, 54 analyze errors in the issue repro).

## Fix

Add a **deep-revert** path to `PluginManager._handleRevert` that walks the canonical entity-snake-keyed paths the generators would produce and deletes those that exist on disk, regardless of whether the current/last run generated them. The existing plan-based revert is preserved for restoring shared files (route registrations, DI aggregators) to previous content.

`zfa make <Entity> --revert` now means **"remove the entity generated architecture"** uniformly — for entities AND value objects.

The entity source file (`lib/src/domain/entities/<snake>/<snake>.dart`) is NEVER touched by deep revert — the entity is the source of truth, not generated architecture.

### Deep-revert scope

- **Entity-scoped directories** (delete all .dart files, prune if empty):
  - `lib/src/data/datasources/<snake>/`
  - `lib/src/domain/usecases/<snake>/`
  - `lib/src/presentation/pages/<snake>/`
  - `test/domain/usecases/<snake>/`
  - `test/presentation/pages/<snake>/`
- **Entity-keyed files** in shared directories (exact paths):
  - data: `data_<snake>_repository.dart`, `<snake>_mock_data.dart`, `<snake>_cache.dart`, `<snake>_sync.dart`, `<snake>_provider.dart`
  - domain: `<snake>_repository.dart`, `<snake>_service.dart`
  - di: `<snake>_repository_di.dart`, `<snake>_datasource_di.dart`, `<snake>_service_di.dart`, `<snake>_provider_di.dart`
  - presentation: `<snake>_route.dart`, `<snake>_observer.dart`, `<snake>_provider.dart`
  - tests: `data_<snake>_repository_test.dart`, `<snake>_repository_test.dart`
- **Glob-keyed** per-method DI registrations: `<op>_<snake>_usecase_di.dart` in `lib/src/di/usecases/`

Honors `--dry-run` (lists but does not delete) and `--verbose`.

## Verification

- `dart analyze lib/src/core/plugin_system/plugin_manager.dart` — No issues found.
- `dart analyze test/regression/issue_323_revert_cleans_orphan_architecture_test.dart` — No issues found.
- 8 new regression tests (all pass):
  - Part A: basic `--revert` after CRUD gen removes all generated architecture.
  - Part B: #323 regression — re-model as VO (orphaning CRUD), then `--revert` cleans the orphans.
  - Part C: `--revert --dry-run` does not delete files.
  - Part D: `--revert` preserves the entity source file (plain entity + VO re-model).
  - Part E: `--revert` on an entity with no generated architecture is a graceful no-op (exit 0).
  - Part F: `--revert` only touches the named entity (EntityB untouched when reverting EntityA).
- No regression: `dart test test/commands/make_command_test.dart` (7 tests) + `issue_294_entity_without_id_test.dart` (5 tests) + `issue_321` sample — all pass.