### PR TITLE
fix(zfa entity): support Dart-keyword field names + custom JSON wire names (#303)

### DIFF
--- a/lib/src/commands/entity_command.dart
+++ b/lib/src/commands/entity_command.dart
@@ -148,6 +148,32 @@ ${missing.map((d) => '   • $d').join('\n')}
       ..._asStringList(parsed['fields']),
     ]);
 
+    // Issue #303: refuse raw Dart-keyword field names (e.g. `in:String`)
+    // up front — without this guard the CLI emits `String get in;`, which
+    // is invalid Dart and only fails later at `zfa build` with a misleading
+    // analyzer error. The user must remap the wire name with
+    // `:json=<wire>` (e.g. `in_:String:json=in`).
+    final bareKeywords = _findBareKeywordFields(fields);
+    if (bareKeywords.isNotEmpty) {
+      print(
+        '❌ Cannot create entity "$name": field name(s) are Dart keywords.',
+      );
+      print('');
+      for (final field in bareKeywords) {
+        print(
+          '  • ${field.name} — reserved word; cannot be used as a Dart '
+          'identifier.',
+        );
+        print(
+          '    Remap with the \'name:type:json=<wire>\' syntax, e.g. '
+          "'${field.name}_:${field.type}:json=${field.name}'",
+        );
+      }
+      print('');
+      print('No files were written. See \'zfa entity --help\' for details.');
+      exit(1);
+    }
+
     // Validate field types BEFORE writing anything (issue #296):
     // if a referenced type is neither a primitive, an existing entity,
     // nor an existing enum, abort with a clear error so the entity is
