### PR TITLE
fix(zfa route create): align route/view contract — probe detail_view on disk + accept entity named-param (#328)

### DIFF
--- a/lib/src/core/ast/ast_helper.dart
+++ b/lib/src/core/ast/ast_helper.dart
@@ -420,6 +420,29 @@ class AstHelper {
     );
   }
 
+  String removeElementsFromReturnListInFunctionWhere({
+    required String source,
+    required String functionName,
+    required bool Function(String elementSource) matches,
+    bool format = true,
+  }) {
+    final parseResult = parseSource(source);
+    final unit = parseResult.unit;
+    if (unit == null) {
+      return source;
+    }
+    final functionNode = findFunction(unit, functionName);
+    if (functionNode == null) {
+      return source;
+    }
+    return AstModifier.removeElementsFromReturnListInFunctionWhere(
+      source: source,
+      functionNode: functionNode,
+      matches: matches,
+      format: format,
+    );
+  }
+
   String removeStatementFromFunction({
     required String source,
     required String functionName,

--- a/lib/src/core/ast/ast_modifier.dart
+++ b/lib/src/core/ast/ast_modifier.dart
@@ -341,6 +341,51 @@ class AstModifier {
     return source;
   }
 
+  /// Removes every element of the function's returned list literal for which
+  /// [matches] returns true. Unlike [removeElementFromReturnListInFunction],
+  /// elements do not have to match a full source string exactly — this allows
+  /// replacing stale elements identified by a stable partial identity.
+  static String removeElementsFromReturnListInFunctionWhere({
+    required String source,
+    required FunctionDeclaration functionNode,
+    required bool Function(String elementSource) matches,
+    bool format = true,
+  }) {
+    final body = functionNode.functionExpression.body;
+    if (body is! BlockFunctionBody) {
+      return source;
+    }
+
+    final returnStatement = body.block.statements
+        .whereType<ReturnStatement>()
+        .firstOrNull;
+    if (returnStatement == null) {
+      return source;
+    }
+
+    final expression = returnStatement.expression;
+    if (expression is! ListLiteral) {
+      return source;
+    }
+
+    final toRemove =
+        expression.elements
+            .where((element) => matches(element.toSource()))
+            .toList()
+          // Remove from the end so earlier offsets stay valid.
+          ..sort((a, b) => b.offset.compareTo(a.offset));
+    if (toRemove.isEmpty) {
+      return source;
+    }
+
+    var result = source;
+    for (final element in toRemove) {
+      result =
+          result.substring(0, element.offset) + result.substring(element.end);
+    }
+    return format ? _formatSafe(result) : result;
+  }
+
   static String removeStatement({
     required String source,
     required List<Statement> statements,

--- a/lib/src/plugins/route/builders/route_builder.dart
+++ b/lib/src/plugins/route/builders/route_builder.dart
@@ -414,13 +414,25 @@ class RouteBuilder {
         (config.methods.contains('getList') ||
             config.methods.contains('watchList'));
 
+    // #328: Probe the actual view file on disk instead of deriving from the
+    // route's own methods list. `zfa view create` only emits a separate
+    // `<entity>_detail_view.dart` when the view was generated with BOTH a
+    // list method (getList/watchList) AND a detail method (get/watch). When
+    // the view was created with different methods than the route (the common
+    // smoke-test case: `zfa view create` defaults to `get,update`, then
+    // `zfa route create --methods=get,getList` is run later), the detail view
+    // file does not exist, and the route must not reference it. Reading the
+    // filesystem aligns the route generator with the view generator's actual
+    // output and eliminates the `uri_does_not_exist` analyze errors.
+    final detailViewPath = path.join(
+      outputDir,
+      'presentation',
+      'pages',
+      domainSnake,
+      '${entitySnake}_detail_view.dart',
+    );
     final hasDetailView =
-        !isCustom &&
-        (config.methods.contains('get') || config.methods.contains('watch'));
-    final hasListView =
-        !isCustom &&
-        (config.methods.contains('getList') ||
-            config.methods.contains('watchList'));
+        !isCustom && await fileSystem.exists(detailViewPath);
 
     final goRoutes = <Expression>[
       if (isCustom)
@@ -458,7 +470,7 @@ class RouteBuilder {
           routeNameBase: routeNameBase,
           viewParam: dependencyInfo.viewParam,
           config: config,
-          viewName: (hasListView && hasDetailView)
+          viewName: hasDetailView
               ? '${entityName}DetailView'
               : '${entityName}View',
         ),
@@ -479,7 +491,7 @@ class RouteBuilder {
           routeNameBase: routeNameBase,
           viewParam: dependencyInfo.viewParam,
           config: config,
-          viewName: (hasListView && hasDetailView)
+          viewName: hasDetailView
               ? '${entityName}DetailView'
               : '${entityName}View',
         ),
@@ -489,7 +501,7 @@ class RouteBuilder {
       'package:go_router/go_router.dart',
       'package:zuraffa/zuraffa.dart',
       '../presentation/pages/$domainSnake/${entitySnake}_view.dart',
-      if (hasListView && hasDetailView)
+      if (hasDetailView)
         '../presentation/pages/$domainSnake/${entitySnake}_detail_view.dart',
       if (!config.noEntity) '../domain/entities/$entitySnake/$entitySnake.dart',
       if (dependencyInfo.importPath.isNotEmpty) dependencyInfo.importPath,

--- a/lib/src/plugins/route/builders/route_builder.dart
+++ b/lib/src/plugins/route/builders/route_builder.dart
@@ -205,6 +205,8 @@ class RouteBuilder {
     required Map<String, String> newRouteConstants,
     required List<Expression> newGoRoutes,
     required List<String> imports,
+    required String detailViewImport,
+    required bool hasDetailView,
     bool force = false,
   }) {
     var content = existingContent;
@@ -224,6 +226,17 @@ class RouteBuilder {
       if (!content.contains("import '$import';")) {
         content = "import '$import';\n$content";
       }
+    }
+
+    // Synchronize the optional detail-view import: when the detail-view
+    // file no longer exists, drop its now-stale import instead of keeping
+    // a reference to a deleted file (which analyze flags as
+    // uri_does_not_exist).
+    if (!hasDetailView) {
+      content = content.replaceAll(
+        RegExp("import\\s+'${RegExp.escape(detailViewImport)}';"),
+        '',
+      );
     }
 
     final helper = const AstHelper();
@@ -266,6 +279,24 @@ class RouteBuilder {
 
       if (normalizedContent.contains(normalizedRouteSource)) {
         continue;
+      }
+
+      // The route source changed (e.g. the view class flipped between
+      // <Entity>View and <Entity>DetailView when the detail-view file
+      // appeared or disappeared). Replace the existing route by its
+      // stable `name:` identity instead of appending a second route for
+      // the same path and name.
+      final nameMatch = RegExp(r"name:\s*'([^']+)'").firstMatch(routeSource);
+      final nameIdentity = nameMatch?.group(1);
+      if (nameIdentity != null) {
+        final identityPattern = RegExp(
+          "name:\\s*'${RegExp.escape(nameIdentity)}'",
+        );
+        content = helper.removeElementsFromReturnListInFunctionWhere(
+          source: content,
+          functionName: routesGetterName,
+          matches: (elementSource) => identityPattern.hasMatch(elementSource),
+        );
       }
 
       content = helper.addElementToReturnListInFunction(
@@ -431,8 +462,9 @@ class RouteBuilder {
       domainSnake,
       '${entitySnake}_detail_view.dart',
     );
-    final hasDetailView =
-        !isCustom && await fileSystem.exists(detailViewPath);
+    final hasDetailView = !isCustom && await fileSystem.exists(detailViewPath);
+    final detailViewImport =
+        '../presentation/pages/$domainSnake/${entitySnake}_detail_view.dart';
 
     final goRoutes = <Expression>[
       if (isCustom)
@@ -501,8 +533,7 @@ class RouteBuilder {
       'package:go_router/go_router.dart',
       'package:zuraffa/zuraffa.dart',
       '../presentation/pages/$domainSnake/${entitySnake}_view.dart',
-      if (hasDetailView)
-        '../presentation/pages/$domainSnake/${entitySnake}_detail_view.dart',
+      if (hasDetailView) detailViewImport,
       if (!config.noEntity) '../domain/entities/$entitySnake/$entitySnake.dart',
       if (dependencyInfo.importPath.isNotEmpty) dependencyInfo.importPath,
     ];
@@ -573,6 +604,8 @@ class RouteBuilder {
             newRouteConstants: routeConstants,
             newGoRoutes: goRoutes,
             imports: imports,
+            detailViewImport: detailViewImport,
+            hasDetailView: hasDetailView,
             force: config.force,
           )
         : entityRoutesBuilder.buildFile(

--- a/lib/src/plugins/view/view_plugin.dart
+++ b/lib/src/plugins/view/view_plugin.dart
@@ -555,7 +555,15 @@ class ViewPlugin extends FileGeneratorPlugin implements CliAwarePlugin {
     final fields = <Field>[];
 
     final withState = config.generateState || config.customStateName != null;
-    if (withState && !config.noEntity) {
+    // #328: Always accept the entity named-param when the entity is
+    // CRUD-backed (`isEntityBased`), so the route generator's
+    // `View(entityCamel: state.extra as Entity?)` call compiles even without
+    // --state. Previously this field was only emitted under --state, so the
+    // route's named-arg had no matching constructor parameter and analyze
+    // flagged `extra_positional_arguments` / undefined named-param. The
+    // field stays optional (not `required`), so non-route call sites that
+    // construct the view without the entity still compile.
+    if (!config.noEntity && (withState || config.isEntityBased)) {
       fields.add(
         Field(
           (f) => f
@@ -690,7 +698,11 @@ class ViewPlugin extends FileGeneratorPlugin implements CliAwarePlugin {
       imports.add('${presenterSnake}_presenter.dart');
 
       final withState = config.generateState || config.customStateName != null;
-      if (withState && !config.noEntity) {
+      // #328: Import the entity whenever the view's constructor accepts it
+      // (CRUD-backed or --state). Must match the field condition in
+      // _buildRouteFieldsForView, otherwise the field's type
+      // (`${config.name}?`) references an unimported symbol.
+      if (!config.noEntity && (withState || config.isEntityBased)) {
         final entitySnake = config.nameSnake;
         imports.add(
           '$relativePath../domain/entities/$entitySnake/$entitySnake.dart',

--- a/test/regression/issue_328_route_view_contract_test.dart
+++ b/test/regression/issue_328_route_view_contract_test.dart
@@ -1,0 +1,531 @@
+// Regression test for issue #328:
+// https://github.com/arrrrny/zuraffa/issues/328
+//
+// Two contract mismatches between `zfa route create` and `zfa view create`:
+//
+//   A. `zfa route create --methods=get,getList` emitted an import for
+//      `<entity>_detail_view.dart` and referenced `<Entity>DetailView`
+//      even when no such file existed on disk. `zfa view create` only
+//      emits a separate detail-view file when the view was generated with
+//      BOTH a list method (getList/watchList) AND a detail method
+//      (get/watch). When the view was created with different methods than
+//      the route (the common smoke-test case: view defaults to
+//      `get,update`, then route is run with `get,getList`), the detail
+//      view file does not exist, and analyze flagged `uri_does_not_exist`.
+//
+//   B. `zfa route create` always passed `View(entityCamel: state.extra as
+//      Entity?)` for CRUD-backed entities, but `zfa view create` only
+//      added the `entityCamel` named-param to the view constructor under
+//      `--state`. Without `--state` the route's named-arg had no matching
+//      constructor parameter, producing `extra_positional_arguments` /
+//      undefined named-param errors.
+//
+// Fix:
+//   - route_builder.dart probes the actual `<entity>_detail_view.dart`
+//     file on disk and only emits the `DetailView` reference + import
+//     when the file exists.
+//   - view_plugin.dart emits the `entityCamel` field (and entity import)
+//     whenever the entity is CRUD-backed (`isEntityBased`), not just
+//     under `--state`.
+
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
+import 'package:test/test.dart';
+import 'package:zuraffa/src/core/generator_options.dart';
+import 'package:zuraffa/src/models/generator_config.dart';
+import 'package:zuraffa/src/plugins/route/builders/route_builder.dart';
+import 'package:zuraffa/src/plugins/view/view_plugin.dart';
+
+void main() {
+  late Directory tempDir;
+  late String outputDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('zuraffa_issue328_');
+    outputDir = Directory('${tempDir.path}/lib/src').path;
+  });
+
+  tearDown(() async {
+    if (tempDir.existsSync()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // Bug A: route builder must not reference a non-existent detail view
+  // ─────────────────────────────────────────────────────────────────
+
+  group('issue #328 A — route/view detail_view contract', () {
+    test(
+      'route does NOT import detail_view.dart when no detail view file '
+      'exists on disk',
+      () async {
+        final builder = RouteBuilder(
+          outputDir: outputDir,
+          options: const GeneratorOptions(
+            dryRun: false,
+            force: true,
+            verbose: false,
+          ),
+        );
+
+        // Simulate the smoke-test scenario: route create with
+        // --methods=get,getList but NO view files generated yet (or view
+        // was generated with different methods).
+        await builder.generate(
+          GeneratorConfig(
+            name: 'ZikZakScore',
+            methods: const ['get', 'getList'],
+            generateVpcs: true,
+            generateRoute: true,
+            outputDir: outputDir,
+          ),
+        );
+
+        final routesFile = File(
+          '$outputDir/routing/zik_zak_score_routes.dart',
+        );
+        expect(routesFile.existsSync(), isTrue);
+        final content = routesFile.readAsStringSync();
+
+        // Must NOT import the non-existent detail view file.
+        expect(
+          content.contains('zik_zak_score_detail_view.dart'),
+          isFalse,
+          reason:
+              'route must not import <entity>_detail_view.dart when the '
+              'file does not exist on disk (was the cause of 53× '
+              'uri_does_not_exist errors in issue #328).',
+        );
+        // Must NOT reference the non-existent DetailView class.
+        expect(
+          content.contains('ZikZakScoreDetailView'),
+          isFalse,
+          reason:
+              'route must not reference <Entity>DetailView when the '
+              'detail view file does not exist on disk.',
+        );
+        // The detail route should fall back to the main View.
+        expect(
+          content.contains('ZikZakScoreView'),
+          isTrue,
+          reason: 'detail route should use the main <Entity>View.',
+        );
+        // The list view import must still be present.
+        expect(
+          content.contains('zik_zak_score_view.dart'),
+          isTrue,
+          reason: 'route must still import the main view file.',
+        );
+      },
+    );
+
+    test(
+      'route DOES import detail_view.dart when the detail view file '
+      'exists on disk',
+      () async {
+        // Simulate `zfa view create --methods=get,getList` having been
+        // run first, which generates both <entity>_view.dart and
+        // <entity>_detail_view.dart.
+        final viewDir = Directory(
+          '$outputDir/presentation/pages/zik_zak_score',
+        );
+        await viewDir.create(recursive: true);
+        // Touch both view files so the route builder's filesystem probe
+        // finds the detail view.
+        await File('${viewDir.path}/zik_zak_score_view.dart').writeAsString(
+          '// stub view file\n',
+        );
+        await File(
+          '${viewDir.path}/zik_zak_score_detail_view.dart',
+        ).writeAsString('// stub detail view file\n');
+
+        final builder = RouteBuilder(
+          outputDir: outputDir,
+          options: const GeneratorOptions(
+            dryRun: false,
+            force: true,
+            verbose: false,
+          ),
+        );
+
+        await builder.generate(
+          GeneratorConfig(
+            name: 'ZikZakScore',
+            methods: const ['get', 'getList'],
+            generateVpcs: true,
+            generateRoute: true,
+            outputDir: outputDir,
+          ),
+        );
+
+        final routesFile = File(
+          '$outputDir/routing/zik_zak_score_routes.dart',
+        );
+        expect(routesFile.existsSync(), isTrue);
+        final content = routesFile.readAsStringSync();
+
+        // When the detail view file exists, the route SHOULD import it.
+        expect(
+          content.contains('zik_zak_score_detail_view.dart'),
+          isTrue,
+          reason:
+              'route must import <entity>_detail_view.dart when the file '
+              'exists on disk (the master/detail contract).',
+        );
+        // And reference the DetailView class.
+        expect(
+          content.contains('ZikZakScoreDetailView'),
+          isTrue,
+          reason:
+              'route must reference <Entity>DetailView when the detail '
+              'view file exists on disk.',
+        );
+      },
+    );
+
+    test(
+      'route falls back to main View for detail route when only the '
+      'list view exists (no detail file)',
+      () async {
+        // Only the list view file exists, not the detail view.
+        final viewDir = Directory(
+          '$outputDir/presentation/pages/product',
+        );
+        await viewDir.create(recursive: true);
+        await File('${viewDir.path}/product_view.dart').writeAsString(
+          '// stub view file\n',
+        );
+        // Note: product_detail_view.dart is intentionally NOT created.
+
+        final builder = RouteBuilder(
+          outputDir: outputDir,
+          options: const GeneratorOptions(
+            dryRun: false,
+            force: true,
+            verbose: false,
+          ),
+        );
+
+        await builder.generate(
+          GeneratorConfig(
+            name: 'Product',
+            methods: const ['get', 'getList', 'create'],
+            generateVpcs: true,
+            generateRoute: true,
+            outputDir: outputDir,
+          ),
+        );
+
+        final routesFile = File('$outputDir/routing/product_routes.dart');
+        expect(routesFile.existsSync(), isTrue);
+        final content = routesFile.readAsStringSync();
+
+        expect(
+          content.contains('product_detail_view.dart'),
+          isFalse,
+          reason: 'detail view file does not exist; must not be imported.',
+        );
+        expect(
+          content.contains('ProductDetailView'),
+          isFalse,
+          reason: 'detail view class does not exist; must not be referenced.',
+        );
+        // The detail route should use ProductView (the main view).
+        expect(
+          content.contains('ProductView'),
+          isTrue,
+        );
+      },
+    );
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // Bug B: view constructor must accept the entity named-param
+  // ─────────────────────────────────────────────────────────────────
+
+  group('issue #328 B — view constructor entity named-param', () {
+    test(
+      'view constructor accepts entity named-param when CRUD-backed '
+      'WITHOUT --state',
+      () async {
+        // Default zfa view create: methods=get,update, no --state flag.
+        // Before the fix, the constructor only had {super.key,
+        // super.routeObserver, required this.repository, this.id} and
+        // did NOT accept `this.<entityCamel>`, so the route's
+        // `View(entityCamel: state.extra as Entity?)` call failed.
+        final plugin = ViewPlugin(
+          outputDir: outputDir,
+          options: const GeneratorOptions(
+            dryRun: false,
+            force: true,
+            verbose: false,
+          ),
+        );
+
+        final files = await plugin.generate(
+          GeneratorConfig(
+            name: 'ZikZakScore',
+            methods: const ['get', 'update'],
+            generateView: true,
+            outputDir: outputDir,
+          ),
+        );
+        expect(files, isNotEmpty);
+        final content = files.first.content ?? '';
+
+        // The constructor must accept the entity named-param.
+        // The field is emitted as `this.zikZakScore` (a `final` field
+        // initialized via the constructor).
+        expect(
+          content.contains('this.zikZakScore,'),
+          isTrue,
+          reason:
+              'view constructor must accept the entity named-param '
+              '(this.zikZakScore) when the entity is CRUD-backed, even '
+              'without --state. The route generator passes '
+              '`zikZakScore: state.extra as ZikZakScore?` and the view '
+              'must accept it (issue #328 class B).',
+        );
+        // The entity import must be present (the field type references
+        // the entity class).
+        expect(
+          content.contains(
+            '../domain/entities/zik_zak_score/zik_zak_score.dart',
+          ),
+          isTrue,
+          reason:
+              'entity import must be present when the constructor '
+              'accepts the entity named-param.',
+        );
+      },
+    );
+
+    test(
+      'view constructor accepts entity named-param when --state is set '
+      '(existing behavior preserved)',
+      () async {
+        final plugin = ViewPlugin(
+          outputDir: outputDir,
+          options: const GeneratorOptions(
+            dryRun: false,
+            force: true,
+            verbose: false,
+          ),
+        );
+
+        final files = await plugin.generate(
+          GeneratorConfig(
+            name: 'Product',
+            methods: const ['get', 'getList'],
+            generateView: true,
+            generateState: true,
+            outputDir: outputDir,
+          ),
+        );
+        expect(files, isNotEmpty);
+        // Find the list view file (not the detail view).
+        final listViewFile = files.firstWhere(
+          (f) => f.path.contains('product_view.dart'),
+        );
+        final content = listViewFile.content ?? '';
+
+        expect(
+          content.contains('this.product,'),
+          isTrue,
+          reason:
+              'view constructor must accept the entity named-param '
+              '(this.product) under --state (existing behavior).',
+        );
+      },
+    );
+
+    test(
+      'view constructor does NOT accept entity named-param when '
+      'noEntity is true',
+      () async {
+        final plugin = ViewPlugin(
+          outputDir: outputDir,
+          options: const GeneratorOptions(
+            dryRun: false,
+            force: true,
+            verbose: false,
+          ),
+        );
+
+        final files = await plugin.generate(
+          GeneratorConfig(
+            name: 'Notification',
+            methods: const ['get', 'update'],
+            generateView: true,
+            noEntity: true,
+            outputDir: outputDir,
+          ),
+        );
+        expect(files, isNotEmpty);
+        final content = files.first.content ?? '';
+
+        expect(
+          content.contains('this.notification,'),
+          isFalse,
+          reason:
+              'view constructor must NOT accept the entity named-param '
+              'when noEntity is true (non-entity-backed view).',
+        );
+      },
+    );
+
+    test(
+      'route passes entity named-param using the exact camelCase name '
+      'the view declares',
+      () async {
+        // Generate the view first (so the detail view file exists and
+        // the route builder picks the DetailView path).
+        final viewPlugin = ViewPlugin(
+          outputDir: outputDir,
+          options: const GeneratorOptions(
+            dryRun: false,
+            force: true,
+            verbose: false,
+          ),
+        );
+        await viewPlugin.generate(
+          GeneratorConfig(
+            name: 'Product',
+            methods: const ['get', 'getList'],
+            generateView: true,
+            outputDir: outputDir,
+          ),
+        );
+
+        // Now generate routes with the same methods.
+        final routeBuilder = RouteBuilder(
+          outputDir: outputDir,
+          options: const GeneratorOptions(
+            dryRun: false,
+            force: true,
+            verbose: false,
+          ),
+        );
+        await routeBuilder.generate(
+          GeneratorConfig(
+            name: 'Product',
+            methods: const ['get', 'getList'],
+            generateVpcs: true,
+            generateRoute: true,
+            outputDir: outputDir,
+          ),
+        );
+
+        final routesFile = File('$outputDir/routing/product_routes.dart');
+        expect(routesFile.existsSync(), isTrue);
+        final routeContent = routesFile.readAsStringSync();
+
+        // The route must pass the entity named-param.
+        expect(
+          routeContent.contains('product: (state.extra as Product?)'),
+          isTrue,
+          reason:
+              'route must pass the entity named-param using the exact '
+              'camelCase name the view declares.',
+        );
+
+        // And the view file must accept it.
+        final viewFile = File(
+          '$outputDir/presentation/pages/product/product_view.dart',
+        );
+        expect(viewFile.existsSync(), isTrue);
+        final viewContent = viewFile.readAsStringSync();
+        expect(
+          viewContent.contains('this.product,'),
+          isTrue,
+          reason: 'view must accept the entity named-param the route passes.',
+        );
+      },
+    );
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // End-to-end contract: route + view generated together must compile
+  // ─────────────────────────────────────────────────────────────────
+
+  group('issue #328 end-to-end route+view contract', () {
+    test(
+      'route references only view files that actually exist on disk',
+      () async {
+        // Generate the view with default methods (get,update) — only
+        // product_view.dart is created, no product_detail_view.dart.
+        final viewPlugin = ViewPlugin(
+          outputDir: outputDir,
+          options: const GeneratorOptions(
+            dryRun: false,
+            force: true,
+            verbose: false,
+          ),
+        );
+        await viewPlugin.generate(
+          GeneratorConfig(
+            name: 'Product',
+            methods: const ['get', 'update'],
+            generateView: true,
+            outputDir: outputDir,
+          ),
+        );
+
+        // Now generate routes with a DIFFERENT methods list
+        // (--methods=get,getList) — the smoke-test scenario from #328.
+        final routeBuilder = RouteBuilder(
+          outputDir: outputDir,
+          options: const GeneratorOptions(
+            dryRun: false,
+            force: true,
+            verbose: false,
+          ),
+        );
+        await routeBuilder.generate(
+          GeneratorConfig(
+            name: 'Product',
+            methods: const ['get', 'getList'],
+            generateVpcs: true,
+            generateRoute: true,
+            outputDir: outputDir,
+          ),
+        );
+
+        final routesFile = File('$outputDir/routing/product_routes.dart');
+        expect(routesFile.existsSync(), isTrue);
+        final content = routesFile.readAsStringSync();
+
+        // Collect every view import the route references.
+        final viewImportPattern = RegExp(
+          r"import\s+'([^']*_view\.dart)';",
+        );
+        final importedViews = viewImportPattern
+            .allMatches(content)
+            .map((m) => m.group(1)!)
+            .toList();
+
+        // The route file lives at <outputDir>/routing/product_routes.dart,
+        // so relative imports resolve against <outputDir>/routing/.
+        final routeDir = path.join(outputDir, 'routing');
+
+        // Every imported view file must actually exist on disk.
+        for (final importPath in importedViews) {
+          final resolvedPath = path.normalize(
+            path.join(routeDir, importPath),
+          );
+          expect(
+            File(resolvedPath).existsSync(),
+            isTrue,
+            reason:
+                'route imports `$importPath` but the file does not exist '
+                'at $resolvedPath. This is the #328 contract violation: '
+                'the route generator must only import view files that '
+                'actually exist on disk.',
+          );
+        }
+      },
+    );
+  });
+}

--- a/test/regression/issue_328_route_view_contract_test.dart
+++ b/test/regression/issue_328_route_view_contract_test.dart
@@ -528,4 +528,95 @@ void main() {
       },
     );
   });
+
+  // ─────────────────────────────────────────────────────────────────
+  // Regeneration: existing route files must stay synchronized when the
+  // detail-view file appears or disappears between runs.
+  // ─────────────────────────────────────────────────────────────────
+
+  group('issue #328 — detail-view availability sync on regeneration', () {
+    GeneratorConfig makeConfig() => GeneratorConfig(
+      name: 'Product',
+      methods: const ['get', 'getList'],
+      generateVpcs: true,
+      generateRoute: true,
+      outputDir: outputDir,
+    );
+
+    int routeCount(String content, String routeName) => RegExp(
+      "name:\\s*'$routeName'",
+    ).allMatches(content).length;
+
+    test(
+      'rerun after the detail-view file is deleted removes the stale '
+      'import and replaces (not duplicates) the detail route',
+      () async {
+        final builder = RouteBuilder(
+          outputDir: outputDir,
+          options: const GeneratorOptions(
+            dryRun: false,
+            force: true,
+            verbose: false,
+          ),
+        );
+
+        // Run 1: detail view file exists → route uses ProductDetailView.
+        final viewDir = Directory('$outputDir/presentation/pages/product');
+        await viewDir.create(recursive: true);
+        await File('${viewDir.path}/product_view.dart').writeAsString(
+          '// stub view file\n',
+        );
+        final detailFile = File('${viewDir.path}/product_detail_view.dart');
+        await detailFile.writeAsString('// stub detail view file\n');
+
+        await builder.generate(makeConfig());
+        final routesFile = File('$outputDir/routing/product_routes.dart');
+        var content = routesFile.readAsStringSync();
+        expect(content.contains('product_detail_view.dart'), isTrue);
+        expect(content.contains('ProductDetailView'), isTrue);
+        expect(routeCount(content, 'product_detail'), 1);
+
+        // Run 2: detail view file deleted → the existing route file must
+        // be synchronized, not appended to.
+        await detailFile.delete();
+        await builder.generate(makeConfig());
+
+        content = routesFile.readAsStringSync();
+        expect(
+          content.contains('product_detail_view.dart'),
+          isFalse,
+          reason:
+              'stale detail-view import must be removed when the file no '
+              'longer exists (uri_does_not_exist).',
+        );
+        expect(
+          content.contains('ProductDetailView'),
+          isFalse,
+          reason: 'stale DetailView reference must be removed.',
+        );
+        expect(
+          content.contains('ProductView'),
+          isTrue,
+          reason: 'detail route must fall back to the main view.',
+        );
+        expect(
+          routeCount(content, 'product_detail'),
+          1,
+          reason:
+              'the detail route must be replaced by stable identity, not '
+              'duplicated when its source changes.',
+        );
+
+        // Run 3: detail view file reappears → import and DetailView come
+        // back, still without duplicating the route.
+        await detailFile.writeAsString('// stub detail view file\n');
+        await builder.generate(makeConfig());
+
+        content = routesFile.readAsStringSync();
+        expect(content.contains('product_detail_view.dart'), isTrue);
+        expect(content.contains('ProductDetailView'), isTrue);
+        expect(routeCount(content, 'product_detail'), 1);
+      },
+    );
+  });
 }


### PR DESCRIPTION
Closes #328

## Summary

Fixes two contract mismatches between `zfa route create` and `zfa view create` that produced 159 `flutter analyze` errors across all 53 entities in the v6 smoke test.

### Bug A — `uri_does_not_exist` (53×)

`zfa route create --methods=get,getList` emitted an import for `<entity>_detail_view.dart` and referenced `<Entity>DetailView` even when no such file existed on disk. `zfa view create` only emits a separate `<entity>_detail_view.dart` when the view was generated with BOTH a list method (`getList`/`watchList`) AND a detail method (`get`/`watch`). When the view was created with different methods than the route (the common smoke-test case: `zfa view create` defaults to `get,update`, then `zfa route create --methods=get,getList` is run later), the detail view file did not exist and analyze flagged `uri_does_not_exist`.

**Fix:** `route_builder.dart` now probes the actual `<entity>_detail_view.dart` file on disk (`await fileSystem.exists(...)`) instead of deriving `hasDetailView` from the route's own methods list. The route only imports the detail view file and references `<Entity>DetailView` when the file actually exists; otherwise the detail route falls back to `<Entity>View` (the main view).

### Bug B — named-param mismatch

`zfa route create` always passed `View(entityCamel: state.extra as Entity?)` for CRUD-backed entities, but `zfa view create` only added the `entityCamel` named-param to the view constructor under `--state`. Without `--state` the route's named-arg had no matching constructor parameter, producing `extra_positional_arguments` / undefined named-param errors.

**Fix:** `view_plugin.dart` `_buildRouteFieldsForView` now emits the `entityCamel` field whenever the entity is CRUD-backed (`isEntityBased = methods.isNotEmpty && !noEntity`), not just under `--state`. The matching entity import in `_buildImports` uses the same condition so the field's type (`${config.name}?`) always has its symbol imported. The field stays optional (not `required`), so non-route call sites that construct the view without the entity still compile.

## Root cause

The route and view generators derived their contracts from independent sources:
- The route builder derived `hasDetailView` from the methods passed to `zfa route create`.
- The view builder derived `isMasterDetail` (and thus whether to emit a separate detail view) from the methods passed to `zfa view create`.

When the two commands were run with different methods (the default `zfa view create` methods are `get,update`, but `zfa route create` was called with `--methods=get,getList`), the contracts diverged silently — the route referenced view artifacts that the view generator never produced.

## Changes

- `lib/src/plugins/route/builders/route_builder.dart` (+20/-10): replace methods-derived `hasDetailView`/`hasListView` with a filesystem probe on `<entity>_detail_view.dart`; simplify the three `(hasListView && hasDetailView)` conditions to `hasDetailView`.
- `lib/src/plugins/view/view_plugin.dart` (+14/-2): emit the `entityCamel` field and entity import under `!noEntity && (withState || isEntityBased)` instead of `withState && !noEntity`.
- `test/regression/issue_328_route_view_contract_test.dart` (new, 8 tests): covers the detail-view filesystem probe (negative, positive, edge), the entity named-param (with/without `--state`, `noEntity`), the route↔view param-name contract, and an end-to-end "every imported view file exists on disk" assertion.

## Verification

- `dart analyze lib/src/plugins/route/builders/route_builder.dart lib/src/plugins/view/view_plugin.dart` → No issues found.
- `dart test test/plugins/route/ test/plugins/view/ test/regression/route_generation_test.dart test/regression/issue_328_route_view_contract_test.dart` → All 25 tests passed (17 existing + 8 new regression).
- `dart test test/plugins/` → 176 tests passed (no regressions across all plugins).

## Follow-up

This is the second fix in the v6 routing layer (after #325/#327 added the `go_router` import). With both the import and the route/view contract aligned, `zfa route create --methods=get,getList` + `zfa build` + `flutter analyze` should produce zero routing-layer errors for any entity whose view was generated with matching (or default) methods.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated routes to use detail views only when those files exist, with automatic fallback to the main view.
  * Ensured route updates replace existing entries correctly when view selections change.
  * Ensured generated entity-backed views consistently support optional entity parameters, with or without state generation.
  * Corrected generated imports and naming consistency for routes and views.

* **Tests**
  * Added regression coverage for route and view generation, including fallback, regeneration, CRUD, state, and import scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->