### PR TITLE
fix(view/route): type route id param after entity's actual id field

### DIFF
--- a/lib/src/plugins/route/builders/route_builder.dart
+++ b/lib/src/plugins/route/builders/route_builder.dart
@@ -832,9 +832,18 @@ class RouteBuilder {
     }
 
     if (withId) {
-      viewArgs['id'] = refer(
-        'state',
-      ).property('pathParameters').index(literalString('id')).nullChecked;
+      // #336: go_router path parameters are always String; convert to
+      // the view's id type (typed after the entity's actual id field).
+      final idValue = refer('state')
+          .property('pathParameters')
+          .index(literalString('id'))
+          .nullChecked;
+      viewArgs['id'] = switch (config.idFieldType) {
+        'int' => refer('int').property('parse').call([idValue]),
+        'double' => refer('double').property('parse').call([idValue]),
+        'num' => refer('num').property('parse').call([idValue]),
+        _ => idValue,
+      };
     }
 
     if (!config.noEntity && !config.isCustomUseCase) {

--- a/lib/src/plugins/route/capabilities/create_route_capability.dart
+++ b/lib/src/plugins/route/capabilities/create_route_capability.dart
@@ -2,6 +2,7 @@ import '../../../core/plugin_system/capability.dart';
 import '../route_plugin.dart';
 import '../../../models/generator_config.dart';
 import '../../../models/generated_file.dart';
+import '../../../utils/entity_id_type.dart';
 
 class CreateRouteCapability implements ZuraffaCapability {
   final RoutePlugin plugin;
@@ -97,12 +98,21 @@ class CreateRouteCapability implements ZuraffaCapability {
     final force = args['force'] ?? false;
     final verbose = args['verbose'] ?? false;
 
+    // #336: keep route id path params consistent with the view's id
+    // field type (probe the entity source / last make plan) so int-id
+    // entities get `int.parse(state.pathParameters['id']!)` instead of
+    // assigning a String into an int-typed view param.
+    final idFieldType =
+        args['id-field-type'] as String? ??
+        await resolveEntityIdFieldType(entityName: name);
+
     final config = GeneratorConfig(
       name: name,
       outputDir: outputDir,
       methods: methods,
       generateRoute: true,
       generateDi: false, // Prevent repository injections in views
+      idFieldType: idFieldType ?? 'String',
       dryRun: dryRun,
       force: force,
       verbose: verbose,

--- a/lib/src/plugins/view/capabilities/create_view_capability.dart
+++ b/lib/src/plugins/view/capabilities/create_view_capability.dart
@@ -2,6 +2,7 @@ import '../../../core/plugin_system/capability.dart';
 import '../view_plugin.dart';
 import '../../../models/generator_config.dart';
 import '../../../models/generated_file.dart';
+import '../../../utils/entity_id_type.dart';
 
 class CreateViewCapability implements ZuraffaCapability {
   final ViewPlugin plugin;
@@ -124,6 +125,16 @@ class CreateViewCapability implements ZuraffaCapability {
     final force = args['force'] ?? false;
     final verbose = args['verbose'] ?? false;
 
+    // #336: type the route id param after the entity's ACTUAL id type
+    // (probe the entity source, fall back to the last `zfa make` plan's
+    // persisted id args) so `onInitState` passes an id the
+    // presenter/controller accessor actually accepts. Previously this
+    // always defaulted to `String`, breaking int-id entities with
+    // `argument_type_not_assignable`.
+    final idFieldType =
+        args['id-field-type'] as String? ??
+        await resolveEntityIdFieldType(entityName: name);
+
     final config = GeneratorConfig(
       name: name,
       outputDir: outputDir,
@@ -134,6 +145,7 @@ class CreateViewCapability implements ZuraffaCapability {
       generateV6State: generateV6State,
       generateState: generateState,
       generateXRay: generateXRay,
+      idFieldType: idFieldType ?? 'String',
       dryRun: dryRun,
       force: force,
       verbose: verbose,

--- a/lib/src/utils/entity_id_type.dart
+++ b/lib/src/utils/entity_id_type.dart
@@ -1,0 +1,60 @@
+// entity_id_type.dart
+//
+// Resolves the ACTUAL type of an entity's identity for standalone
+// generator commands (`zfa view create`, `zfa route create`).
+//
+// Background (issue #336): `zfa view create` hardcoded the route id
+// param as `String?` while `zfa make` types the presenter/controller
+// accessor after the entity's real id field (e.g. `int`). Regenerating a
+// view for an int-id entity then produced
+// `controller.getX(widget.id!)` where `widget.id` is `String?` but the
+// accessor takes `int` → argument_type_not_assignable.
+//
+// Resolution order:
+//   1. Probe the entity source file via [EntityFieldResolver] (a field
+//      named `id`, else the first field ending in `Id`, else the
+//      synthetic `id: String` promised by `autoId: true`).
+//   2. Fall back to the persisted args of the last `zfa make` run
+//      (`.zfa/plans/last_run_<Entity>.json`). This covers entities
+//      whose identity was declared explicitly at make time via
+//      `--id-field`/`--id-field-type` and that have no id-like field on
+//      the entity itself (e.g. CustomerProfile → yearOfBirth:int).
+//
+// Returns null when neither source yields a type; callers keep their
+// existing default (`String`).
+
+import '../core/plugin_system/plan_store.dart';
+import '../core/project/project_root.dart';
+import 'entity_field_resolver.dart';
+
+/// Resolves the entity's actual id type for standalone view/route
+/// generation, or null when it cannot be determined.
+Future<String?> resolveEntityIdFieldType({
+  required String entityName,
+  String? projectRoot,
+}) async {
+  final root = projectRoot ?? ProjectRoot.find();
+
+  // 1. Probe the entity source file.
+  final resolution = EntityFieldResolver.resolveIdField(
+    entityName: entityName,
+    projectRoot: root,
+  );
+  if (resolution?.idField != null) {
+    return resolution!.idField!.nonNullableType;
+  }
+
+  // 2. Fall back to the last `zfa make` plan's persisted id args.
+  final report = await PlanStore.instance.loadPlan(
+    'last_run_$entityName',
+    baseDir: root,
+  );
+  final args = report?.args;
+  if (args is Map<String, dynamic>) {
+    final type = args['id-field-type'];
+    if (type is String && type.isNotEmpty) {
+      return type;
+    }
+  }
+  return null;
+}

--- a/test/regression/issue_336_view_route_id_type_test.dart
+++ b/test/regression/issue_336_view_route_id_type_test.dart
@@ -1,0 +1,417 @@
+// Regression test for issue #336:
+// https://github.com/arrrrny/zuraffa/issues/336
+//
+// `zfa view create` hardcoded the route id param as `String?` while
+// `zfa make` types the presenter/controller accessor after the entity's
+// ACTUAL id field type. For an entity whose route id path param is
+// String (the go_router convention) but whose id field is `int`, the
+// regenerated view's `onInitState` passed `widget.id!` (String) into an
+// int-typed accessor → argument_type_not_assignable.
+//
+// Fix:
+//   - `CreateViewCapability` / `CreateRouteCapability` resolve the id
+//     type by probing the entity source (EntityFieldResolver), falling
+//     back to the persisted args of the last `zfa make` run
+//     (`.zfa/plans/last_run_<Entity>.json`) for entities whose identity
+//     was declared explicitly at make time (e.g. CustomerProfile →
+//     yearOfBirth:int, no id-like field on the entity itself).
+//   - `RouteBuilder` converts the String path parameter with
+//     int.parse/double.parse/num.parse when the id type is numeric.
+
+import 'dart:io';
+
+import 'package:test/test.dart';
+import 'package:zuraffa/src/core/generator_options.dart';
+import 'package:zuraffa/src/core/plugin_system/plan_store.dart';
+import 'package:zuraffa/src/models/generator_config.dart';
+import 'package:zuraffa/src/plugins/route/builders/route_builder.dart';
+import 'package:zuraffa/src/plugins/route/route_plugin.dart';
+import 'package:zuraffa/src/plugins/view/view_plugin.dart';
+import 'package:zuraffa/src/utils/entity_id_type.dart';
+
+void main() {
+  late Directory tempDir;
+  late String originalCwd;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('zuraffa_issue336_');
+    // The capabilities resolve the project root from the CWD; run inside
+    // the temp project so the entity probe and the persisted-plan
+    // fallback read the temp fixtures, not the zuraffa repo itself.
+    originalCwd = Directory.current.path;
+    Directory.current = tempDir.path;
+    PlanStore.instance.rootDirectory = tempDir.path;
+  });
+
+  tearDown(() async {
+    Directory.current = originalCwd;
+    PlanStore.instance.rootDirectory = null;
+    if (tempDir.existsSync()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  Directory entityDir(String snake) =>
+      Directory('${tempDir.path}/lib/src/domain/entities/$snake');
+
+  Future<void> writeEntity(String snake, String body) async {
+    final dir = entityDir(snake);
+    await dir.create(recursive: true);
+    await File('${dir.path}/$snake.dart').writeAsString(body);
+  }
+
+  // ─────────────────────────────────────────────────────────────────
+  // Resolver: probe entity source, then persisted make-plan args
+  // ─────────────────────────────────────────────────────────────────
+
+  group('issue #336 — resolveEntityIdFieldType', () {
+    test('probes int id field from the entity source', () async {
+      await writeEntity(
+        'gadget',
+        '@Zorphy()\n'
+        'abstract class \$Gadget {\n'
+        '  int get id;\n'
+        '  String get name;\n'
+        '}\n',
+      );
+
+      final type = await resolveEntityIdFieldType(
+        entityName: 'Gadget',
+        projectRoot: tempDir.path,
+      );
+      expect(type, 'int');
+    });
+
+    test(
+      'falls back to the last make-plan id-field-type for entities with '
+      'no id-like field (CustomerProfile case)',
+      () async {
+        // Entity has NO id-like field; its identity was declared at make
+        // time via --id-field=yearOfBirth --id-field-type=int.
+        await writeEntity(
+          'wardrobe',
+          '@Zorphy()\n'
+          'abstract class \$Wardrobe {\n'
+          '  int get yearOfBirth;\n'
+          '  String get style;\n'
+          '}\n',
+        );
+        final plansDir = Directory('${tempDir.path}/.zfa/plans');
+        await plansDir.create(recursive: true);
+        await File('${plansDir.path}/last_run_Wardrobe.json').writeAsString(
+          '{"plan_id":"last_run_Wardrobe","plugin_id":"manager",'
+          '"capability_name":"make","args":{"name":"Wardrobe",'
+          '"id-field":"yearOfBirth","id-field-type":"int"},'
+          '"changes":[],"valid":true}',
+        );
+
+        final type = await resolveEntityIdFieldType(
+          entityName: 'Wardrobe',
+          projectRoot: tempDir.path,
+        );
+        expect(type, 'int');
+      },
+    );
+
+    test('returns null when neither source yields a type', () async {
+      final type = await resolveEntityIdFieldType(
+        entityName: 'Ghost',
+        projectRoot: tempDir.path,
+      );
+      expect(type, isNull);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // View: route id param typed after the entity's actual id type
+  // ─────────────────────────────────────────────────────────────────
+
+  group('issue #336 — zfa view create id param type', () {
+    test(
+      'int-id entity gets `final int? id` and passes int into the '
+      'accessor (String route id convention vs int entity id)',
+      () async {
+        await writeEntity(
+          'gadget',
+          '@Zorphy()\n'
+          'abstract class \$Gadget {\n'
+          '  int get id;\n'
+          '  String get name;\n'
+          '}\n',
+        );
+
+        final plugin = ViewPlugin(
+          outputDir: 'lib/src',
+          options: const GeneratorOptions(
+            dryRun: false,
+            force: true,
+            verbose: false,
+          ),
+        );
+        final capability = plugin.capabilities.firstWhere(
+          (c) => c.name == 'create',
+        );
+        final result = await capability.execute({
+          'name': 'Gadget',
+          'methods': ['get'],
+          'di': true,
+          'force': true,
+        });
+
+        final files = result.data?['generatedFiles'] as List;
+        expect(files, isNotEmpty);
+        final content = (files.first as dynamic).content as String;
+
+        expect(
+          content.contains('final int? id;'),
+          isTrue,
+          reason:
+              'the route id param must be typed after the entity id field '
+              '(int), not the String path-param convention (#336).',
+        );
+        expect(
+          content.contains('final String? id;'),
+          isFalse,
+          reason: 'String-typed id param is what caused '
+              'argument_type_not_assignable for int-id entities.',
+        );
+        expect(
+          content.contains('controller.getGadget(widget.id!)'),
+          isTrue,
+          reason: 'onInitState must still pass the id into the accessor.',
+        );
+
+        // The generated view must actually compile against an int-typed
+        // accessor: simulate the controller signature from #336.
+        expect(
+          RegExp(r'getGadget\(widget\.id!\)').hasMatch(content) &&
+              !content.contains('final String? id'),
+          isTrue,
+        );
+      },
+    );
+
+    test(
+      'no-id-like-field entity restores int id type from the last make '
+      'plan (CustomerProfile repro)',
+      () async {
+        await writeEntity(
+          'customer_profile',
+          '@Zorphy()\n'
+          'abstract class \$CustomerProfile {\n'
+          '  int get yearOfBirth;\n'
+          '  String get shoppingStyle;\n'
+          '}\n',
+        );
+        final plansDir = Directory('${tempDir.path}/.zfa/plans');
+        await plansDir.create(recursive: true);
+        await File(
+          '${plansDir.path}/last_run_CustomerProfile.json',
+        ).writeAsString(
+          '{"plan_id":"last_run_CustomerProfile","plugin_id":"manager",'
+          '"capability_name":"make","args":{"name":"CustomerProfile",'
+          '"id-field":"yearOfBirth","id-field-type":"int"},'
+          '"changes":[],"valid":true}',
+        );
+
+        final plugin = ViewPlugin(
+          outputDir: 'lib/src',
+          options: const GeneratorOptions(
+            dryRun: false,
+            force: true,
+            verbose: false,
+          ),
+        );
+        final capability = plugin.capabilities.firstWhere(
+          (c) => c.name == 'create',
+        );
+        final result = await capability.execute({
+          'name': 'CustomerProfile',
+          'methods': ['get'],
+          'di': true,
+          'force': true,
+        });
+
+        final files = result.data?['generatedFiles'] as List;
+        final content = (files.first as dynamic).content as String;
+        expect(
+          content.contains('final int? id;'),
+          isTrue,
+          reason:
+              'the id type must be restored from the persisted make-plan '
+              'args when the entity has no id-like field (#336).',
+        );
+        expect(content.contains('controller.getCustomerProfile(widget.id!)'),
+            isTrue);
+      },
+    );
+
+    test('string-id entity keeps the String id param (no regression)',
+        () async {
+      await writeEntity(
+        'product',
+        '@Zorphy()\n'
+        'abstract class \$Product {\n'
+        '  String get id;\n'
+        '  String get name;\n'
+        '}\n',
+      );
+
+      final plugin = ViewPlugin(
+        outputDir: 'lib/src',
+        options: const GeneratorOptions(
+          dryRun: false,
+          force: true,
+          verbose: false,
+        ),
+      );
+      final capability = plugin.capabilities.firstWhere(
+        (c) => c.name == 'create',
+      );
+      final result = await capability.execute({
+        'name': 'Product',
+        'methods': ['get'],
+        'di': true,
+        'force': true,
+      });
+
+      final files = result.data?['generatedFiles'] as List;
+      final content = (files.first as dynamic).content as String;
+      expect(content.contains('final String? id;'), isTrue);
+      expect(content.contains('controller.getProduct(widget.id!)'), isTrue);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // Route: String path params converted for numeric id types
+  // ─────────────────────────────────────────────────────────────────
+
+  group('issue #336 — route id path param conversion', () {
+    test('int id type emits int.parse(state.pathParameters[\'id\']!)',
+        () async {
+      final viewDir =
+          Directory('${tempDir.path}/lib/src/presentation/pages/gadget');
+      await viewDir.create(recursive: true);
+      await File('${viewDir.path}/gadget_view.dart')
+          .writeAsString('// stub view file\n');
+      await File('${viewDir.path}/gadget_detail_view.dart')
+          .writeAsString('// stub detail view file\n');
+
+      final builder = RouteBuilder(
+        outputDir: 'lib/src',
+        options: const GeneratorOptions(
+          dryRun: false,
+          force: true,
+          verbose: false,
+        ),
+      );
+      await builder.generate(
+        GeneratorConfig(
+          name: 'Gadget',
+          methods: const ['get', 'getList'],
+          generateVpcs: true,
+          generateRoute: true,
+          idFieldType: 'int',
+          outputDir: 'lib/src',
+        ),
+      );
+
+      final routesFile =
+          File('${tempDir.path}/lib/src/routing/gadget_routes.dart');
+      expect(routesFile.existsSync(), isTrue);
+      final content = routesFile.readAsStringSync();
+      expect(
+        content.contains("int.parse(state.pathParameters['id']!)"),
+        isTrue,
+        reason:
+            'go_router path params are String; an int-typed view id param '
+            'must be converted with int.parse (#336).',
+      );
+    });
+
+    test('String id type keeps the raw path parameter (no int.parse)',
+        () async {
+      final viewDir =
+          Directory('${tempDir.path}/lib/src/presentation/pages/product');
+      await viewDir.create(recursive: true);
+      await File('${viewDir.path}/product_view.dart')
+          .writeAsString('// stub view file\n');
+      await File('${viewDir.path}/product_detail_view.dart')
+          .writeAsString('// stub detail view file\n');
+
+      final builder = RouteBuilder(
+        outputDir: 'lib/src',
+        options: const GeneratorOptions(
+          dryRun: false,
+          force: true,
+          verbose: false,
+        ),
+      );
+      await builder.generate(
+        GeneratorConfig(
+          name: 'Product',
+          methods: const ['get', 'getList'],
+          generateVpcs: true,
+          generateRoute: true,
+          idFieldType: 'String',
+          outputDir: 'lib/src',
+        ),
+      );
+
+      final routesFile =
+          File('${tempDir.path}/lib/src/routing/product_routes.dart');
+      expect(routesFile.existsSync(), isTrue);
+      final content = routesFile.readAsStringSync();
+      expect(
+        content.contains("state.pathParameters['id']!"),
+        isTrue,
+      );
+      expect(
+        content.contains('int.parse'),
+        isFalse,
+        reason: 'String ids must be passed through unchanged.',
+      );
+    });
+
+    test('route capability resolves int id type by probing the entity',
+        () async {
+      await writeEntity(
+        'gadget',
+        '@Zorphy()\n'
+        'abstract class \$Gadget {\n'
+        '  int get id;\n'
+        '  String get name;\n'
+        '}\n',
+      );
+      final viewDir =
+          Directory('${tempDir.path}/lib/src/presentation/pages/gadget');
+      await viewDir.create(recursive: true);
+      await File('${viewDir.path}/gadget_view.dart')
+          .writeAsString('// stub view file\n');
+      await File('${viewDir.path}/gadget_detail_view.dart')
+          .writeAsString('// stub detail view file\n');
+
+      final plugin = RoutePlugin(outputDir: 'lib/src');
+      final capability = plugin.capabilities.firstWhere(
+        (c) => c.name == 'create',
+      );
+      await capability.execute({
+        'name': 'Gadget',
+        'methods': ['get', 'getList'],
+        'force': true,
+      });
+
+      final routesFile =
+          File('${tempDir.path}/lib/src/routing/gadget_routes.dart');
+      expect(routesFile.existsSync(), isTrue);
+      final content = routesFile.readAsStringSync();
+      expect(
+        content.contains("int.parse(state.pathParameters['id']!)"),
+        isTrue,
+        reason:
+            'zfa route create must probe the entity id type and convert '
+            'the String path param for int-id entities (#336).',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Problem (#336)

`zfa view create` hardcoded the route id param as `String?` while `zfa make` types the presenter/controller accessor after the entity's real id field. For an entity whose route id is String (go_router path-param convention) but whose id field is `int`, the regenerated view's `onInitState` passed `widget.id!` (String) into an int-typed accessor:

```
error • The argument type 'String' can't be assigned to the parameter type 'int'.
  • lib/src/presentation/pages/customer_profile/customer_profile_view.dart:38:55 • argument_type_not_assignable
```

## Fix (generator-side, no hand-edited generated files)

- **`lib/src/utils/entity_id_type.dart`** (new): `resolveEntityIdFieldType` — probes the entity source via `EntityFieldResolver` (id-like field), falls back to the persisted `.zfa/plans/last_run_<Entity>.json` make-plan args (`id-field-type`) for entities whose identity was declared explicitly at make time (CustomerProfile → `yearOfBirth:int`, no id-like field on the entity itself).
- **`CreateViewCapability`**: resolves `idFieldType` via the resolver (explicit `--id-field-type` arg still wins) → view emits `final int? id;` for int-id entities.
- **`CreateRouteCapability`**: same resolution so routes and views stay in contract.
- **`RouteBuilder`**: go_router path params are always String — converts with `int.parse`/`double.parse`/`num.parse` when the id type is numeric.

## Verification

- New regression test `test/regression/issue_336_view_route_id_type_test.dart` (9 cases): int-id entity → `final int? id`, CustomerProfile no-id-field → type restored from last make plan, String-id no-regression, resolver unit cases, route `int.parse` conversion.
- End-to-end proof (the exact failing command): rebuilt `zfa`, regenerated the affected view in apps/zikzak_demo via `zfa view create CustomerProfile --di --force`, then `flutter analyze` in apps/zikzak_demo → **0 errors** (was 1 `argument_type_not_assignable`).
- `dart test test/plugins/view/ test/plugins/route/ test/regression/issue_328_route_view_contract_test.dart test/regression/issue_336_view_route_id_type_test.dart` → all pass. (issue_310/323/304/321 regression failures are pre-existing on clean development — verified by stashing this change.)

Closes #336

Unblocks task 7545 (zikzak-zuraffa-v6-migration, standing by on #336+#337).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Route parameters now automatically convert to numeric ID types, including integers, decimals, and other numeric values.
  * View and route generation can determine an entity’s ID type from its configuration or existing project metadata.
  * String-based IDs continue to be handled as text by default.

* **Bug Fixes**
  * Fixed generated routes receiving numeric identifiers as unconverted strings.
  * Improved handling for entities whose ID type is defined in existing project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->