@@ -213,7 +239,7 @@ ${missing.map((d) => '   • $d').join('\n')}
       if (fields.isNotEmpty) {
         print('\n✨ Generated ${fields.length} fields:');
         for (final field in fields) {
-          print('  - ${field.name}: ${field.fullType}');
+          print('  - ${_formatFieldDisplay(field)}');
         }
       }
     } else {
@@ -313,6 +339,30 @@ ${missing.map((d) => '   • $d').join('\n')}
 
     final fields = _parseFields(fieldStrings);
 
+    // Issue #303: same raw-keyword guard as `entity create` — refuse to
+    // add a field whose Dart name is a reserved word without an explicit
+    // `:json=<wire>` remap.
+    final bareKeywords = _findBareKeywordFields(fields);
+    if (bareKeywords.isNotEmpty) {
+      print(
+        '❌ Cannot add field(s) to "$name": field name(s) are Dart keywords.',
+      );
+      print('');
+      for (final field in bareKeywords) {
+        print(
+          '  • ${field.name} — reserved word; cannot be used as a Dart '
+          'identifier.',
+        );
+        print(
+          '    Remap with the \'name:type:json=<wire>\' syntax, e.g. '
+          "'${field.name}_:${field.type}:json=${field.name}'",
+        );
+      }
+      print('');
+      print('No files were modified. See \'zfa entity --help\' for details.');
+      exit(1);
+    }
+
     // Validate field types BEFORE writing anything (issue #296):
     // same guard as `entity create` — refuse to add fields whose types
     // cannot be resolved against the on-disk entity/enum layout.
@@ -350,7 +400,7 @@ ${missing.map((d) => '   • $d').join('\n')}
       await _fixEntityImports(result.filePath, fields, fixedEntityOutput);
       print('✓ Added ${fields.length} field(s) to ${result.className}');
       for (final field in fields) {
-        print('  + ${field.name}: ${field.fullType}');
+        print('  + ${_formatFieldDisplay(field)}');
       }
     } else {
       print('❌ ${result.error}');
@@ -537,6 +587,12 @@ ${missing.map((d) => '   • $d').join('\n')}
 
     if (result.isSuccess) {
       print('✓ Created entity: ${result.filePath}');
+      if (fields.isNotEmpty) {
+        print('\n✨ Generated ${fields.length} fields:');
+        for (final field in fields) {
+          print('  - ${_formatFieldDisplay(field)}');
+        }
+      }
     } else {
       print('❌ ${result.error}');
       exit(1);
@@ -632,6 +688,80 @@ ${missing.map((d) => '   • $d').join('\n')}
     return fields;
   }
 
+  /// Dart reserved words (contextual + built-in) that cannot be used as a
+  /// field identifier in generated entity source. Issue #303: when a user
+  /// writes `--field in:String` the CLI used to emit `String get in;` —
+  /// invalid Dart — and `zfa build` later failed with
+  /// `'in' can't be used as an identifier because it's a keyword.`
+  ///
+  /// The intended workflow for a Dart-keyword JSON wire name is to pick a
+  /// Dart-safe field name and remap the wire name via `:json=<wire>`
+  /// (e.g. `in_:String:json=in`). [_findBareKeywordFields] refuses the
+  /// bare-keyword form up front with an actionable error.
+  static const Set<String> _dartKeywords = {
+    // Built-in reserved words.
+    'abstract', 'as', 'assert', 'async', 'await', 'break', 'case', 'catch',
+    'class', 'const', 'continue', 'covariant', 'default', 'deferred', 'do',
+    'dynamic', 'else', 'enum', 'export', 'extends', 'extension', 'external',
+    'factory', 'false', 'final', 'finally', 'for', 'function', 'get', 'hide',
+    'if', 'implements', 'import', 'in', 'interface', 'is', 'library',
+    'late', 'mixin', 'new', 'null', 'on', 'operator', 'part', 'rethrow',
+    'return', 'set', 'show', 'static', 'super', 'switch', 'sync', 'this',
+    'throw', 'true', 'try', 'typedef', 'var', 'void', 'while', 'with', 'yield',
+    // Contextual keywords / reserved-for-future-use that would also break
+    // generated source identifiers.
+    'required', 'base', 'sealed', 'when', 'record', 'view',
+  };
+
+  bool _isDartKeyword(String name) => _dartKeywords.contains(name);
+
+  /// Maps a raw JSON wire key to a Dart-safe (name, jsonName) pair.
+  ///
+  /// Rules (issue #303):
+  /// - Dart keyword (`in`, `required`, ...): Dart name = `<key>_`, jsonName
+  ///   = `<key>` (preserves the wire contract while keeping the Dart source
+  ///   compilable). Example: `in` -> (`in_`, `in`).
+  /// - Leading underscore (`_and`, `_or`): Dart name = `<key>` without the
+  ///   leading underscore (a leading `_` would mark the member private),
+  ///   jsonName = `<key>`. Example: `_and` -> (`and`, `_and`).
+  /// - Anything else: returned as-is with a null jsonName (no `@JsonKey`
+  ///   needed — the Dart name already matches the wire name).
+  ///
+  /// Used by `zfa entity from-json` (which has no field-string syntax to
+  /// lean on) so that JSON payloads carrying Dart-keyword or `_`-prefixed
+  /// keys produce compilable entities with the correct wire names.
+  ({String dartName, String? jsonName}) _resolveFieldName(String jsonKey) {
+    if (_isDartKeyword(jsonKey)) {
+      return (dartName: '${jsonKey}_', jsonName: jsonKey);
+    }
+    if (jsonKey.startsWith('_') && jsonKey.length > 1) {
+      return (dartName: jsonKey.substring(1), jsonName: jsonKey);
+    }
+    return (dartName: jsonKey, jsonName: null);
+  }
+
+  /// Issue #303 guard: refuses field definitions whose Dart name is a raw
+  /// Dart keyword AND that do not carry an explicit `jsonName`. The user
+  /// must use the `name:type:json=<wire>` syntax (e.g. `in_:String:json=in`)
+  /// so the generated source stays compilable and the wire name is
+  /// preserved. Returns the list of offending field definitions.
+  List<FieldDefinition> _findBareKeywordFields(List<FieldDefinition> fields) {
+    return fields
+        .where((f) => f.jsonName == null && _isDartKeyword(f.name))
+        .toList();
+  }
+
+  /// Pretty-prints a single field for success messages, appending
+  /// `(json: '<wire>')` when the field carries an explicit json wire name
+  /// (issue #303 — makes the remap visible to the caller).
+  String _formatFieldDisplay(FieldDefinition field) {
+    final base = '${field.name}: ${field.fullType}';
+    if (field.jsonName != null && field.jsonName != field.name) {
+      return "$base (json: '${field.jsonName}')";
+    }
+    return base;
+  }
+
   List<String> _asStringList(dynamic value) {
     if (value == null) return [];
     final List<String> result = [];
@@ -681,7 +811,15 @@ ${missing.map((d) => '   • $d').join('\n')}
       final key = entry.key;
       final value = entry.value;
       final isNullable = key.endsWith('?');
-      final fieldName = isNullable ? key.substring(0, key.length - 1) : key;
+      final rawKey = isNullable ? key.substring(0, key.length - 1) : key;
+
+      // Issue #303: a JSON key may be a Dart keyword (`in`, `required`) or
+      // carry a leading underscore (`_and`, `_or`) — neither is a valid
+      // Dart identifier. Resolve to a Dart-safe (name, jsonName) pair so
+      // the generated source compiles AND the wire contract is preserved.
+      final resolved = _resolveFieldName(rawKey);
+      final fieldName = resolved.dartName;
+      final jsonName = resolved.jsonName;
 
       String type;
       if (value is Map<String, dynamic>) {
@@ -699,6 +837,7 @@ ${missing.map((d) => '   • $d').join('\n')}
           name: fieldName,
           type: type,
           nullable: isNullable || value == null,
+          jsonName: jsonName,
         ),
       );
     }
