### PR TITLE
fix(zfa route create): omit detail GoRoute stub when no detail_view (#333)

### DIFF
--- a/lib/src/core/ast/ast_modifier.dart
+++ b/lib/src/core/ast/ast_modifier.dart
@@ -332,8 +332,12 @@ class AstModifier {
     final elements = expression.elements;
     for (final element in elements) {
       if (element.toSource() == elementSource) {
-        final result =
-            source.substring(0, element.offset) + source.substring(element.end);
+        // #333: extend the removal end past any trailing whitespace +
+        // comma so the surrounding list literal doesn't end up with a
+        // stray `,` (which would make _formatSafe throw and leave the
+        // file with mangled raw emitter output).
+        final end = _listElementRemovalEnd(source, element.end);
+        final result = source.substring(0, element.offset) + source.substring(end);
         return format ? _formatSafe(result) : result;
       }
     }
@@ -380,10 +384,41 @@ class AstModifier {
 
     var result = source;
     for (final element in toRemove) {
-      result =
-          result.substring(0, element.offset) + result.substring(element.end);
+      // #333: extend the removal end past any trailing whitespace + comma
+      // (computed on the current `result` string; offsets for elements
+      // sorted by descending offset stay valid because we only removed
+      // text after their positions).
+      final end = _listElementRemovalEnd(result, element.end);
+      result = result.substring(0, element.offset) + result.substring(end);
     }
     return format ? _formatSafe(result) : result;
+  }
+
+  /// Returns the end offset to use when removing a list-literal element
+  /// starting at [elementEnd] from [source]. Extends past any trailing
+  /// whitespace + comma so the surrounding list literal doesn't end up
+  /// with a stray `,` (which would make [DartFormatter] throw and cause
+  /// [_formatSafe] to return the raw, unformatted source — see issue
+  /// #333 for the resulting mangled detail-route stub).
+  ///
+  /// When the element is the last in the list with no trailing comma
+  /// (the next non-whitespace character is `]`), the original
+  /// [elementEnd] is returned unchanged — the formatter will collapse
+  /// any leftover `[ ,]` / `[ ]` shape on its own.
+  static int _listElementRemovalEnd(String source, int elementEnd) {
+    var i = elementEnd;
+    while (i < source.length) {
+      final ch = source[i];
+      if (ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r') {
+        i++;
+        continue;
+      }
+      break;
+    }
+    if (i < source.length && source[i] == ',') {
+      return i + 1;
+    }
+    return elementEnd;
   }
 
   static String removeStatement({

--- a/lib/src/plugins/route/builders/route_builder.dart
+++ b/lib/src/plugins/route/builders/route_builder.dart
@@ -207,6 +207,7 @@ class RouteBuilder {
     required List<String> imports,
     required String detailViewImport,
     required bool hasDetailView,
+    required String routeBase,
     bool force = false,
   }) {
     var content = existingContent;
@@ -240,6 +241,26 @@ class RouteBuilder {
     }
 
     final helper = const AstHelper();
+
+    // #333: When the new run does NOT emit a detail GoRoute (because no
+    // `<entity>_detail_view.dart` exists on disk), remove any stale
+    // detail route from the existing file. Without this cleanup,
+    // re-running with --force over a pre-fix routes file (which
+    // referenced <Entity>DetailView) would leave the broken stub in
+    // place. The route's stable identity is its `name:` field —
+    // `'${routeBase}_detail'`.
+    if (!hasDetailView) {
+      final detailRouteName = '${routeBase}_detail';
+      final detailNamePattern = RegExp(
+        "name:\\s*'${RegExp.escape(detailRouteName)}'",
+      );
+      content = helper.removeElementsFromReturnListInFunctionWhere(
+        source: content,
+        functionName: routesGetterName,
+        matches: (elementSource) =>
+            detailNamePattern.hasMatch(elementSource),
+      );
+    }
 
     // Add route constants
     for (final entry in newRouteConstants.entries) {
@@ -494,7 +515,14 @@ class RouteBuilder {
           viewParam: dependencyInfo.viewParam,
           config: config,
         ),
-      if (needsIdRoute)
+      // #333: only emit the detail GoRoute when the corresponding
+      // `<entity>_detail_view.dart` actually exists on disk. When the
+      // detail-view file is absent, omit the detail route entirely
+      // instead of emitting a "stub" pointing to the main View. The
+      // previous behavior (always emit + flip viewName) produced
+      // malformed stubs when re-running with --force over a pre-existing
+      // routes file — see issue #333.
+      if (needsIdRoute && hasDetailView)
         _buildDetailRouteExpr(
           entityName: entityName,
           entityCamel: entityCamel,
@@ -502,9 +530,7 @@ class RouteBuilder {
           routeNameBase: routeNameBase,
           viewParam: dependencyInfo.viewParam,
           config: config,
-          viewName: hasDetailView
-              ? '${entityName}DetailView'
-              : '${entityName}View',
+          viewName: '${entityName}DetailView',
         ),
       if (hasCreate)
         _buildCreateRouteExpr(
@@ -606,6 +632,7 @@ class RouteBuilder {
             imports: imports,
             detailViewImport: detailViewImport,
             hasDetailView: hasDetailView,
+            routeBase: routeBase,
             force: config.force,
           )
         : entityRoutesBuilder.buildFile(

--- a/test/regression/issue_328_route_view_contract_test.dart
+++ b/test/regression/issue_328_route_view_contract_test.dart
@@ -106,11 +106,22 @@ void main() {
               'route must not reference <Entity>DetailView when the '
               'detail view file does not exist on disk.',
         );
-        // The detail route should fall back to the main View.
+        // #333: when no detail view file exists, the detail GoRoute must
+        // be omitted entirely (no stub) — the route file should contain
+        // only the list route.
+        expect(
+          content.contains("name: 'zik_zak_score_detail'"),
+          isFalse,
+          reason:
+              'route must NOT emit a detail GoRoute stub when the '
+              'detail view file does not exist on disk (#333 — was the '
+              'cause of 108 malformed detail-route stubs).',
+        );
+        // The list route still uses the main <Entity>View.
         expect(
           content.contains('ZikZakScoreView'),
           isTrue,
-          reason: 'detail route should use the main <Entity>View.',
+          reason: 'list route should use the main <Entity>View.',
         );
         // The list view import must still be present.
         expect(
@@ -186,8 +197,8 @@ void main() {
     );
 
     test(
-      'route falls back to main View for detail route when only the '
-      'list view exists (no detail file)',
+      'route omits detail GoRoute entirely when only the list view '
+      'exists (no detail file)',
       () async {
         // Only the list view file exists, not the detail view.
         final viewDir = Directory(
@@ -232,10 +243,20 @@ void main() {
           isFalse,
           reason: 'detail view class does not exist; must not be referenced.',
         );
-        // The detail route should use ProductView (the main view).
+        // #333: when no detail view file exists, the detail GoRoute must
+        // be omitted entirely (no stub).
+        expect(
+          content.contains("name: 'product_detail'"),
+          isFalse,
+          reason:
+              'route must NOT emit a detail GoRoute stub when the detail '
+              'view file does not exist on disk (#333).',
+        );
+        // The list + create routes still use ProductView (the main view).
         expect(
           content.contains('ProductView'),
           isTrue,
+          reason: 'list/create routes should use the main <Entity>View.',
         );
       },
     );
@@ -549,7 +570,7 @@ void main() {
 
     test(
       'rerun after the detail-view file is deleted removes the stale '
-      'import and replaces (not duplicates) the detail route',
+      'import AND the stale detail route (no stub emitted — #333)',
       () async {
         final builder = RouteBuilder(
           outputDir: outputDir,
@@ -576,8 +597,10 @@ void main() {
         expect(content.contains('ProductDetailView'), isTrue);
         expect(routeCount(content, 'product_detail'), 1);
 
-        // Run 2: detail view file deleted → the existing route file must
-        // be synchronized, not appended to.
+        // Run 2: detail view file deleted → #333 says the detail GoRoute
+        // must be omitted entirely (no stub pointing to the main view).
+        // The stale detail-view import and the stale detail route must
+        // both be removed.
         await detailFile.delete();
         await builder.generate(makeConfig());
 
@@ -595,16 +618,18 @@ void main() {
           reason: 'stale DetailView reference must be removed.',
         );
         expect(
-          content.contains('ProductView'),
-          isTrue,
-          reason: 'detail route must fall back to the main view.',
+          routeCount(content, 'product_detail'),
+          0,
+          reason:
+              '#333: the detail GoRoute must be omitted entirely (not '
+              'replaced with a stub) when no detail_view file exists on '
+              'disk — the previous "fall back to main View" stub was '
+              'the cause of 108 malformed detail-route stubs.',
         );
         expect(
-          routeCount(content, 'product_detail'),
-          1,
-          reason:
-              'the detail route must be replaced by stable identity, not '
-              'duplicated when its source changes.',
+          content.contains('ProductView'),
+          isTrue,
+          reason: 'list route must still use the main <Entity>View.',
         );
 
         // Run 3: detail view file reappears → import and DetailView come

--- a/test/regression/issue_333_route_no_detail_stub_test.dart
+++ b/test/regression/issue_333_route_no_detail_stub_test.dart
@@ -1,0 +1,336 @@
+// Regression test for issue #333:
+// https://github.com/arrrrny/zuraffa/issues/333
+//
+// After #331's "probe detail_view on disk" fix, re-running
+// `zfa route create <Entity> --methods=get,getList --force` over a
+// pre-existing routes file (which referenced <Entity>DetailView)
+// produced a malformed detail-route stub:
+//
+//     GoRoute(path: ErrorLogRoutes.errorLogList, ...),
+//     ,                       // <-- stray comma + blank line (syntax error)
+//
+//     GoRoute(path: ErrorLogRoutes.errorLogDetail, name: 'error_log_detail',
+//       builder: (context, state, ) { return  ErrorLogView(id: state.pathParameters  [
+// 'id'
+// ]!, errorLog: (state.extra as ErrorLog?), ); } , ),
+//     ];
+//
+// Root cause:
+//   - `_updateEntityRoutesFile` removed the old detail route via
+//     `removeElementsFromReturnListInFunctionWhere` which only cut
+//     `element.offset..element.end`, leaving a stray trailing comma.
+//   - `_formatSafe` (DartFormatter) then threw on the broken syntax
+//     and returned the raw, unformatted source — which contained the
+//     raw `code_builder.DartEmitter` output for the new detail route
+//     (with the mangled `state.pathParameters  [ 'id' ]!` whitespace).
+//
+// Fix (#333):
+//   A. `route_builder.dart`: when `!hasDetailView`, do NOT emit a
+//      detail GoRoute at all (the route file should contain only the
+//      routes for views that actually exist on disk).
+//   B. `route_builder.dart _updateEntityRoutesFile`: when the new run
+//      does NOT include a detail route, remove any stale detail route
+//      by `name:` identity so pre-existing broken files are cleaned up
+//      on the next `--force` re-run.
+//   C. `ast_modifier.dart`: fix
+//      `removeElementsFromReturnListInFunctionWhere` and
+//      `removeElementFromReturnListInFunction` to also strip the
+//      trailing comma after the removed element — so removal never
+//      leaves a stray `,` that breaks DartFormatter.
+
+import 'dart:io';
+
+import 'package:dart_style/dart_style.dart' show DartFormatter;
+import 'package:test/test.dart';
+import 'package:zuraffa/src/core/generator_options.dart';
+import 'package:zuraffa/src/models/generator_config.dart';
+import 'package:zuraffa/src/plugins/route/builders/route_builder.dart';
+
+/// A pre-#331 routes file: it unconditionally referenced
+/// `<Entity>DetailView` even when no `<entity>_detail_view.dart`
+/// existed on disk. This is the broken state the smoke-test re-run
+/// encountered.
+const _preFixRoutesFile = r'''
+// GENERATED - DO NOT EDIT
+import 'package:go_router/go_router.dart';
+import 'package:zuraffa/zuraffa.dart';
+import '../domain/entities/error_log/error_log.dart';
+import '../presentation/pages/error_log/error_log_view.dart';
+import '../presentation/pages/error_log/error_log_detail_view.dart';
+
+abstract class ErrorLogRoutes {
+  static const String errorLogList = '/error_log';
+  static const String errorLogDetail = '/error_log/:id';
+}
+
+List<GoRoute> errorLogRoutes() {
+  return [
+    GoRoute(
+      path: ErrorLogRoutes.errorLogList,
+      name: 'error_log_list',
+      builder: (context, state) {
+        return ErrorLogView(errorLog: (state.extra as ErrorLog?));
+      },
+    ),
+    GoRoute(
+      path: ErrorLogRoutes.errorLogDetail,
+      name: 'error_log_detail',
+      builder: (context, state) {
+        return ErrorLogDetailView(
+          id: state.pathParameters['id']!,
+          errorLog: (state.extra as ErrorLog?),
+        );
+      },
+    ),
+  ];
+}
+
+// END GENERATED
+''';
+
+void main() {
+  late Directory tempDir;
+  late String outputDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('issue_333_');
+    outputDir = Directory('${tempDir.path}/lib/src').path;
+  });
+
+  tearDown(() async {
+    if (tempDir.existsSync()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  group('issue #333 — malformed detail-route stub when no detail_view', () {
+    test(
+      'FRESH generation with no detail_view file omits the detail GoRoute',
+      () async {
+        // No detail view file on disk — the smoke-test scenario.
+        final builder = RouteBuilder(
+          outputDir: outputDir,
+          options: const GeneratorOptions(
+            dryRun: false,
+            force: true,
+            verbose: false,
+          ),
+        );
+
+        await builder.generate(
+          GeneratorConfig(
+            name: 'ErrorLog',
+            methods: const ['get', 'getList'],
+            generateVpcs: true,
+            generateRoute: true,
+            outputDir: outputDir,
+          ),
+        );
+
+        final routesFile = File('$outputDir/routing/error_log_routes.dart');
+        expect(routesFile.existsSync(), isTrue);
+        final content = routesFile.readAsStringSync();
+
+        // No detail GoRoute stub.
+        expect(
+          content.contains("name: 'error_log_detail'"),
+          isFalse,
+          reason: 'detail GoRoute stub must NOT be emitted when no '
+              'detail_view file exists on disk.',
+        );
+        // No stray comma + blank line.
+        expect(
+          RegExp(r',\s*\n\s*,').hasMatch(content),
+          isFalse,
+          reason: 'stray comma + blank line detected',
+        );
+        // No mangled pathParameters access.
+        expect(
+          content.contains('pathParameters  [') ||
+              content.contains('pathParameters [\n') ||
+              content.contains("pathParameters [ 'id'"),
+          isFalse,
+          reason: 'mangled state.pathParameters access detected',
+        );
+        // No trailing comma in closure params.
+        expect(
+          content.contains('(context, state, )'),
+          isFalse,
+          reason: 'trailing comma in closure params',
+        );
+        // The list route + import are still present.
+        expect(
+          content.contains("name: 'error_log_list'"),
+          isTrue,
+        );
+        expect(
+          content.contains('error_log_view.dart'),
+          isTrue,
+        );
+      },
+    );
+
+    test(
+      'RE-RUN with --force over a pre-fix routes file cleans up the stale '
+      'detail route and produces a syntactically valid file',
+      () async {
+        // Pre-create the routes file with the pre-#331 broken content
+        // (referencing <Entity>DetailView unconditionally).
+        final routesDir = Directory('$outputDir/routing');
+        await routesDir.create(recursive: true);
+        await File('${routesDir.path}/error_log_routes.dart').writeAsString(
+          _preFixRoutesFile,
+        );
+        // Pre-create supporting files so _regenerateIndexFile doesn't choke.
+        await File('${routesDir.path}/index.dart').writeAsString(
+          "import 'error_log_routes.dart';\n",
+        );
+        await File('${routesDir.path}/app_routes.dart').writeAsString(
+          "import './index.dart';\n"
+          "class AppRoutes {}\n"
+          "extension RouterExtension on AppRoutes {}\n",
+        );
+
+        final builder = RouteBuilder(
+          outputDir: outputDir,
+          options: const GeneratorOptions(
+            dryRun: false,
+            force: true,
+            verbose: false,
+          ),
+        );
+
+        await builder.generate(
+          GeneratorConfig(
+            name: 'ErrorLog',
+            methods: const ['get', 'getList'],
+            generateVpcs: true,
+            generateRoute: true,
+            outputDir: outputDir,
+          ),
+        );
+
+        final routesFile = File('$outputDir/routing/error_log_routes.dart');
+        final content = routesFile.readAsStringSync();
+
+        // The stale detail GoRoute (referencing ErrorLogDetailView) must
+        // be removed.
+        expect(
+          content.contains('ErrorLogDetailView'),
+          isFalse,
+          reason: 'stale detail route referencing <Entity>DetailView '
+              'must be removed on re-run.',
+        );
+        expect(
+          content.contains("name: 'error_log_detail'"),
+          isFalse,
+          reason: 'no detail GoRoute stub must be emitted when no '
+              'detail_view file exists on disk.',
+        );
+        // No stray comma + blank line.
+        expect(
+          RegExp(r',\s*\n\s*,').hasMatch(content),
+          isFalse,
+          reason: 'stray comma + blank line detected',
+        );
+        // No mangled pathParameters access.
+        expect(
+          content.contains('pathParameters  [') ||
+              content.contains('pathParameters [\n') ||
+              content.contains("pathParameters [ 'id'"),
+          isFalse,
+          reason: 'mangled state.pathParameters access detected',
+        );
+        // No trailing comma in closure params.
+        expect(
+          content.contains('(context, state, )'),
+          isFalse,
+          reason: 'trailing comma in closure params',
+        );
+        // The stale detail_view import must be dropped.
+        expect(
+          content.contains('error_log_detail_view.dart'),
+          isFalse,
+          reason: 'stale detail_view import must be dropped when no '
+              'detail_view file exists.',
+        );
+        // The list route + main view import must still be present.
+        expect(
+          content.contains("name: 'error_log_list'"),
+          isTrue,
+        );
+        expect(
+          content.contains('error_log_view.dart'),
+          isTrue,
+        );
+
+        // The file must parse cleanly — verify by running the Dart
+        // formatter on it (throws on invalid syntax).
+        final formatted = _format(content);
+        expect(
+          formatted,
+          isNotNull,
+          reason: 'routes file must be parseable by DartFormatter',
+        );
+      },
+    );
+
+    test(
+      'RE-RUN with --force is idempotent — second run produces the same '
+      'file as the first',
+      () async {
+        final builder = RouteBuilder(
+          outputDir: outputDir,
+          options: const GeneratorOptions(
+            dryRun: false,
+            force: true,
+            verbose: false,
+          ),
+        );
+
+        // First run.
+        await builder.generate(
+          GeneratorConfig(
+            name: 'ErrorLog',
+            methods: const ['get', 'getList'],
+            generateVpcs: true,
+            generateRoute: true,
+            outputDir: outputDir,
+          ),
+        );
+        final routesFile = File('$outputDir/routing/error_log_routes.dart');
+        final firstRun = routesFile.readAsStringSync();
+
+        // Second run.
+        await builder.generate(
+          GeneratorConfig(
+            name: 'ErrorLog',
+            methods: const ['get', 'getList'],
+            generateVpcs: true,
+            generateRoute: true,
+            outputDir: outputDir,
+          ),
+        );
+        final secondRun = routesFile.readAsStringSync();
+
+        expect(
+          secondRun,
+          equals(firstRun),
+          reason: 're-running with --force must be idempotent',
+        );
+      },
+    );
+  });
+}
+
+/// Returns the formatted source, or null if the formatter fails (i.e.
+/// the source is not valid Dart).
+String? _format(String source) {
+  try {
+    return DartFormatter(
+      languageVersion: DartFormatter.latestLanguageVersion,
+    ).format(source);
+  } catch (_) {
+    return null;
+  }
+}


### PR DESCRIPTION
Closes #333

## Summary

Fixes #333 — `zfa route create` was emitting malformed detail-route stubs (stray comma + mangled `state.pathParameters  ['id']!` + collapsed one-line GoRoute) when no `<entity>_detail_view.dart` existed on disk. 108 route files affected in the smoke-test scenario.

## Root cause

After #331's "probe detail_view on disk" fix, re-running `zfa route create <Entity> --methods=get,getList --force` over a pre-existing routes file (which referenced `<Entity>DetailView`) triggered `_updateEntityRoutesFile`'s "remove old route by name identity → add new route" dance. The dance was broken in three compounding ways:

1. `removeElementsFromReturnListInFunctionWhere` only cut `element.offset..element.end`, leaving a stray trailing `,` in the list literal.
2. `_formatSafe` (DartFormatter) then **threw** on the resulting `GoRoute(...),
  ,
` syntax error and returned the raw, unformatted source.
3. `addElementToReturnListInFunction` inserted the new detail route's raw `code_builder.DartEmitter` output (with the weird `state.pathParameters  [
'id'
]!` whitespace) into the broken file. The final `_formatSafe` also failed → the mangled output persisted.

The detail route was emitted as a "stub" pointing to the main `<Entity>View` (per #331's `viewName = hasDetailView ? DetailView : View` fallback) — but the stub path was the broken one.

## Fix (3 changes)

### A. `route_builder.dart` — gate detail route on `hasDetailView`

When the detail-view probe finds no `<entity>_detail_view.dart` on disk, the detail GoRoute is omitted entirely (instead of emitting a stub pointing to the main View). The list route + create/update routes still emit normally.

```diff
-      if (needsIdRoute)
+      if (needsIdRoute && hasDetailView)
         _buildDetailRouteExpr(
           ...
-          viewName: hasDetailView
-              ? '${entityName}DetailView'
-              : '${entityName}View',
+          viewName: '${entityName}DetailView',
         ),
```

### B. `route_builder.dart` — stale-detail-route cleanup in `_updateEntityRoutesFile`

When `!hasDetailView`, any existing GoRoute whose `name:` is `'${routeBase}_detail'` is removed from the file by stable identity. This ensures pre-existing broken files (with the old `<Entity>DetailView` reference, or the broken stub) get cleaned up on the next `--force` re-run instead of leaving the broken stub in place.

### C. `ast_modifier.dart` — strip trailing comma after element removal

Added `_listElementRemovalEnd(source, elementEnd)` helper that extends the removal end past any trailing whitespace + comma. Used in both `removeElementFromReturnListInFunction` and `removeElementsFromReturnListInFunctionWhere`. Without this, removal left a stray `,` in the list literal that made `DartFormatter` throw — causing `_formatSafe` to return the raw, unformatted source.

## Test changes

- **`test/regression/issue_328_route_view_contract_test.dart`** (updated):
  - The "fall back to main View" assertions (from #331) are replaced with "no detail GoRoute stub is emitted" assertions (`name: '<entity>_detail'` must NOT be present).
  - The "rerun after detail-view deleted → replaces (not duplicates) the detail route" test is renamed + updated: the detail GoRoute is now REMOVED (routeCount == 0 in Run 2), not replaced with a stub.
- **`test/regression/issue_333_route_no_detail_stub_test.dart`** (new): 3-test regression suite covering (1) fresh generation with no detail_view file, (2) re-run with --force over a pre-fix routes file (referencing `<Entity>DetailView`) — verifies the file is cleaned up and parses cleanly via DartFormatter, (3) re-run is idempotent.

## Verification

- `dart analyze` on edited files: **No issues found!**
- `dart test test/regression/issue_333_route_no_detail_stub_test.dart`: **3/3 passed**
- `dart test test/regression/issue_328_route_view_contract_test.dart`: **12/12 passed**
- `dart test test/plugins/route test/plugins/view test/core/ast`: **36/36 passed**
- `dart test test/regression/route_generation_test.dart test/regression/output_quality_test.dart test/regression/pattern_compliance_test.dart test/regression/file_structure_test.dart test/regression/cli_command_test.dart test/regression/v5_pipeline_contract_test.dart test/regression/issue_294_entity_without_id_test.dart test/regression/issue_302_toggle_param_collision_test.dart test/regression/issue_320_entity_create_autoid_valueobject_e2e_test.dart`: **all passed**
- `dart test test/state`: **68/68 passed**
- `dart test test/commands/make_command_test.dart test/commands/feature_command_test.dart test/commands/build_command_unit_test.dart`: **34/34 passed**

## Closes

Closes #333