### PR TITLE
fix(di): sync plugin activation flags before schema defaults so datasource DI is generated

### DIFF
--- a/lib/src/core/plugin_system/plugin_manager.dart
+++ b/lib/src/core/plugin_system/plugin_manager.dart
@@ -91,6 +91,22 @@ class PluginManager {
 
     final data = <String, dynamic>{};
 
+    // #346: Sync plugin activation flags into data FIRST, before merging
+    // schema defaults below. Some schema properties share their name with a
+    // plugin id (e.g. RepositoryPlugin's `datasource` option, DataSourcePlugin's
+    // `cache` option) and default to false — when the schema-default merge ran
+    // first it wrote `data['datasource'] = false` and the activation sync's
+    // `!data.containsKey(id)` guard then skipped marking the datasource plugin
+    // active. Downstream plugins (DI) read `data['datasource']` to decide
+    // whether to emit datasource registrations, so the app compiled but
+    // crashed at runtime with `GetIt: DataSource is not registered`.
+    final activePluginIds = activePlugins.map((p) => p.id).toSet();
+    for (final id in activePluginIds) {
+      if (!data.containsKey(id)) {
+        data[id] = true;
+      }
+    }
+
     // Merge plugin-specific data from ArgResults
     if (argResults != null) {
       for (final plugin in activePlugins) {
@@ -138,7 +154,11 @@ class PluginManager {
               } else {
                 data[key] = val;
               }
-            } else if (propertyConfig.containsKey('default')) {
+            } else if (propertyConfig.containsKey('default') &&
+                // #346: never let a schema default overwrite a plugin
+                // activation flag (e.g. `datasource`, `cache` are both
+                // plugin ids and schema properties of other plugins).
+                !data.containsKey(key)) {
               final def = propertyConfig['default'];
               if (def is String && propertyConfig['type'] == 'array') {
                 data[key] = def
@@ -216,14 +236,6 @@ class PluginManager {
     // Add positional arguments and other common fields to data for backward compat
     data['name'] = name;
     data['output_dir'] = core.outputDir;
-
-    // Sync plugin activation flags into data so plugins can inspect each other
-    final activePluginIds = activePlugins.map((p) => p.id).toSet();
-    for (final id in activePluginIds) {
-      if (!data.containsKey(id)) {
-        data[id] = true;
-      }
-    }
 
     final baseFileSystem = FileSystem.create(root: projectRoot);
     final transactionalFileSystem = TransactionalFileSystem(baseFileSystem);

--- a/test/commands/make_command_test.dart
+++ b/test/commands/make_command_test.dart
@@ -407,5 +407,119 @@ abstract class \$ParserConfig {
         );
       },
     );
+
+    // #346: `zfa make --with=di` must generate datasource DI registrations.
+    // PluginManager.buildContext used to fill schema defaults (e.g.
+    // RepositoryPlugin's `datasource: false`) BEFORE syncing plugin
+    // activation flags, so `data['datasource']` was clobbered to false and
+    // the DI plugin never emitted lib/src/di/datasources/ — the app compiled
+    // but crashed at runtime with
+    // `GetIt: ProductRemoteDataSource is not registered`.
+    test(
+      '#346 — with di generates and wires datasource DI registrations',
+      timeout: const Timeout(Duration(minutes: 2)),
+      () async {
+        await writeEntity('Product', '''
+class Product {
+  final String id;
+
+  const Product({required this.id});
+}
+''');
+
+        final result = await runZfaSource([
+          'make',
+          'Product',
+          '--preset=crud',
+          '--with=di',
+          '--methods=get,getList',
+        ]);
+        expect(result.exitCode, 0, reason: result.stderr.toString());
+
+        final diPath = path.join(outputDir, 'di');
+
+        // 1. Datasource DI registration file exists and registers the
+        //    datasource in GetIt.
+        final dsDi = File(
+          path.join(diPath, 'datasources', 'product_remote_datasource_di.dart'),
+        );
+        expect(dsDi.existsSync(), isTrue, reason: 'datasource DI file missing');
+        final dsContent = dsDi.readAsStringSync();
+        expect(dsContent, contains('void registerProductRemoteDataSource('));
+        expect(
+          dsContent,
+          contains(
+            'getIt.registerLazySingleton<ProductRemoteDataSource>(',
+          ),
+        );
+
+        // 2. Datasource barrel exists and is called by setupDependencies
+        //    BEFORE repositories (repositories resolve datasources from GetIt).
+        final dsIndex = File(path.join(diPath, 'datasources', 'index.dart'));
+        expect(dsIndex.existsSync(), isTrue);
+        expect(
+          dsIndex.readAsStringSync(),
+          contains('registerAllDataSources(GetIt getIt)'),
+        );
+
+        final mainContent = File(
+          path.join(diPath, 'index.dart'),
+        ).readAsStringSync();
+        expect(mainContent, contains('registerAllDataSources(getIt);'));
+        expect(
+          mainContent.indexOf('registerAllDataSources(getIt);'),
+          lessThan(mainContent.indexOf('registerAllRepositories(getIt);')),
+          reason: 'datasources must be registered before repositories',
+        );
+      },
+    );
+
+    // #346 (mock variant): `--use-mock` must register the mock datasource
+    // instead of the remote one.
+    test(
+      '#346 — with di --use-mock registers the mock datasource',
+      timeout: const Timeout(Duration(minutes: 2)),
+      () async {
+        await writeEntity('Product', '''
+class Product {
+  final String id;
+
+  const Product({required this.id});
+}
+''');
+
+        final result = await runZfaSource([
+          'make',
+          'Product',
+          '--preset=crud',
+          '--with=di',
+          '--use-mock',
+          '--methods=get',
+        ]);
+        expect(result.exitCode, 0, reason: result.stderr.toString());
+
+        final mockDi = File(
+          path.join(
+            outputDir,
+            'di',
+            'datasources',
+            'product_mock_datasource_di.dart',
+          ),
+        );
+        expect(mockDi.existsSync(), isTrue, reason: 'mock datasource DI missing');
+        expect(
+          mockDi.readAsStringSync(),
+          contains('registerProductMockDataSource('),
+        );
+
+        final dsIndex = File(
+          path.join(outputDir, 'di', 'datasources', 'index.dart'),
+        );
+        expect(
+          dsIndex.readAsStringSync(),
+          contains('registerProductMockDataSource(getIt);'),
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary

Fixes #346.

`zfa make --with=di` never generated datasource DI registrations, so any generated screen crashed at runtime with `GetIt: ProductRemoteDataSource is not registered` — the repository DI referenced datasources that were never registered in GetIt.

### Root cause

`PluginManager.buildContext` merged plugin config-schema **defaults** (e.g. `RepositoryPlugin.configSchema` has `datasource: {default: false}`) **before** syncing plugin activation flags (`data['datasource'] = true` for active plugins). Since `datasource` is both a plugin id and a schema property of another plugin, the default `false` was written first and the activation sync's `!data.containsKey(id)` guard skipped marking the plugin active. `DiPlugin.generateWithContext` then saw `generateDataSource == false` and never emitted `lib/src/di/datasources/`.

### Fix (`lib/src/core/plugin_system/plugin_manager.dart`)

1. Sync plugin activation flags into `context.data` **first**, before any schema-default merge.
2. Guard the schema-default fill with `!data.containsKey(key)` so a default can never overwrite an activation flag (also covers the `cache` id/property collision).

No changes to the DI plugin itself were needed — its datasource generators, barrel, and `registerAllDataSources` wiring already existed and were simply never reached.

### Result

`zfa make Product --preset=crud --with=di --methods=get,getList` now generates:

- `di/datasources/product_remote_datasource_di.dart` (registers `ProductRemoteDataSource` in GetIt)
- `di/datasources/index.dart` barrel (`registerAllDataSources`)
- `di/index.dart` calls `registerAllDataSources(getIt)` **before** `registerAllRepositories(getIt)`
- `--use-mock` registers the mock datasource instead of remote

## Tests

Two regression tests in `test/commands/make_command_test.dart` (#346 group): remote variant asserts file + barrel + before-repositories ordering; mock variant asserts the mock datasource DI is emitted and wired.

## Verification

- `dart test test/commands/make_command_test.dart` — all 9 pass
- `dart test test/plugins/di/ test/core/ test/commands/` — all 665 pass
- End-to-end repro: fresh project, `zfa make Product --preset=crud --with=di` → datasource DI files generated (previously missing)
- Mock path verified on `apps/zikzak_demo` entity (`--use-mock` → `category_mock_datasource_di.dart`)
- Full suite: 5 pre-existing flaky failures (`issue_304/310/313/321/323`) reproduce identically on clean `development` — unrelated to this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved active plugin settings when applying schema defaults.
  * Ensured plugin activation flags remain correctly synchronized during configuration processing.

* **Tests**
  * Added coverage for dependency-injection code generation.
  * Verified correct datasource registration order and mock datasource generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->