@@ -795,6 +934,24 @@ ADD-FIELD COMMAND:
     --allow-forward-refs    Skip on-disk type validation (batch generation of
                             cyclic schemas — referenced entity is created later)
 
+FIELD SYNTAX:
+  name:type                 Basic field, Dart name = JSON wire name
+                            (e.g. `id:String`, `note:String?`)
+  name:type:json=<wire>     Dart name differs from the JSON wire name.
+                            Required when the wire name is a Dart keyword
+                            (`in`, `required`) or starts with `_`
+                            (Vendure `_and` / `_or`). Emits
+                            `@JsonKey(name: '<wire>')` on the getter so
+                            json_serializable serializes with the wire name.
+                            Examples:
+                              in_:String:json=in            # `in` wire key
+                              and:ProductFilterParameter:json=_and
+                              required:ConfigArgDef:json=required
+
+  The same syntax is accepted by `--field` (single) and `-F/--fields`
+  (comma-separated). `zfa entity from-json` resolves Dart-keyword and
+  `_`-prefixed JSON keys automatically (no manual `:json=` needed).
+
 EXAMPLES:
   zfa entity create -n User --field id:String --field name:String
   zfa entity create -n Product --field name:String --field price:double --filter
@@ -802,6 +959,12 @@ EXAMPLES:
     --field content:String --field timestamp:DateTime
   zfa entity create -n ParserConfig --kind=value_object
     --field separator:String --field trimWhitespace:bool
+  # Vendure-style filter parameter with nested _and/_or composition:
+  zfa entity create -n ProductFilterParameter --allow-forward-refs
+    --field and:ProductFilterParameter:json=_and
+    --field or:ProductFilterParameter:json=_or
+  # IdOperators with `in` (Dart keyword) remapped to `in_`:
+  zfa entity create -n IdOperators --field in_:String:json=in --field eq:String
   zfa entity enum -n Status --value pending,active,completed
   zfa entity add-field -n User --field email:String?
   zfa entity list
@@ -809,6 +972,8 @@ EXAMPLES:
 NOTES:
   - Entities always live under lib/src/domain/entities in Zuraffa v5.
   - Legacy --output values are accepted for compatibility but ignored.
