### PR TITLE
fix(zfa view create): hide colliding Flutter symbols from material import (#337)

### DIFF
--- a/lib/src/plugins/view/builders/view_class_builder.dart
+++ b/lib/src/plugins/view/builders/view_class_builder.dart
@@ -56,13 +56,31 @@ class ViewClassBuilder {
 
   static const _ignoreComment = '// ignore_for_file: no_logic_in_create_state';
 
+  /// Parses an import string, honoring an optional trailing
+  /// `hide Symbol1, Symbol2` combinator so callers can disambiguate entity
+  /// names that collide with Flutter symbols (#337).
+  static Directive _parseImport(String import) {
+    final match = RegExp('^(.*)\\s+hide\\s+(.+)\$').firstMatch(import);
+    if (match == null) {
+      return Directive.import(import);
+    }
+    return Directive(
+      (d) => d
+        ..type = DirectiveType.import
+        ..url = match.group(1)!.trim()
+        ..hide.addAll(
+          match.group(2)!.split(',').map((s) => s.trim()),
+        ),
+    );
+  }
+
   String build(ViewClassSpec spec, {String? leadingComment}) {
     if (spec.isCustom) {
       return _buildCustomView(spec, leadingComment: leadingComment);
     }
     final viewClass = _buildViewClass(spec);
     final stateClass = _buildStateClass(spec);
-    final directives = spec.imports.toSet().map(Directive.import).toList();
+    final directives = spec.imports.toSet().map(_parseImport).toList();
 
     final library = specLibrary.library(
       specs: [viewClass, stateClass],
@@ -179,7 +197,7 @@ class ViewClassBuilder {
         ),
     );
 
-    final directives = spec.imports.toSet().map(Directive.import).toList();
+    final directives = spec.imports.toSet().map(_parseImport).toList();
     final library = specLibrary.library(
       specs: [viewClass],
       directives: directives,
@@ -298,7 +316,7 @@ class ViewClassBuilder {
         ),
     );
 
-    final directives = spec.imports.toSet().map(Directive.import).toList();
+    final directives = spec.imports.toSet().map(_parseImport).toList();
     final library = specLibrary.library(
       specs: [viewClass, stateClass],
       directives: directives,

--- a/lib/src/plugins/view/view_plugin.dart
+++ b/lib/src/plugins/view/view_plugin.dart
@@ -11,6 +11,7 @@ import '../../core/context/file_system.dart';
 import '../../models/generated_file.dart';
 import '../../models/generator_config.dart';
 import '../../utils/file_utils.dart';
+import '../../utils/flutter_symbols.dart';
 import '../../utils/string_utils.dart';
 import 'builders/adaptive_layout_scaffold_builder.dart';
 import 'builders/view_class_builder.dart';
@@ -669,6 +670,22 @@ class ViewPlugin extends FileGeneratorPlugin implements CliAwarePlugin {
         !config.generatePresenter &&
         !config.isEntityBased &&
         !config.isOrchestrator;
+
+    // #337: The entity file is imported below, so an entity named after a
+    // Flutter material symbol (e.g. `Feedback`) would be ambiguous with the
+    // unqualified symbol from material.dart. Hide the colliding symbol from
+    // the material import so the entity wins.
+    final hideSymbol = collidesWithFlutterSymbol(config.name) &&
+        !isCustom &&
+        !config.noEntity &&
+        (config.generateState ||
+            config.customStateName != null ||
+            config.isEntityBased)
+        ? config.name
+        : null;
+    if (hideSymbol != null) {
+      imports[0] = 'package:flutter/material.dart hide $hideSymbol';
+    }
 
     if (!isCustom) {
       // #284/#281: Presentation layer imports `zuraffa_flutter` (which

--- a/lib/src/utils/flutter_symbols.dart
+++ b/lib/src/utils/flutter_symbols.dart
@@ -1,0 +1,70 @@
+/// Public Flutter symbols (exported via `package:flutter/material.dart`)
+/// that generated views never reference but entity class names commonly
+/// collide with.
+///
+/// When a generated view imports both `package:flutter/material.dart` and the
+/// entity's file, a colliding entity name (e.g. an entity named `Feedback`)
+/// makes every unqualified reference ambiguous (`ambiguous_import`). The view
+/// generator hides the colliding symbol from the material import so the
+/// entity always wins (#337).
+///
+/// Symbols the generated view code itself uses (e.g. `Text`, `Widget`,
+/// `Scaffold`, `AppBar`, `Container`, `Center`, `ValueKey`, `State`, `Key`)
+/// must NOT be listed here — hiding them would break the generated code.
+const Set<String> flutterMaterialCollidingSymbols = {
+  'Feedback',
+  'Table',
+  'Divider',
+  'Chip',
+  'Tooltip',
+  'Drawer',
+  'Material',
+  'Dialog',
+  'Card',
+  'Switch',
+  'Slider',
+  'Radio',
+  'Checkbox',
+  'Icon',
+  'Theme',
+  'Banner',
+  'SnackBar',
+  'CircleAvatar',
+  'Stepper',
+  'TickerMode',
+  'GridView',
+  'ListView',
+  'PageView',
+  'ScrollView',
+  'Form',
+  'FormField',
+  'DropdownButton',
+  'PopupMenuButton',
+  'SelectableText',
+  'Spacer',
+  'Wrap',
+  'Flow',
+  'Stack',
+  'Positioned',
+  'Align',
+  'Padding',
+  'DecoratedBox',
+  'ClipRRect',
+  'ClipOval',
+  'Transform',
+  'Opacity',
+  'AspectRatio',
+  'ConstrainedBox',
+  'FittedBox',
+  'IntrinsicHeight',
+  'IntrinsicWidth',
+  'LimitedBox',
+  'OverflowBox',
+  'SizedBox',
+  'Placeholder',
+};
+
+/// Whether [entityName] collides with a Flutter material symbol that the
+/// generated view must hide from its material import.
+bool collidesWithFlutterSymbol(String? entityName) =>
+    entityName != null && flutterMaterialCollidingSymbols.contains(entityName);

--- a/test/plugins/view/view_plugin_flutter_collision_test.dart
+++ b/test/plugins/view/view_plugin_flutter_collision_test.dart
@@ -1,0 +1,149 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+import 'package:zuraffa/src/core/generator_options.dart';
+import 'package:zuraffa/src/models/generator_config.dart';
+import 'package:zuraffa/src/plugins/view/view_plugin.dart';
+
+void main() {
+  late Directory tempDir;
+  late String outputDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('zuraffa_view_337_');
+    outputDir = Directory('${tempDir.path}/lib/src').path;
+  });
+
+  tearDown(() async {
+    if (tempDir.existsSync()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  // Regression test for #337: an entity named after a Flutter material
+  // symbol (`Feedback`) must not produce an ambiguous_import between
+  // package:flutter/material.dart and the entity import. The generator must
+  // hide the colliding symbol from the material import.
+  group('#337 entity named after Flutter symbol', () {
+    test('hides colliding Flutter symbol from material import', () async {
+      final plugin = ViewPlugin(
+        outputDir: outputDir,
+        options: const GeneratorOptions(
+          dryRun: false,
+          force: true,
+          verbose: false,
+        ),
+      );
+      final config = GeneratorConfig(
+        name: 'Feedback',
+        methods: const ['get', 'update'],
+        generateDi: true,
+        generateView: true,
+        outputDir: outputDir,
+      );
+      final files = await plugin.generate(config);
+      final content =
+          files.firstWhere((f) => f.path.contains('feedback_view.dart'))
+              .content ??
+          '';
+
+      // The entity symbol must resolve to the entity, never be ambiguous.
+      expect(
+        content.contains("import 'package:flutter/material.dart' hide Feedback;"),
+        isTrue,
+        reason: 'material import must hide the colliding entity symbol',
+      );
+      expect(
+        content.contains("import 'package:flutter/material.dart';"),
+        isFalse,
+        reason: 'the plain material import must be replaced by the hidden one',
+      );
+      // The entity import must still be present unqualified.
+      expect(
+        content.contains('domain/entities/feedback/feedback.dart'),
+        isTrue,
+      );
+      // The view must still reference the entity type.
+      expect(content.contains('final Feedback? feedback;'), isTrue);
+      expect(content.contains('class FeedbackView'), isTrue);
+    });
+
+    test('hides colliding symbol on detail views too', () async {
+      final plugin = ViewPlugin(
+        outputDir: outputDir,
+        options: const GeneratorOptions(
+          dryRun: false,
+          force: true,
+          verbose: false,
+        ),
+      );
+      final config = GeneratorConfig(
+        name: 'Feedback',
+        methods: const ['get', 'getList'],
+        generateDi: true,
+        generateView: true,
+        outputDir: outputDir,
+      );
+      final files = await plugin.generate(config);
+      final detail =
+          files.firstWhere((f) => f.path.contains('feedback_detail_view.dart'))
+              .content ??
+          '';
+      expect(
+        detail.contains("import 'package:flutter/material.dart' hide Feedback;"),
+        isTrue,
+      );
+    });
+
+    test('does not hide symbols for non-colliding entities', () async {
+      final plugin = ViewPlugin(
+        outputDir: outputDir,
+        options: const GeneratorOptions(
+          dryRun: false,
+          force: true,
+          verbose: false,
+        ),
+      );
+      final config = GeneratorConfig(
+        name: 'Product',
+        methods: const ['get'],
+        generateDi: true,
+        generateView: true,
+        outputDir: outputDir,
+      );
+      final files = await plugin.generate(config);
+      final content =
+          files.firstWhere((f) => f.path.contains('product_view.dart'))
+              .content ??
+          '';
+      expect(content.contains("import 'package:flutter/material.dart';"), isTrue);
+      expect(content.contains(' hide '), isFalse);
+    });
+
+    test('generated view is valid Dart', () async {
+      final plugin = ViewPlugin(
+        outputDir: outputDir,
+        options: const GeneratorOptions(
+          dryRun: false,
+          force: true,
+          verbose: false,
+        ),
+      );
+      final config = GeneratorConfig(
+        name: 'Feedback',
+        methods: const ['get', 'update'],
+        generateDi: true,
+        generateView: true,
+        outputDir: outputDir,
+      );
+      await plugin.generate(config);
+      final viewFile = File(
+        '$outputDir/presentation/pages/feedback/feedback_view.dart',
+      );
+      expect(viewFile.existsSync(), isTrue);
+
+      final result = await Process.run('dart', ['format', '--output=none', viewFile.path]);
+      expect(result.exitCode, 0, reason: result.stderr.toString());
+    });
+  });
+}


### PR DESCRIPTION
## Problem
`zfa view create` on an entity named `Feedback` generated a view importing both `package:flutter/material.dart` and the entity file unqualified → `ambiguous_import` compile error (Flutter's `Feedback` widget vs the `Feedback` entity).

Issue: #337

## Fix (generator-side, no hand-edited generated files)
- New `lib/src/utils/flutter_symbols.dart`: curated denylist of public Flutter material symbols (Feedback, Table, Divider, Chip, Tooltip, Drawer, Material, …) that generated views never reference. Symbols used by generated view code (Widget, Scaffold, Text, …) are deliberately excluded.
- `ViewPlugin._buildImports`: when the entity name collides AND the entity file is imported (entity-based/state views), emit `import 'package:flutter/material.dart' hide <Entity>;` so the entity always wins.
- `ViewClassBuilder._parseImport`: import strings may now carry a trailing `hide A, B` combinator, parsed into `code_builder` `Directive.hide` (used at all 3 directive-mapping sites).

## Verification
- Regenerated the affected view in apps/zikzak_demo with the exact repro: `zfa view create Feedback --di --force` → emitted `import 'package:flutter/material.dart' hide Feedback;`
- `flutter analyze lib/src/presentation/pages/feedback/` → **No issues found** (ambiguous_import gone; was 2 errors before: ambiguous_import ×2 sites in the view)
- Full-project `flutter analyze` in zikzak_demo: the remaining error is `customer_profile_view.dart` String→int, which is issue **#336** (separate defect, separate pool task), not this fix.
- `dart test test/plugins/view/ test/commands/` → 120 tests pass.

## Regression tests (mandatory per user rule)
`test/plugins/view/view_plugin_flutter_collision_test.dart` — 4 tests:
1. Feedback view hides colliding symbol + still references entity type
2. Detail view also hides
3. Non-colliding entity (Product) keeps plain import (no `hide`)
4. Generated view is valid Dart (formatter check)

Closes #337

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented naming conflicts between generated entities and Flutter Material symbols.
  - Generated views now hide conflicting Material imports while preserving entity references.
  - Improved handling of imports that include `hide` directives.

- **Tests**
  - Added coverage for collision handling across list and detail views.
  - Verified non-conflicting imports and valid generated Dart formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->