### PR TITLE
test(zfa entity create): #320 autoId + ValueObject end-to-end + migration guide

### DIFF
--- a/docs/issue-320-zikzak-entity-identity-migration.md
+++ b/docs/issue-320-zikzak-entity-identity-migration.md
@@ -1,0 +1,206 @@
+# Issue #320 — zik_zak entity-identity migration guide
+
+> Framework gaps filled: **auto-generated uuid id** (`@Zorphy(autoId: true)`),
+> **ValueObject third kind** (`@ZValueObject`), and a **loud no-id error** that
+> kills the silent first-field id fallback (the #307 root cause). This guide
+> classifies zik_zak's 88 id-less entities and gives the migration recipe.
+
+## Status
+
+The framework work landed across two coordinated PRs and the zorphy repo:
+
+| Layer | Where | Commit / PR | What it adds |
+|-------|-------|-------------|--------------|
+| Annotation | `zorphy_annotation` (`development` branch) | `63510ea` | `ZorphyKind { entity, valueObject }`, `@Zorphy(autoId: true)`, `@ZValueObject` const alias |
+| Builder | `zorphy` (`fix/310-determine-prefix-comment-safe` branch) | `727a8c6` | `autoId` → constructor `id ??= const Uuid().v4()`; uuid import; `kind` read from annotation |
+| zfa CLI | zuraffa PR #322 → `87fc008` | merged 2026-08-14 | `--auto-id`, `--kind=value_object`, `EntityIdResolution`, loud no-id error in `zfa make` |
+| Enum imports | zuraffa PR #324 → `2c037f6` | merged 2026-08-14 | enum barrel imports for signature types (the #321 half) |
+
+zik_zak is **unaffected** until you run the migration below — no entity changes ship
+unless you re-model them. The `zfa make` loud error will fire on the first id-less
+entity you rebuild, which is the intended forcing function.
+
+## The three identity kinds
+
+Every `@Zorphy()`-annotated class now resolves to exactly one identity kind. The
+kind controls whether `zfa make` generates a persistence surface (repository /
+datasource / usecase / controller / presenter / view / route / state / provider /
+observer / cache) and how the id is sourced.
+
+### 1. Entity with a real id (the default)
+
+An entity that declares a literal `id` field, or any field whose name ends in
+`Id` (e.g. `depotId`), resolves with that field as its identity. The field's type
+flows into the generated `UpdateParams`, `ToggleParams`, query, and repository
+signatures. This is the clean path — `Authentication` (with `id: String`) is the
+control case that already compiled clean. No annotation change is needed for
+entities in this category; the resolver finds the id automatically.
+
+```
+@Zorphy(generateJson: true, generateCompareTo: true)
+abstract class $Authentication {
+  String get id;          // ← literal id → resolved as the identity
+  String get userId;
+  String get token;
+}
+```
+
+### 2. Entity with an auto-generated uuid id (`autoId: true`)
+
+Aggregate roots and event records that have no natural id field but still need
+real client-side identity use `@Zorphy(autoId: true)`. The generator emits the
+`id` constructor parameter as an optional `String?` that defaults to
+`const Uuid().v4()` at construction time, and the `id` import
+(`package:uuid/uuid.dart`) is always emitted. The resolver treats a uuid-backed
+id as **the** id: no first-field fallback, and query / update / toggle
+signatures use `String id` (never an enum-typed id). This is the fix for the
+`ChatMessage` / `TelemetryEvent` shapes that produced 48 analyze errors in #307.
+
+```
+@Zorphy(generateJson: true, generateCompareTo: true, autoId: true)
+abstract class $ChatMessage {
+  String get id;                 // ← declared; builder defaults it to Uuid().v4()
+  ChatMessageRole get role;
+  String get content;
+  DateTime get timestamp;
+}
+```
+
+### 3. Value object (`@ZValueObject`)
+
+Immutable composition types that have no identity of their own — they exist only
+as fields inside entities. A value object generates **no** repository, usecase,
+controller, presenter, view, route, state, provider, observer, or cache. It still
+gets equality, `hashCode`, `toString`, `copyWith`, and JSON serialization exactly
+like an entity (so it serializes cleanly when embedded). This is the third kind
+the framework was missing: the 88 id-less entities in zik_zak are mostly value
+objects that were forced into the entity kind and then broke the id resolver.
+
+```
+@ZValueObject
+abstract class $ParserConfig {
+  String get separator;
+  bool get trimWhitespace;
+}
+```
+
+`@ZValueObject` is a const alias for `@Zorphy(kind: ZorphyKind.valueObject)` —
+use whichever reads better at the call site.
+
+## The loud no-id error
+
+If an entity (not a value object) has **no** id field, **no** `*Id` field, and
+**no** `autoId: true`, `zfa make` now fails loudly instead of silently picking
+the first field:
+
+```
+❌ Entity "ChatMessage" has no id field.
+
+   A non-value-object entity needs an identity. One of:
+     1. add a literal `String get id;` field,
+     2. re-create with `zfa entity create -n ChatMessage --auto-id`,
+     3. or model it as a value object: `zfa entity create -n ChatMessage --kind=value_object`.
+
+   (The previous silent first-field fallback produced enum-typed ids and
+    missing enum imports — issue #307.)
+```
+
+This is the forcing function that surfaces the 88 id-less entities during the
+migration. It throws `MakeCommandException` (exit 1) so it is visible in CI and
+`runCapturing` tests without killing the test isolate.
+
+## How to classify a zik_zak entity
+
+Apply this decision tree to each of the 88 id-less entities:
+
+1. **Is it persisted/retrieved by its own identity?** Do you store it in a
+   repository, query it by id, update it, or toggle a field on it? If yes → it
+   is an **entity**. Go to step 2.
+   - If no → it is a **value object**. Migrate with `--kind=value_object`.
+
+2. **Does it have a natural id field** (a literal `id`, or a `*Id` like
+   `userId`, `depotId`)? If yes → keep it as a **plain entity** (no annotation
+   change; the resolver finds the id). You are done.
+
+3. **It is an aggregate / event root with no natural id** (e.g. a chat message,
+   a telemetry event, a log entry, a session) → give it an **auto-generated uuid
+   id**. Migrate with `--auto-id`.
+
+The heuristic: names ending in `_config`, `_options`, `_mapping`, `_result`,
+`_params`, `_entry`, `_record` (when the record is embedded) lean value object;
+names that read as standalone documents or events (`chat_message`,
+`telemetry_event`, `session`, `log_entry`) lean autoId entity.
+
+## Named-entity mapping (from the #320 spec)
+
+The spec names 11 of the 88 entities. Their classification:
+
+| Entity | Kind | Why |
+|--------|------|-----|
+| `ChatMessage` | entity + `autoId` | aggregate root (a chat message is a standalone document) |
+| `TelemetryEvent` | entity + `autoId` | event root (events need client-side identity for dedup/ordering) |
+| `value_mapping` | value object | pure lookup/config composition |
+| `parser_config` | value object | configuration composition (separator, trim flags) |
+| `string_between_parser_options` | value object | parser options bag |
+| `barcode_lookup_result` | value object | a lookup result returned inside another entity |
+| `store_price` | value object | a price snapshot embedded in a product |
+| `regex_transformation_options` | value object | transformation options bag |
+| `filter_value_mapping` | value object | filter config composition |
+| `map_transformation_options` | value object | transformation options bag |
+
+The remaining ~77 entities follow the same heuristic. Run `zfa make` on each
+after re-modeling — the loud no-id error will catch any entity you
+mis-classified as a plain entity (it will tell you to add an id, use `--auto-id`,
+or switch to `--kind=value_object`).
+
+## Migration recipe (per entity)
+
+The migration is **not** part of this task — it is the follow-up. When you run
+it, the recipe per entity is:
+
+```bash
+# 1. Re-model a value object (no id, no persistence surface):
+zfa entity create -n ParserConfig --kind=value_object \
+  --field separator:String --field trimWhitespace:bool
+
+# 2. Re-model an autoId entity (aggregate/event root):
+zfa entity create -n ChatMessage --auto-id \
+  --field role:ChatMessageRole --field content:String --field timestamp:DateTime
+
+# 3. Then rebuild + re-make:
+zfa build
+zfa make ChatMessage --preset=crud --with=vpc,state,di,test,mock
+```
+
+For entities that already have a real `id: String` (like `Authentication`), no
+change is needed — they already compile clean.
+
+### zik_zak pubspec note
+
+zik_zak already depends on `uuid: ^4.6.0` (several entities hand-roll uuid ids
+today: `text_spark`, `url_spark`, `zik`, `barcode_spark`). The framework now owns
+this — once an entity is migrated to `autoId: true`, delete the hand-rolled
+`import 'package:uuid/uuid.dart';` and the manual `id: Uuid().v4()` constructor
+default from that entity; the generated `.zorphy.dart` file provides both.
+
+## Verification (after migration)
+
+- `dart analyze` on the zik_zak app: zero `Undefined class` errors for
+  enum-typed ids (the #307 symptom).
+- `zfa make <entity>` on every migrated entity: exit 0 (autoId entities and
+  value objects) — never the loud no-id error (that only fires on un-migrated
+  id-less entities).
+- Value objects: no `domain/repositories/`, `domain/usecases/`,
+  `presentation/controllers/`, or `presentation/presenter/` directories
+  generated for them.
+- autoId entities: generated `update` / `toggle` / `query` signatures use
+  `String id` (not `ChatMessageRole` / `TelemetryEventType`).
+
+## Related issues
+
+- #307 — CLOSED (the id-fallback + enum-import bug; fixed by PR #322 + #324).
+- #321 — the minimal #307 fix track (no first-field fallback + enum imports);
+  its acceptance is met by PR #324.
+- #320 — this framework spec (autoId + ValueObject + loud no-id error).
+- #323 — `zfa make --revert` now deep-cleans orphan architecture after a VO
+  re-model (so the migration is reversible if you mis-classify an entity).

--- a/test/regression/issue_320_entity_create_autoid_valueobject_e2e_test.dart
+++ b/test/regression/issue_320_entity_create_autoid_valueobject_e2e_test.dart
@@ -1,0 +1,229 @@
+// Regression tests for issue #320 — zfa entity create: autoId + ValueObject
+// end-to-end (the CREATE step).
+//
+// The framework gaps from #320 (auto-generated uuid id, ValueObject third
+// kind, loud no-id error) were implemented across the zorphy annotation +
+// builder (zorphy repo commits 63510ea + 727a8c6) and the zuraffa zfa CLI
+// (PR #322 → commit 87fc008). The `zfa make` half is already locked in by
+// `test/commands/make_command_test.dart` (#307 identity-contract group) and
+// `test/regression/issue_321_no_first_field_id_fallback_enum_import_test.dart`.
+//
+// What was NOT covered end-to-end was the `zfa entity create` step itself —
+// the flags `--auto-id` and `--kind=value_object` and the entity file they
+// generate. #320 explicitly lists "zfa entity create --kind=value_object
+// works end to end" as a verification item. These tests close that gap:
+//
+//   - `--kind=value_object` → the generated entity file carries
+//     `@Zorphy(kind: ZorphyKind.valueObject, ...)`, declares NO `id` field,
+//     and does NOT import `package:uuid/uuid.dart` (value objects have no
+//     identity).
+//   - `--auto-id` → the generated entity file carries `autoId: true` in the
+//     `@Zorphy(...)` annotation, prepends a `String get id;` declaration
+//     (the zorphy builder defaults the concrete constructor's `id` to
+//     `Uuid().v4()`), and imports `package:uuid/uuid.dart`.
+//   - A plain entity create (no `--auto-id`, no id field, no value-object
+//     kind) still writes the entity file — the identity contract is enforced
+//     at `zfa make` time (loud error, covered by make_command_test), NOT at
+//     `zfa entity create` time. This documents the create-vs-make contract.
+
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
+import 'package:test/test.dart';
+import '../helpers/project_root.dart';
+
+void main() {
+  group('#320 — zfa entity create: --kind=value_object + --auto-id e2e', () {
+    late Directory workspace;
+    late String outputDir;
+    late String zfaSourceBin;
+
+    // Runs zfa from SOURCE (never a stale compiled ~/.local/bin/zfa) as a
+    // subprocess with an explicit workingDirectory — mirrors the
+    // make_command_test #307 group so these tests cannot race with other
+    // test files that capture Directory.current at load time (#296).
+    Future<ProcessResult> runZfaSource(List<String> args) {
+      return Process.run(
+        'dart',
+        [zfaSourceBin, ...args],
+        workingDirectory: workspace.path,
+      );
+    }
+
+    setUpAll(() async {
+      final projectRoot = await findProjectRoot();
+      zfaSourceBin = path.join(projectRoot, 'bin', 'zfa.dart');
+    });
+
+    setUp(() async {
+      workspace = await Directory.systemTemp.createTemp('zfa_entity_create_320_');
+      outputDir = path.join(workspace.path, 'lib', 'src', 'domain', 'entities');
+      await Directory(outputDir).create(recursive: true);
+      // `zfa entity create` runs a pubspec dependency check that greps for
+      // `zorphy_annotation:` and `build_runner:` (it does NOT resolve them —
+      // the create step only writes the entity template; the zorphy builder
+      // runs later via `zfa build`). The test workspace mirrors the real
+      // app pubspec: uuid (the autoId dep) + the two zfa-required names so
+      // the dependency gate passes and the entity file is actually written.
+      await File(path.join(workspace.path, 'pubspec.yaml')).writeAsString('''
+name: zuraffa_entity_create_320_test
+environment:
+  sdk: ^3.11.0
+dependencies:
+  uuid: ^4.6.0
+  zorphy_annotation: any
+dev_dependencies:
+  build_runner: any
+''');
+    });
+
+    tearDown(() async {
+      if (workspace.existsSync()) {
+        await workspace.delete(recursive: true);
+      }
+    });
+
+    test(
+      '--kind=value_object generates an entity file with '
+      '@Zorphy(kind: ZorphyKind.valueObject), no id field, no uuid import',
+      timeout: const Timeout(Duration(minutes: 2)),
+      () async {
+        final result = await runZfaSource([
+          'entity', 'create',
+          '-n', 'ParserConfig',
+          '--kind=value_object',
+          '--field', 'separator:String',
+          '--field', 'trimWhitespace:bool',
+          '--output', outputDir,
+        ]);
+
+        expect(result.exitCode, 0, reason: 'stderr: ${result.stderr}');
+        final file = File(
+          path.join(outputDir, 'parser_config', 'parser_config.dart'),
+        );
+        expect(file.existsSync(), isTrue, reason: 'entity file not written');
+        final src = file.readAsStringSync();
+
+        // Value-object annotation surface.
+        expect(
+          src,
+          contains('kind: ZorphyKind.valueObject'),
+          reason: 'value object must carry its kind in the annotation',
+        );
+        // Default-on options still emit (parity with the entity kind).
+        expect(src, contains('generateJson: true'));
+        expect(src, contains('generateCompareTo: true'));
+
+        // A value object has NO identity — no autoId, no id getter, no uuid.
+        expect(
+          src,
+          isNot(contains('autoId')),
+          reason: 'value objects must not carry the autoId flag',
+        );
+        expect(
+          src,
+          isNot(contains('String get id;')),
+          reason: 'value objects must not declare an id getter',
+        );
+        expect(
+          src,
+          isNot(contains("package:uuid/uuid.dart")),
+          reason: 'value objects must not import the uuid package',
+        );
+
+        // Fields are emitted as abstract getters on $ParserConfig.
+        expect(src, contains('abstract class \$ParserConfig'));
+        expect(src, contains('String get separator;'));
+        expect(src, contains('bool get trimWhitespace;'));
+      },
+    );
+
+    test(
+      '--auto-id generates an entity file with autoId: true, a prepended '
+      'String get id; getter, and the uuid import',
+      timeout: const Timeout(Duration(minutes: 2)),
+      () async {
+        final result = await runZfaSource([
+          'entity', 'create',
+          '-n', 'ChatMessage',
+          '--auto-id',
+          '--field', 'content:String',
+          '--field', 'timestamp:DateTime',
+          '--output', outputDir,
+        ]);
+
+        expect(result.exitCode, 0, reason: 'stderr: ${result.stderr}');
+        final file = File(
+          path.join(outputDir, 'chat_message', 'chat_message.dart'),
+        );
+        expect(file.existsSync(), isTrue, reason: 'entity file not written');
+        final src = file.readAsStringSync();
+
+        // autoId is carried on the @Zorphy(...) annotation; the builder
+        // turns it into a constructor `id ??= const Uuid().v4()` default.
+        expect(
+          src,
+          contains('autoId: true'),
+          reason: 'autoId must be emitted on the annotation',
+        );
+        // The uuid import is emitted so the builder-generated default
+        // (`const Uuid().v4()`) resolves.
+        expect(
+          src,
+          contains("import 'package:uuid/uuid.dart';"),
+          reason: 'autoId entities must import the uuid package',
+        );
+        // A synthetic `String get id;` is prepended (no id field was passed
+        // on the CLI); the concrete constructor the builder emits defaults
+        // it at construction time.
+        expect(
+          src,
+          contains('String get id;'),
+          reason: 'autoId entities must declare the id getter',
+        );
+
+        // autoId is an entity concept, not a value-object one.
+        expect(
+          src,
+          isNot(contains('kind: ZorphyKind.valueObject')),
+          reason: 'autoId entities must not be marked as value objects',
+        );
+
+        // The user-supplied fields are still present.
+        expect(src, contains('abstract class \$ChatMessage'));
+        expect(src, contains('String get content;'));
+        expect(src, contains('DateTime get timestamp;'));
+      },
+    );
+
+    test(
+      'a plain entity create (no --auto-id, no id field) still writes the '
+      'file — the identity contract is enforced at `zfa make`, not at create',
+      timeout: const Timeout(Duration(minutes: 2)),
+      () async {
+        // `zfa entity create` only writes the entity definition; it does
+        // not resolve identity. The loud no-id error fires in `zfa make`
+        // (covered by make_command_test #307 identity-contract group).
+        final result = await runZfaSource([
+          'entity', 'create',
+          '-n', 'Note',
+          '--field', 'body:String',
+          '--output', outputDir,
+        ]);
+
+        expect(result.exitCode, 0, reason: 'stderr: ${result.stderr}');
+        final file = File(path.join(outputDir, 'note', 'note.dart'));
+        expect(file.existsSync(), isTrue, reason: 'entity file not written');
+        final src = file.readAsStringSync();
+
+        // No identity surface was requested, so none is emitted.
+        expect(src, isNot(contains('autoId')));
+        expect(src, isNot(contains('String get id;')));
+        expect(src, isNot(contains('kind: ZorphyKind.valueObject')));
+        expect(src, isNot(contains("package:uuid/uuid.dart")));
+        expect(src, contains('abstract class \$Note'));
+        expect(src, contains('String get body;'));
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Closes #320. The framework gaps (auto-generated uuid id, ValueObject third kind, loud no-id error) were **already implemented** across the zorphy repo and zuraffa PRs #322 / #324 — this PR closes the two remaining #320 deliverables: the end-to-end `zfa entity create` verification gap and the Gap C migration spec.

## What's already landed (verified green)

| Layer | Where | Commit | What |
|-------|-------|--------|------|
| Annotation | `zorphy_annotation` (`development`) | `63510ea` | `ZorphyKind { entity, valueObject }`, `@Zorphy(autoId: true)`, `@ZValueObject` |
| Builder | `zorphy` (`fix/310-determine-prefix-comment-safe`) | `727a8c6` | `autoId` → `id ??= const Uuid().v4()`; uuid import; `kind` read |
| zfa CLI | zuraffa #322 → `87fc008` | merged | `--auto-id`, `--kind=value_object`, `EntityIdResolution`, loud no-id error |
| Enum imports | zuraffa #324 → `2c037f6` | merged | enum barrel imports for signature types (#321) |

Test results on `development` (dart 3.12.2): `entity_field_resolver_test` 20/20, `make_command` #307 identity-contract group 3/3 (autoId, loud error, value object), `issue_321` regression all pass, `dart analyze lib test` clean.

## What this PR adds

### 1. `test/regression/issue_320_entity_create_autoid_valueobject_e2e_test.dart`

End-to-end coverage of the **`zfa entity create` CREATE step** — the one verification item from #320 not covered by existing tests (which exercise `zfa make` on hand-written entity files, not the `--auto-id` / `--kind=value_object` flags that generate the entity file):

- `--kind=value_object` → generated file carries `@Zorphy(kind: ZorphyKind.valueObject, ...)`, declares **no** `id` field, imports **no** `package:uuid/uuid.dart`.
- `--auto-id` → generated file carries `autoId: true`, prepends `String get id;`, imports `package:uuid/uuid.dart`.
- A plain entity create (no `--auto-id`, no id) still writes the file — documents the create-vs-make identity contract (the loud no-id error fires at `zfa make`, not at `zfa entity create`).

### 2. `docs/issue-320-zikzak-entity-identity-migration.md` (Gap C)

The migration spec + mapping list (the #320 Gap C deliverable — the migration itself is the follow-up task):

- The three identity kinds (real id / autoId / value object) with code examples.
- The loud no-id error diagnostic.
- The classification decision tree.
- The named-entity mapping: `ChatMessage` / `TelemetryEvent` → autoId entities; `parser_config`, `value_mapping`, `string_between_parser_options`, `barcode_lookup_result`, `store_price`, `regex_transformation_options`, `filter_value_mapping`, `map_transformation_options` → value objects.
- The per-entity migration recipe + the zik_zak uuid note (delete hand-rolled uuid ids once migrated).

## Verification

```
dart analyze test/regression/issue_320_entity_create_autoid_valueobject_e2e_test.dart  → No issues found!
dart test  test/regression/issue_320_entity_create_autoid_valueobject_e2e_test.dart    → 3/3 pass
```

No framework code changes — the implementation is complete; this PR locks in the last #320 verification item and ships the migration spec.

## Related

- #307 (CLOSED) — the id-fallback + enum-import bug.
- #321 — the minimal #307 fix track; its acceptance is met by #324. Can be closed.
- #323 — `zfa make --revert` deep-cleans orphan architecture after a VO re-model (makes the migration reversible).