+  - Raw Dart-keyword field names (e.g. `--field in:String`) are rejected;
+    remap with `:json=<wire>` so the generated source compiles.
 
 For more information, visit: https://github.com/arrrrny/zorphy
 ''');

--- a/test/regression/issue_303_json_wire_names_test.dart
+++ b/test/regression/issue_303_json_wire_names_test.dart
@@ -1,0 +1,614 @@
+// Regression test for issue #303.
+//
+// `zfa entity create` had no way to express a Dart field name different
+// from the JSON wire name. Three concrete failures:
+//
+//   1. `zfa entity create -n IdOperators --field 'in_:String'` succeeded
+//      but emitted JSON key `'in_'` in the generated `.g.dart` instead of
+//      `'in'` — a silent wire-contract break.
+//
+//   2. `zfa entity create -n X --field 'in:String'` accepted the keyword
+//      and wrote `String get in;` into the entity source — invalid Dart —
+//      and `zfa build` then failed with
+//      `'in' can't be used as an identifier because it's a keyword.`
+//
+//   3. `zfa entity create -n HistoryEntryFilterParameter --field and:...`
+//      emitted JSON keys `'and'`/`'or'`, not the Vendure wire keys
+//      `'_and'`/`'_or'`.
+//
+//   4. `zfa entity from-json` had the same limitation —
+//      `_extractFieldsFromJson` only read names/types.
+//
+// The fix (zorphy#80 — `FieldDefinition.jsonName` + the
+// `name:type:json=<wire>` field syntax — already merged into zorphy
+// development) is consumed by zuraffa via the zorphy `development` git
+// ref. This test exercises the zuraffa-side wiring:
+//
+//   - `entity create` / `entity add-field` accept `:json=<wire>` and the
+//     emitted source carries `@JsonKey(name: '<wire>')` on the getter.
+//   - Raw Dart-keyword field names (e.g. `in:String`) are rejected up
+//     front with an actionable error that points to `:json=<wire>`.
+//   - `entity from-json` auto-resolves Dart-keyword and `_`-prefixed
+//     JSON keys to a Dart-safe name + jsonName pair (no `:json=` needed).
+//   - The generated source parses (no Dart-keyword identifier break).
+//
+// The tests drive the real `zfa` CLI binary via Process.run on
+// `bin/zfa.dart`. The full build_runner round-trip (`.g.dart` emitting
+// `'in': instance.in_`) is verified in a dedicated test that mirrors
+// zuraffa's `dependency_overrides` (local zorphy checkout).
+
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+import '../helpers/project_root.dart';
+
+void main() {
+  group('#303 — zfa entity create: Dart-keyword field names + JSON wire names', () {
+    late Directory workspace;
+    late String repoRoot;
+    late String zfaBin;
+    late String zorphyPath;
+    late String zorphyAnnotationPath;
+
+    Future<ProcessResult> runDart(List<String> args) =>
+        Process.run('dart', args, workingDirectory: workspace.path);
+
+    Future<ProcessResult> runZfa(List<String> args) =>
+        Process.run('dart', [zfaBin, ...args], workingDirectory: workspace.path);
+
+    setUp(() async {
+      repoRoot = await findProjectRoot();
+      zfaBin = p.join(repoRoot, 'bin', 'zfa.dart');
+      zorphyPath = p.normalize(p.join(repoRoot, '..', 'zorphy', 'zorphy'));
+      zorphyAnnotationPath = p.normalize(
+        p.join(repoRoot, '..', 'zorphy', 'zorphy_annotation'),
+      );
+      workspace = await Directory.systemTemp.createTemp('issue_303_');
+      // Minimal pubspec so the entity command's dependency check (which
+      // scans for `zorphy_annotation:` and `build_runner:`) succeeds
+      // without running `dart pub get`. The string check is enough for
+      // entity source generation; build_runner is only invoked in the
+      // dedicated end-to-end test.
+      await File(p.join(workspace.path, 'pubspec.yaml')).writeAsString('''
+name: issue_303_test_app
+environment:
+  sdk: '>=3.12.0 <4.0.0'
+dependencies:
+  zorphy_annotation:
+dev_dependencies:
+  build_runner:
+''');
+    });
+
+    tearDown(() async {
+      if (workspace.existsSync()) {
+        await workspace.delete(recursive: true);
+      }
+    });
+
+    /// Path to the generated entity source file for [snakeName].
+    File entityFile(String snakeName) {
+      return File(
+        p.join(
+          workspace.path,
+          'lib',
+          'src',
+          'domain',
+          'entities',
+          snakeName,
+          '$snakeName.dart',
+        ),
+      );
+    }
+
+    /// Asserts the generated file parses as valid Dart. `dart format` exits
+    /// non-zero on any syntax error, so a raw keyword getter (`String get in;`)
+    /// or any other break in the emitted source cannot slip through.
+    Future<void> expectFormats(File file) async {
+      final result = await Process.run(
+        'dart',
+        ['format', '--output=none', file.path],
+        workingDirectory: workspace.path,
+      );
+      expect(
+        result.exitCode,
+        equals(0),
+        reason: 'generated ${file.path} must parse as valid Dart '
+            '(exit ${result.exitCode}): ${result.stdout}${result.stderr}',
+      );
+    }
+
+    test(
+      '`in_:String:json=in` emits @JsonKey(name: \'in\') on the getter',
+      timeout: const Timeout(Duration(minutes: 2)),
+      () async {
+        final result = await runZfa([
+          'entity',
+          'create',
+          '-n',
+          'IdOperators',
+          '--field',
+          'in_:String:json=in',
+          '--field',
+          'eq:String',
+        ]);
+
+        expect(
+          result.exitCode,
+          equals(0),
+          reason: 'zfa entity create must accept the :json= wire syntax. '
+          'stderr: ${result.stderr}',
+        );
+
+        final file = entityFile('id_operators');
+        expect(file.existsSync(), isTrue, reason: 'entity file must be written');
+        final src = await file.readAsString();
+
+        // The fix: the getter is named `in_` (Dart-safe) and carries
+        // `@JsonKey(name: 'in')` so json_serializable serializes with the
+        // `in` wire key (preserving the Vendure contract).
+        expect(
+          src,
+          contains("@JsonKey(name: 'in')"),
+          reason: '@JsonKey(name: \'in\') must annotate the in_ getter',
+        );
+        expect(
+          src,
+          contains('String get in_;'),
+          reason: 'Dart-safe getter name `in_` must be emitted',
+        );
+
+        // Negative: the raw keyword `in` must NOT appear as a getter
+        // identifier. Matches `get in;` (the broken pre-fix form).
+        expect(
+          src,
+          isNot(RegExp(r'get\s+in\s*;')),
+          reason: 'raw `get in;` must not appear — that is the #303 bug',
+        );
+
+        // The plain `eq` field carries no @JsonKey (name matches wire).
+        expect(src, contains('String get eq;'));
+        expect(
+          src,
+          isNot(contains("@JsonKey(name: 'eq')")),
+          reason: 'no @JsonKey needed when Dart name == wire name',
+        );
+
+        await expectFormats(file);
+
+        // Success message should make the wire-name remap visible.
+        expect(
+          result.stdout,
+          contains("in_: String (json: 'in')"),
+          reason: 'success message must show the json wire name',
+        );
+      },
+    );
+
+    test(
+      'raw `--field in:String` (Dart keyword) is rejected up front',
+      timeout: const Timeout(Duration(minutes: 2)),
+      () async {
+        final result = await runZfa([
+          'entity',
+          'create',
+          '-n',
+          'TestKeyword',
+          '--field',
+          'in:String',
+        ]);
+
+        // The fix: the CLI refuses the bare-keyword form BEFORE writing
+        // anything — instead of emitting `String get in;` and failing
+        // later at `zfa build` with a misleading analyzer error.
+        expect(
+          result.exitCode,
+          isNot(equals(0)),
+          reason: 'raw Dart-keyword field name must be rejected',
+        );
+
+        // No file should have been written.
+        expect(
+          entityFile('test_keyword').existsSync(),
+          isFalse,
+          reason: 'no entity file should exist after a rejected create',
+        );
+
+        // The error message must point the user at the `:json=<wire>` fix.
+        expect(
+          result.stdout + result.stderr,
+          contains('Dart keyword'),
+          reason: 'error must explain the keyword collision',
+        );
+        expect(
+          result.stdout + result.stderr,
+          contains('in_'),
+          reason: 'error must suggest the Dart-safe name `in_`',
+        );
+        expect(
+          result.stdout + result.stderr,
+          contains('json=in'),
+          reason: 'error must suggest the `:json=in` remap',
+        );
+      },
+    );
+
+    test(
+      '`add-field` also enforces the keyword guard + accepts `:json=`',
+      timeout: const Timeout(Duration(minutes: 2)),
+      () async {
+        // First, create a plain entity to add fields to.
+        final create = await runZfa([
+          'entity',
+          'create',
+          '-n',
+          'ConfigArgDefinition',
+          '--field',
+          'name:String',
+        ]);
+        expect(create.exitCode, equals(0), reason: 'stderr: ${create.stderr}');
+
+        // Adding a raw-keyword field must be refused with the same error.
+        final badAdd = await runZfa([
+          'entity',
+          'add-field',
+          '-n',
+          'ConfigArgDefinition',
+          '--field',
+          'required:bool',
+        ]);
+        expect(
+          badAdd.exitCode,
+          isNot(equals(0)),
+          reason: 'add-field must reject raw Dart keyword `required`',
+        );
+        expect(
+          badAdd.stdout + badAdd.stderr,
+          contains('json=required'),
+          reason: 'error must suggest the `:json=required` remap',
+        );
+
+        // Adding with the explicit `:json=` remap succeeds and emits the
+        // @JsonKey annotation.
+        final goodAdd = await runZfa([
+          'entity',
+          'add-field',
+          '-n',
+          'ConfigArgDefinition',
+          '--field',
+          'required_:bool:json=required',
+        ]);
+        expect(
+          goodAdd.exitCode,
+          equals(0),
+          reason: 'add-field with :json= must succeed. stderr: ${goodAdd.stderr}',
+        );
+
+        final file = entityFile('config_arg_definition');
+        final src = await file.readAsString();
+        expect(
+          src,
+          contains("@JsonKey(name: 'required')"),
+          reason: '@JsonKey(name: \'required\') must annotate the required_ getter',
+        );
+        expect(
+          src,
+          contains('bool get required_;'),
+          reason: 'Dart-safe getter name `required_` must be emitted',
+        );
+        expect(
+          src,
+          isNot(RegExp(r'get\s+required\s*;')),
+          reason: 'raw `get required;` must not appear',
+        );
+
+        await expectFormats(file);
+      },
+    );
+
+    test(
+      '`and:...:json=_and` + `or:...:json=_or` emit the Vendure wire keys',
+      timeout: const Timeout(Duration(minutes: 2)),
+      () async {
+        // Vendure `*FilterParameter` types compose nested filters with
+        // `_and` / `_or` (leading-underscore wire keys). Self-references
+        // need `--allow-forward-refs` (the entity's own dir does not exist
+        // yet at create time).
+        final result = await runZfa([
+          'entity',
+          'create',
+          '-n',
+          'ProductFilterParameter',
+          '--allow-forward-refs',
+          '--field',
+          'and:ProductFilterParameter:json=_and',
+          '--field',
+          'or:ProductFilterParameter:json=_or',
+        ]);
+
+        expect(
+          result.exitCode,
+          equals(0),
+          reason: 'entity create with _and/_or wire names must succeed. '
+          'stderr: ${result.stderr}',
+        );
+
+        final file = entityFile('product_filter_parameter');
+        expect(file.existsSync(), isTrue);
+        final src = await file.readAsString();
+
+        // Both wire keys are emitted via @JsonKey, getters are the
+        // Dart-safe `and` / `or` names.
+        expect(src, contains("@JsonKey(name: '_and')"));
+        expect(src, contains("@JsonKey(name: '_or')"));
+        expect(src, contains('ProductFilterParameter get and;'));
+        expect(src, contains('ProductFilterParameter get or;'));
+
+        // Negative: no private `_and`/`_or` Dart identifiers (a leading `_`
+        // would mark the getter private and break the API).
+        expect(
+          src,
+          isNot(RegExp(r'get\s+_and\s*;')),
+          reason: 'private `_and` getter must not be emitted',
+        );
+        expect(
+          src,
+          isNot(RegExp(r'get\s+_or\s*;')),
+          reason: 'private `_or` getter must not be emitted',
+        );
+
+        await expectFormats(file);
+
+        // Success message shows both wire names.
+        expect(
+          result.stdout,
+          contains("and: ProductFilterParameter (json: '_and')"),
+        );
+        expect(
+          result.stdout,
+          contains("or: ProductFilterParameter (json: '_or')"),
+        );
+      },
+    );
+
+    test(
+      '`entity from-json` auto-resolves Dart-keyword + `_`-prefixed JSON keys',
+      timeout: const Timeout(Duration(minutes: 2)),
+      () async {
+        // A JSON payload mirroring the Vendure shape: `in` (Dart keyword),
+        // `_and` / `_or` (leading-underscore wire keys), and a plain key.
+        final jsonPath = p.join(workspace.path, 'payload.json');
+        await File(jsonPath).writeAsString('''
+{
+  "in": ["abc"],
+  "eq": "abc",
+  "_and": [],
+  "_or": []
+}
+''');
+
+        final result = await runZfa([
+          'entity',
+          'from-json',
+          'payload.json',
+          '-n',
+          'IdOperatorsFromJson',
+        ]);
+
+        expect(
+          result.exitCode,
+          equals(0),
+          reason: 'from-json must accept Dart-keyword and _-prefixed keys. '
+          'stderr: ${result.stderr}',
+        );
+
+        final file = entityFile('id_operators_from_json');
+        expect(file.existsSync(), isTrue);
+        final src = await file.readAsString();
+
+        // `in` (Dart keyword) -> Dart name `in_`, jsonName `in`.
+        expect(src, contains("@JsonKey(name: 'in')"));
+        expect(src, contains('get in_;'));
+
+        // `_and` / `_or` -> Dart names `and` / `or`, jsonName `_and`/`_or`.
+        expect(src, contains("@JsonKey(name: '_and')"));
+        expect(src, contains("@JsonKey(name: '_or')"));
+        expect(src, contains('get and;'));
+        expect(src, contains('get or;'));
+
+        // Plain `eq` key: no @JsonKey needed.
+        expect(src, contains('get eq;'));
+        expect(
+          src,
+          isNot(contains("@JsonKey(name: 'eq')")),
+        );
+
+        // No raw keyword / private identifiers.
+        expect(
+          src,
+          isNot(RegExp(r'get\s+in\s*;')),
+          reason: 'raw `get in;` must not appear (from-json path)',
+        );
+        expect(
+          src,
+          isNot(RegExp(r'get\s+_and\s*;')),
+          reason: 'private `_and` getter must not appear (from-json path)',
+        );
+
+        await expectFormats(file);
+      },
+    );
+
+    test(
+      'end-to-end: build_runner emits `.g.dart` with the correct wire keys',
+      timeout: const Timeout(Duration(minutes: 5)),
+      () async {
+        // Skip when the local zorphy checkout (used by zuraffa's
+        // dependency_overrides) is not available — e.g. CI without a
+        // sibling zorphy repo. The zorphy `development` git ref in
+        // pubspec.yaml still carries the fix in that case.
+        final skipReason = _checkLocalZorphy(zorphyPath, zorphyAnnotationPath);
+        if (skipReason != null) {
+          print(skipReason);
+          return;
+        }
+
+        // Workspace pubspec — path deps on local zorphy (mirrors zuraffa's
+        // dependency_overrides) + build_runner + json_serializable.
+        await File(p.join(workspace.path, 'pubspec.yaml')).writeAsString('''
+name: issue_303_e2e_app
+environment:
+  sdk: '>=3.12.0 <4.0.0'
+dependencies:
+  zorphy:
+    path: $zorphyPath
+  zorphy_annotation:
+    path: $zorphyAnnotationPath
+  json_annotation: ^4.12.0
+dev_dependencies:
+  build_runner: ^2.4.0
+  json_serializable: ^6.13.0
+  analyzer: '14.1.0'
+dependency_overrides:
+  zorphy:
+    path: $zorphyPath
+  zorphy_annotation:
+    path: $zorphyAnnotationPath
+  analyzer: '14.1.0'
+''');
+
+        await File(p.join(workspace.path, 'build.yaml')).writeAsString('''
+targets:
+  \$default:
+    builders:
+      zorphy:zorphy:
+        enabled: true
+        generate_for:
+          - lib/**
+      json_serializable:
+        enabled: true
+        generate_for:
+          - lib/**
+        options:
+          explicit_to_json: false
+          include_if_null: false
+''');
+
+        // Create the entity with the json= remap.
+        final create = await runZfa([
+          'entity',
+          'create',
+          '-n',
+          'IdOperatorsE2E',
+          '--field',
+          'in_:String:json=in',
+          '--field',
+          'eq:String',
+        ]);
+        expect(
+          create.exitCode,
+          equals(0),
+          reason: 'entity create failed: ${create.stdout}${create.stderr}',
+        );
+
+        // Resolve deps + run build_runner to generate the `.g.dart`.
+        final pubGet = await runDart(['pub', 'get']);
+        expect(
+          pubGet.exitCode,
+          equals(0),
+          reason: 'dart pub get failed: ${pubGet.stdout}${pubGet.stderr}',
+        );
+
+        final build = await runDart(['run', 'build_runner', 'build']);
+        expect(
+          build.exitCode,
+          equals(0),
+          reason: 'build_runner failed: ${build.stdout}${build.stderr}',
+        );
+
+        // The generated `.g.dart` must serialize using the WIRE key `in`,
+        // not the Dart name `in_`. This is the actual user-visible
+        // contract: a Vendure server expects `"in": [...]`, not `"in_": [...]`.
+        final gFile = File(
+          p.join(
+            workspace.path,
+            'lib',
+            'src',
+            'domain',
+            'entities',
+            'id_operators_e2_e',
+            'id_operators_e2_e.g.dart',
+          ),
+        );
+        expect(
+          gFile.existsSync(),
+          isTrue,
+          reason: '.g.dart was not generated by build_runner',
+        );
+        final generated = gFile.readAsStringSync();
+
+        // Wire key `in` must be present (the contract).
+        expect(
+          generated,
+          contains("'in':"),
+          reason: "generated .g.dart must use the 'in' wire key "
+              '(the whole point of #303)',
+        );
+
+        // The Dart name `in_` is the instance member access on the RHS
+        // of the toJson entry — the wire key is `in`, the accessor is
+        // `instance.in_`.
+        expect(
+          generated,
+          contains("'in': instance.in_"),
+          reason: "generated .g.dart toJson must map wire key 'in' to "
+              '`instance.in_` (Dart name) — that is the #303 contract',
+        );
+
+        // Negative: the broken pre-fix form must NOT appear in the toJson
+        // output. The bug was that json_serializable used the Dart name
+        // `in_` as the wire key, producing `'in_': instance.in_`. After
+        // the fix, only `'in': instance.in_` appears in the toJson map.
+        // (Note: `'in_'` DOES legitimately appear in `fieldKeyMap` and as
+        // a constructor parameter name — those are NOT the bug. The bug
+        // signature is `'in_': instance.in_` in the toJson map literal.)
+        expect(
+          generated,
+          isNot(contains("'in_': instance.in_")),
+          reason: "generated .g.dart toJson must NOT use 'in_' as the wire "
+              'key (that is the #303 bug — wire contract broken). The fix '
+              "uses 'in' as the wire key with instance.in_ as the accessor.",
+        );
+
+        // `eq` (no remap) keeps using the Dart name as the wire key.
+        expect(generated, contains("'eq':"));
+
+        // `dart analyze` on the generated library must be clean.
+        final analyze = await runDart(['analyze', 'lib']);
+        expect(
+          analyze.exitCode,
+          equals(0),
+          reason: 'dart analyze reported issues:\n'
+          '${analyze.stdout}${analyze.stderr}',
+        );
+      },
+    );
+  });
+}
+
+/// Returns `null` if both local zorphy package paths exist, otherwise a
+/// human-readable skip reason.
+String? _checkLocalZorphy(String zorphyPath, String zorphyAnnotationPath) {
+  if (!Directory(zorphyPath).existsSync()) {
+    return 'Skipping: local zorphy checkout not found at $zorphyPath '
+        '(CI without a sibling zorphy repo). The fix is still carried by '
+        'the zorphy `development` git ref in pubspec.yaml.';
+  }
+  if (!Directory(zorphyAnnotationPath).existsSync()) {
+    return 'Skipping: local zorphy_annotation checkout not found at '
+        '$zorphyAnnotationPath.';
+  }
+  return null;
+}


### PR DESCRIPTION
Closes #303

Issue #303: zfa entity create had no way to express a Dart field name
different from the JSON wire name. Three concrete failures:

  1. --field 'in_:String' succeeded but emitted JSON key 'in_' (broken
     wire contract — Vendure expects 'in').
  2. --field 'in:String' accepted the keyword, emitted invalid
     'String get in;', and zfa build later failed with
     'in can'"'t be used as an identifier because it'"'s a keyword.'
  3. --field and:... emitted 'and'/'or', not the Vendure '_and'/'_or'.
  4. zfa entity from-json had the same limitation.

The fix in zorphy#80 (merged into zorphy development) added
FieldDefinition.jsonName + the name:type:json=<wire> field syntax +
@JsonKey(name: <wire>) emission in EntityCreator. This PR wires the
zuraffa side to consume it.

Source changes (lib/src/commands/entity_command.dart):
- Add _dartKeywords set (built-in + contextual: in, required, sealed,
  when, record, view, base, ...) and _isDartKeyword helper.
- Add _resolveFieldName(jsonKey) helper: Dart keyword -> (<key>_, <key>);
  leading _ -> (stripped, <key>); otherwise -> (<key>, null).
- Add _findBareKeywordFields guard + wire it into _handleCreate AND
  _handleAddField — refuses raw Dart-keyword field names (e.g. in:String)
  with an actionable error pointing to in_:String:json=in. Exits 1,
  no file written. Closes the silent String get in -> build failure.
- Update _extractFieldsFromJson to use _resolveFieldName and thread
  jsonName through FieldDefinition — from-json now auto-resolves
  Dart-keyword and _-prefixed JSON keys (no manual :json= needed).
- Add _formatFieldDisplay helper — success messages append
  (json: <wire>) when jsonName != name, so the remap is visible.
- Update _printHelp with a new FIELD SYNTAX: section documenting
  name:type:json=<wire> + Vendure-style examples (IdOperators
  in_:String:json=in, ProductFilterParameter _and/_or).

Tests (test/regression/issue_303_json_wire_names_test.dart, new):
- 6 regression tests covering: in_:json=in emits @JsonKey(name: in);
  raw in:String is rejected up front; add-field enforces same guard;
  _and/_or wire keys via :json=; from-json auto-resolves; end-to-end
  build_runner round-trip confirms .g.dart toJson emits
  in: instance.in_ (NOT in_: instance.in_ — the silent
  wire-contract break described in the issue).

All 6 new tests pass; dart analyze clean on changed files; smoke tests
on related regression suites (#306, #294, #308, cli_command, entity
type validator) all green.