### PR TITLE
fix(preset): bundle di with crud/read-only so canonical flow is runnable (#348)

### DIFF
--- a/lib/src/core/planning/preset_registry.dart
+++ b/lib/src/core/planning/preset_registry.dart
@@ -11,8 +11,14 @@ class PresetRegistry {
       'di',
       'test',
     ],
-    'crud': ['usecase', 'repository', 'datasource'],
-    'read-only': ['usecase', 'repository', 'datasource'],
+    // #348: `di` is bundled with the data presets so the canonical
+    // `zfa make X --preset=crud` (or `--preset=read-only`) produces a
+    // runnable app without the `--with=di` crutch. Every other preset
+    // already includes di; crud/read-only were the only two that didn't,
+    // and the resulting app compiled but crashed at runtime with
+    // `GetIt: DataSource is not registered` (issue #346).
+    'crud': ['usecase', 'repository', 'datasource', 'di'],
+    'read-only': ['usecase', 'repository', 'datasource', 'di'],
     'service-feature': [
       'service',
       'provider',

--- a/lib/src/plugins/repository/repository_plugin.dart
+++ b/lib/src/plugins/repository/repository_plugin.dart
@@ -194,16 +194,20 @@ class RepositoryPlugin extends FileGeneratorPlugin implements CliAwarePlugin {
         (config.appendToExisting && config.repo != null)) {
       files.add(await interfaceGen.generate(targetConfig));
     }
-    // #284: Always emit the data repository implementation alongside the
-    // interface for entity-based configs.  Previously this was gated on
-    // generateData || generateDataSource || appendToExisting, but those flags
-    // are not reliably set when the make invocation activates the datasource
-    // plugin via a preset (the schema default of false wins over the
-    // plugin-activation sync in PluginManager.buildContext).  The DI plugin
-    // unconditionally emits `product_repository_di.dart` referencing
+    // #284 / #348: Always emit the data repository implementation alongside
+    // the interface for entity-based configs.  Historically this was gated
+    // on generateData || generateDataSource || appendToExisting, but those
+    // flags are not reliably set for `--append` runs that don't activate the
+    // datasource plugin (the repository schema property `datasource` defaults
+    // to false and only the active-plugin sync flips it to true).  #347 made
+    // the plugin-activation sync run BEFORE the schema-default merge in
+    // PluginManager.buildContext, so `data['datasource'] == true` now holds
+    // whenever the datasource plugin is active (preset or explicit) and the
+    // DI plugin emits `product_repository_di.dart` referencing
     // `DataProductRepository` whenever generateRepository || generateData
-    // is true, so the impl must be produced for every entity-based config to
-    // keep the generated app compiling.
+    // is true.  The impl is still produced unconditionally for every
+    // entity-based config to keep `--append` and `--repo` flows compiling
+    // even when no datasource plugin is active (custom-usecase scenarios).
     if ((config.isEntityBased ||
             config.generateData ||
             config.generateDataSource ||

--- a/test/core/planning/plan_resolver_test.dart
+++ b/test/core/planning/plan_resolver_test.dart
@@ -43,16 +43,22 @@ void main() {
       );
 
       expect(plan.preset, 'crud');
+      // #348: `crud` now bundles `di` (lib/src/core/planning/preset_registry.dart),
+      // so `di` is requested by the preset itself and surfaces in plan.pluginIds
+      // immediately after the data layer (usecase/repository/datasource),
+      // before the presentation layer added via `--with=vpc`. Previously `di`
+      // appeared at the tail because it was only contributed by
+      // `ZfaConfig(diByDefault: true)` after the preset+with expansion.
       expect(
         plan.pluginIds,
         equals([
           'usecase',
           'repository',
           'datasource',
+          'di',
           'view',
           'presenter',
           'controller',
-          'di',
         ]),
       );
       expect(plan.executionOrder, plan.pluginIds);

--- a/test/core/planning/preset_registry_test.dart
+++ b/test/core/planning/preset_registry_test.dart
@@ -26,6 +26,23 @@ void main() {
       expect(PresetRegistry.hasPreset('unknown'), isFalse);
       expect(PresetRegistry.pluginIdsFor('unknown'), isEmpty);
     });
+
+    // #348: `crud` and `read-only` are the only data presets that previously
+    // omitted `di`. They now bundle it so the canonical
+    // `zfa make X --preset=crud` (or `--preset=read-only`) produces a
+    // runnable app without the `--with=di` crutch.
+    test('crud and read-only presets include di (issue #348)', () {
+      expect(PresetRegistry.hasPreset('crud'), isTrue);
+      expect(PresetRegistry.hasPreset('read-only'), isTrue);
+      expect(
+        PresetRegistry.pluginIdsFor('crud'),
+        containsAll(['usecase', 'repository', 'datasource', 'di']),
+      );
+      expect(
+        PresetRegistry.pluginIdsFor('read-only'),
+        containsAll(['usecase', 'repository', 'datasource', 'di']),
+      );
+    });
   });
 
   group('PluginAliasResolver', () {

--- a/test/regression/issue_348_preset_crud_datasource_di_test.dart
+++ b/test/regression/issue_348_preset_crud_datasource_di_test.dart
@@ -1,0 +1,239 @@
+// Regression test for issue #348:
+// https://github.com/arrrrny/zuraffa/issues/348
+//
+// `zfa make: preset crud/read-only lack di + datasource activation doesn't
+// flow into DI` — the canonical documented flow
+//
+//     zfa entity create -n ScratchItem --auto-id --field name:String
+//     zfa make ScratchItem --preset=crud --with=di --force
+//
+// produced an app that compiled but crashed at runtime with
+// `GetIt: DataSource is not registered`, because:
+//   - the `crud` and `read-only` presets did not include the `di` plugin, so
+//     `--with=di` was a silent requirement on data presets; and
+//   - even with `--with=di`, the repository plugin's `datasource` schema
+//     property defaulted to `false` and overrode the plugin-activation
+//     sync, so the DI plugin never emitted the datasource registration.
+//
+// #347 shipped the activation-flag-first sync in PluginManager.buildContext
+// (lib/src/core/plugin_system/plugin_manager.dart:94-108) and gated the
+// schema-default merge with `!data.containsKey(key)` (line 157-161), which
+// fixes the `--with=di` path. #348 closes the remaining half: the `crud`
+// and `read-only` presets now bundle `di` (lib/src/core/planning/preset_registry.dart),
+// so the canonical one-flag invocation is runnable without `--with=di`.
+//
+// This regression guard exercises the full CliRunner end-to-end against a
+// temp workspace and asserts:
+//   1. `--preset=crud --with=di` still produces the datasource DI file
+//      (guards the #346/#347 fix path).
+//   2. `--preset=crud` ALONE now produces the datasource DI file AND the
+//      repository DI file (the #348 preset-consistency fix).
+//   3. The repository DI references the datasource via `getIt<…RemoteDataSource>()`
+//      so the runtime resolution pattern is intact.
+//   4. The DI index `setupDependencies(getIt)` wires up
+//      `registerAllDataSources(getIt)` before `registerAllRepositories(getIt)`,
+//      so the datasource is registered before the repository tries to resolve it.
+
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+import 'package:zuraffa/src/cli/cli_runner.dart';
+
+void main() {
+  group('issue #348 — preset crud includes di + datasource activation', () {
+    late Directory workspace;
+    late String outputDir;
+    late String savedCwd;
+
+    Future<void> writeWorkspacePubspec() {
+      return File(p.join(workspace.path, 'pubspec.yaml')).writeAsString('''
+name: zuraffa_issue_348_test
+environment:
+  sdk: ^3.11.0
+''');
+    }
+
+    Future<void> writeProductEntity() async {
+      final entityDir = Directory(
+        p.join(outputDir, 'domain', 'entities', 'product'),
+      );
+      await entityDir.create(recursive: true);
+      await File(p.join(entityDir.path, 'product.dart')).writeAsString('''
+class Product {
+  final String id;
+  final String name;
+
+  const Product({required this.id, required this.name});
+}
+''');
+    }
+
+    setUp(() async {
+      savedCwd = Directory.current.path;
+      workspace = await Directory.systemTemp.createTemp('zfa_issue_348_');
+      outputDir = p.join(workspace.path, 'lib', 'src');
+      await Directory(outputDir).create(recursive: true);
+      await writeWorkspacePubspec();
+      await writeProductEntity();
+      Directory.current = workspace.path;
+    });
+
+    tearDown(() async {
+      try {
+        if (Directory(savedCwd).existsSync()) {
+          Directory.current = savedCwd;
+        } else {
+          Directory.current = Directory.systemTemp.path;
+        }
+      } catch (_) {
+        try {
+          Directory.current = Directory.systemTemp.path;
+        } catch (_) {}
+      }
+      if (workspace.existsSync()) {
+        await workspace.delete(recursive: true);
+      }
+    });
+
+    test('--preset=crud --with=di generates datasource DI (regression for #346/#347)',
+        () async {
+      final runner = CliRunner(exitOnCompletion: false);
+      await runner.run([
+        'make',
+        'Product',
+        '--preset=crud',
+        '--with=di',
+        '--output',
+        outputDir,
+        '--force',
+      ]);
+
+      final datasourceDi = File(
+        p.join(outputDir, 'di', 'datasources', 'product_remote_datasource_di.dart'),
+      );
+      final repositoryDi = File(
+        p.join(outputDir, 'di', 'repositories', 'product_repository_di.dart'),
+      );
+      final diIndex = File(p.join(outputDir, 'di', 'index.dart'));
+
+      expect(datasourceDi.existsSync(), isTrue,
+          reason: 'datasource DI file must exist for --preset=crud --with=di');
+      expect(repositoryDi.existsSync(), isTrue,
+          reason: 'repository DI file must exist for --preset=crud --with=di');
+      expect(diIndex.existsSync(), isTrue,
+          reason: 'di/index.dart must exist for --preset=crud --with=di');
+
+      final datasourceContent = datasourceDi.readAsStringSync();
+      expect(
+        datasourceContent,
+        contains('registerLazySingleton<ProductRemoteDataSource>'),
+        reason: 'datasource DI must register ProductRemoteDataSource',
+      );
+
+      final repositoryContent = repositoryDi.readAsStringSync();
+      expect(
+        repositoryContent,
+        contains('getIt<ProductRemoteDataSource>()'),
+        reason: 'repository DI must resolve the datasource via getIt — '
+            'this is the exact #346 runtime-crash pattern when missing',
+      );
+      expect(
+        repositoryContent,
+        contains('DataProductRepository'),
+        reason: 'repository DI must construct DataProductRepository',
+      );
+
+      final indexContent = diIndex.readAsStringSync();
+      expect(
+        indexContent,
+        contains('registerAllDataSources(getIt)'),
+        reason: 'setupDependencies must wire up registerAllDataSources',
+      );
+      expect(
+        indexContent,
+        contains('registerAllRepositories(getIt)'),
+        reason: 'setupDependencies must wire up registerAllRepositories',
+      );
+      // Datasources must be registered BEFORE repositories so the repository
+      // can resolve its datasource dependency at registration time.
+      final dsPos = indexContent.indexOf('registerAllDataSources(getIt)');
+      final repoPos = indexContent.indexOf('registerAllRepositories(getIt)');
+      expect(dsPos, lessThan(repoPos),
+          reason: 'registerAllDataSources must come before '
+              'registerAllRepositories in setupDependencies');
+    });
+
+    test('--preset=crud ALONE generates datasource DI (the #348 preset-consistency fix)',
+        () async {
+      final runner = CliRunner(exitOnCompletion: false);
+      await runner.run([
+        'make',
+        'Product',
+        '--preset=crud',
+        '--output',
+        outputDir,
+        '--force',
+      ]);
+
+      final datasourceDi = File(
+        p.join(outputDir, 'di', 'datasources', 'product_remote_datasource_di.dart'),
+      );
+      final repositoryDi = File(
+        p.join(outputDir, 'di', 'repositories', 'product_repository_di.dart'),
+      );
+      final diIndex = File(p.join(outputDir, 'di', 'index.dart'));
+
+      expect(datasourceDi.existsSync(), isTrue,
+          reason: 'the canonical `zfa make X --preset=crud` (no --with=di) '
+              'must now produce the datasource DI file — this is the #348 fix');
+      expect(repositoryDi.existsSync(), isTrue,
+          reason: 'the canonical `zfa make X --preset=crud` (no --with=di) '
+              'must now produce the repository DI file');
+      expect(diIndex.existsSync(), isTrue,
+          reason: 'the canonical `zfa make X --preset=crud` (no --with=di) '
+              'must now produce di/index.dart');
+
+      final repositoryContent = repositoryDi.readAsStringSync();
+      expect(
+        repositoryContent,
+        contains('getIt<ProductRemoteDataSource>()'),
+        reason: 'repository DI must resolve the datasource via getIt — '
+            'the canonical one-flag flow must be runnable',
+      );
+    });
+
+    test('--preset=read-only ALONE generates datasource DI (read-only parity with crud)',
+        () async {
+      final runner = CliRunner(exitOnCompletion: false);
+      await runner.run([
+        'make',
+        'Product',
+        '--preset=read-only',
+        '--output',
+        outputDir,
+        '--force',
+      ]);
+
+      final datasourceDi = File(
+        p.join(outputDir, 'di', 'datasources', 'product_remote_datasource_di.dart'),
+      );
+      final repositoryDi = File(
+        p.join(outputDir, 'di', 'repositories', 'product_repository_di.dart'),
+      );
+
+      expect(datasourceDi.existsSync(), isTrue,
+          reason: 'read-only preset must include di and produce the '
+              'datasource DI file (same #348 fix as crud)');
+      expect(repositoryDi.existsSync(), isTrue,
+          reason: 'read-only preset must produce the repository DI file');
+
+      final repositoryContent = repositoryDi.readAsStringSync();
+      expect(
+        repositoryContent,
+        contains('getIt<ProductRemoteDataSource>()'),
+        reason: 'read-only repository DI must resolve the datasource via getIt',
+      );
+    });
+  });
+}


### PR DESCRIPTION
Closes #348

Bundles the di plugin with the crud and read-only presets so the canonical zfa make X --preset=crud flow is runnable without the --with=di crutch. Updates the stale repository_plugin.dart comment that claimed the schema default wins over the activation sync (no longer true after #347). Adds end-to-end regression coverage through the real CliRunner. See commit message for full details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CRUD and read-only application presets now include dependency injection by default.
  * Generated applications automatically register datasource and repository dependencies.
* **Bug Fixes**
  * Corrected dependency-registration ordering during preset-based generation.
  * Ensured consistent dependency-injection output for CRUD and read-only workflows.
* **Tests**
  * Added regression coverage for generated dependency-injection files, registrations, and resolution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->