### PR TITLE
fix(test): detect Flutter vs pure-Dart in zfa test plugin so generated tests resolve — closes #354

### DIFF
--- a/lib/src/plugins/test/builders/test_builder.dart
+++ b/lib/src/plugins/test/builders/test_builder.dart
@@ -12,6 +12,7 @@ import '../../../models/generator_config.dart';
 import '../../../utils/entity_utils.dart';
 import '../../../utils/file_utils.dart';
 import '../../../utils/string_utils.dart';
+import '../../../core/dependencies/dependency_wirer.dart';
 
 part 'test_builder_custom.dart';
 part 'test_builder_entity.dart';
@@ -26,6 +27,12 @@ class TestBuilder {
   final SpecLibrary specLibrary;
   final DiscoveryEngine discovery;
   final FileSystem fileSystem;
+
+  // #354: cached Flutter-vs-pure-Dart detection for the test framework +
+  // zuraffa core imports. `null` = not yet resolved. Computed lazily by
+  // `_isFlutterProject` in TestBuilderHelpers. Reset by re-creating the
+  // TestBuilder (each TestBuilder instance targets one projectRoot).
+  bool? _cachedIsFlutterProject;
 
   /// Creates a [TestBuilder].
   TestBuilder({

--- a/lib/src/plugins/test/builders/test_builder_custom.dart
+++ b/lib/src/plugins/test/builders/test_builder_custom.dart
@@ -29,10 +29,12 @@ extension TestBuilderCustom on TestBuilder {
 
     final packageName = await _resolvePackageName(projectRoot);
 
+    // #354: detect Flutter vs pure-Dart from pubspec.yaml (see entity builder).
+    final isFlutter = await _isFlutterProject(projectRoot);
     final directives = [
-      Directive.import('package:flutter_test/flutter_test.dart'),
+      _testFrameworkImport(isFlutter),
       Directive.import('package:mocktail/mocktail.dart'),
-      Directive.import('package:zuraffa_flutter/zuraffa_flutter.dart'),
+      _zuraffaCoreImport(isFlutter),
       Directive.import(
         'package:$packageName/src/domain/usecases/${config.effectiveDomain}/${config.nameSnake}_usecase.dart',
       ),

--- a/lib/src/plugins/test/builders/test_builder_entity.dart
+++ b/lib/src/plugins/test/builders/test_builder_entity.dart
@@ -123,11 +123,15 @@ extension TestBuilderEntity on TestBuilder {
       return GeneratedFile(path: filePath, type: 'test', action: 'skipped');
     }
 
+    // #354: detect Flutter vs pure-Dart from pubspec.yaml so the test
+    // framework + zuraffa core imports resolve. `zfa setup --dart` only
+    // wires `test` + `mocktail` + `zuraffa` (no `flutter_test`, no
+    // `zuraffa_flutter`).
+    final isFlutter = await _isFlutterProject(projectRoot);
     final directives = [
-      Directive.import('package:flutter_test/flutter_test.dart'),
+      _testFrameworkImport(isFlutter),
       Directive.import('package:mocktail/mocktail.dart'),
-      if (method != 'create')
-        Directive.import('package:zuraffa_flutter/zuraffa_flutter.dart'),
+      if (method != 'create') _zuraffaCoreImport(isFlutter),
     ];
 
     String toPackageImport(String filePath) {

--- a/lib/src/plugins/test/builders/test_builder_helpers.dart
+++ b/lib/src/plugins/test/builders/test_builder_helpers.dart
@@ -566,6 +566,53 @@ extension TestBuilderHelpers on TestBuilder {
       _ => refer('t$type'),
     };
   }
+
+  // #354: detect whether the projectRoot's pubspec.yaml declares a Flutter
+  // dependency (`flutter: sdk: flutter`). Pure-Dart apps (`zfa setup --dart`)
+  // cannot import `package:flutter_test/flutter_test.dart` or
+  // `package:zuraffa_flutter/zuraffa_flutter.dart` — they only wire
+  // `test` + `mocktail` + `zuraffa`. Falls back to false when pubspec.yaml
+  // is missing or unreadable, matching DependencyWirer.isFlutterProject's
+  // conservative default. Result is cached per TestBuilder instance.
+  Future<bool> _isFlutterProject(String projectRoot) async {
+    if (_cachedIsFlutterProject != null) {
+      return _cachedIsFlutterProject!;
+    }
+    bool isFlutter = false;
+    try {
+      final pubspecPath = path.join(projectRoot, 'pubspec.yaml');
+      if (await fileSystem.exists(pubspecPath)) {
+        final content = await fileSystem.read(pubspecPath);
+        isFlutter = DependencyWirer.isFlutterProject(content);
+      }
+    } catch (_) {
+      // Mirror DependencyWirer: unreadable pubspec -> not Flutter.
+    }
+    _cachedIsFlutterProject = isFlutter;
+    return isFlutter;
+  }
+
+  /// Test framework import: `flutter_test` for Flutter apps, `test` for pure
+  /// Dart apps. `zfa setup --dart` only wires `test` + `mocktail` (no
+  /// `flutter_test`), so a pure-Dart app cannot resolve `flutter_test`.
+  Directive _testFrameworkImport(bool isFlutter) => Directive.import(
+    isFlutter
+        ? 'package:flutter_test/flutter_test.dart'
+        : 'package:test/test.dart',
+  );
+
+  /// Zuraffa core import: `zuraffa_flutter` (which re-exports `zuraffa`) for
+  /// Flutter apps, plain `zuraffa` for pure-Dart apps. The params classes
+  /// (UpdateParams, ListQueryParams, DeleteParams, QueryParams, ToggleParams,
+  /// NoParams, Eq, Success, Failure) are all exported from
+  /// `package:zuraffa/zuraffa.dart` (lib/zuraffa.dart → src/core/params/index.dart).
+  /// A pure-Dart app cannot import `package:zuraffa_flutter/zuraffa_flutter.dart`
+  /// (which transitively pulls in `flutter`).
+  Directive _zuraffaCoreImport(bool isFlutter) => Directive.import(
+    isFlutter
+        ? 'package:zuraffa_flutter/zuraffa_flutter.dart'
+        : 'package:zuraffa/zuraffa.dart',
+  );
 }
 
 extension ExpressionClosure on Expression {

--- a/lib/src/plugins/test/builders/test_builder_orchestrator.dart
+++ b/lib/src/plugins/test/builders/test_builder_orchestrator.dart
@@ -17,10 +17,12 @@ extension TestBuilderOrchestrator on TestBuilder {
 
     final packageName = await _resolvePackageName(projectRoot);
 
+    // #354: detect Flutter vs pure-Dart from pubspec.yaml (see entity builder).
+    final isFlutter = await _isFlutterProject(projectRoot);
     final directives = [
-      Directive.import('package:flutter_test/flutter_test.dart'),
+      _testFrameworkImport(isFlutter),
       Directive.import('package:mocktail/mocktail.dart'),
-      Directive.import('package:zuraffa_flutter/zuraffa_flutter.dart'),
+      _zuraffaCoreImport(isFlutter),
       Directive.import(
         'package:$packageName/src/domain/usecases/${config.effectiveDomain}/${config.nameSnake}_usecase.dart',
       ),

--- a/lib/src/plugins/test/builders/test_builder_polymorphic.dart
+++ b/lib/src/plugins/test/builders/test_builder_polymorphic.dart
@@ -22,10 +22,12 @@ extension TestBuilderPolymorphic on TestBuilder {
       final fileName = '${classSnake}_usecase_test.dart';
       final filePath = path.join(testDirPath, fileName);
 
+      // #354: detect Flutter vs pure-Dart from pubspec.yaml (see entity builder).
+      final isFlutter = await _isFlutterProject(projectRoot);
       final directives = [
-        Directive.import('package:flutter_test/flutter_test.dart'),
+        _testFrameworkImport(isFlutter),
         Directive.import('package:mocktail/mocktail.dart'),
-        Directive.import('package:zuraffa_flutter/zuraffa_flutter.dart'),
+        _zuraffaCoreImport(isFlutter),
         Directive.import(
           'package:$packageName/src/domain/usecases/${config.effectiveDomain}/${classSnake}_usecase.dart',
         ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -759,13 +759,13 @@ packages:
       path: "../zorphy/zorphy"
       relative: true
     source: path
-    version: "2.0.0"
+    version: "2.2.0"
   zorphy_annotation:
     dependency: "direct main"
     description:
       path: "../zorphy/zorphy_annotation"
       relative: true
     source: path
-    version: "2.0.0"
+    version: "2.2.0"
 sdks:
   dart: ">=3.11.0 <4.0.0"

--- a/test/regression/issue_354_test_plugin_flutter_vs_dart_imports_test.dart
+++ b/test/regression/issue_354_test_plugin_flutter_vs_dart_imports_test.dart
@@ -1,0 +1,435 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
+import 'package:test/test.dart';
+import 'package:zuraffa/src/core/generator_options.dart';
+import 'package:zuraffa/src/core/context/file_system.dart';
+import 'package:zuraffa/src/core/plugin_system/discovery_engine.dart';
+import 'package:zuraffa/src/models/generator_config.dart';
+import 'package:zuraffa/src/plugins/test/builders/test_builder.dart';
+
+/// #354 regression: zfa test plugin must generate package:test/test.dart
+/// (not flutter_test) and package:zuraffa/zuraffa.dart (not
+/// zuraffa_flutter) when the target project is pure-Dart (no
+/// flutter: sdk: flutter in pubspec.yaml).
+void main() {
+  group('issue 354 - test plugin Flutter-vs-pure-Dart imports', () {
+    late Directory tempDir;
+    late String projectRoot;
+    late String outputDir;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('zuraffa_354_');
+      projectRoot = tempDir.path;
+      outputDir = path.join(projectRoot, 'lib', 'src');
+
+      // Create minimal project structure so DiscoveryEngine + TestBuilder
+      // can resolve paths.
+      await Directory(outputDir).create(recursive: true);
+      await Directory(
+        path.join(outputDir, 'domain', 'entities', 'product'),
+      ).create(recursive: true);
+      await Directory(
+        path.join(outputDir, 'domain', 'usecases', 'product'),
+      ).create(recursive: true);
+      await Directory(
+        path.join(outputDir, 'domain', 'repositories'),
+      ).create(recursive: true);
+      await Directory(
+        path.join(outputDir, 'data', 'repositories'),
+      ).create(recursive: true);
+
+      // Entity file (so DiscoveryEngine.findFile resolves).
+      await File(
+        path.join(
+          outputDir, 'domain', 'entities', 'product', 'product.dart',
+        ),
+      ).writeAsString(
+        'class Product { final String id; const Product({required this.id}); }',
+      );
+
+      // Repository file.
+      await File(
+        path.join(
+          outputDir,
+          'domain',
+          'repositories',
+          'product_repository.dart',
+        ),
+      ).writeAsString('abstract class ProductRepository {}');
+
+      // UseCase file (required - generateForMethod skips if absent).
+      await File(
+        path.join(
+          outputDir,
+          'domain',
+          'usecases',
+          'product',
+          'get_product_usecase.dart',
+        ),
+      ).writeAsString('class GetProductUseCase {}');
+
+      // Also create update usecase for zuraffa import check.
+      await File(
+        path.join(
+          outputDir,
+          'domain',
+          'usecases',
+          'product',
+          'update_product_usecase.dart',
+        ),
+      ).writeAsString('class UpdateProductUseCase {}');
+
+      // Also create the generic product usecase for custom builder.
+      await File(
+        path.join(
+          outputDir,
+          'domain',
+          'usecases',
+          'product',
+          'product_usecase.dart',
+        ),
+      ).writeAsString('class ProductUseCase {}');
+    });
+
+    tearDown(() async {
+      if (tempDir.existsSync()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    test(
+      'pure-Dart pubspec generates test + zuraffa imports',
+      () async {
+        // Write a pure-Dart pubspec.yaml (no flutter SDK dependency).
+        await File(
+          path.join(projectRoot, 'pubspec.yaml'),
+        ).writeAsString('''
+name: my_pure_dart_app
+environment:
+  sdk: ">=3.11.0 <4.0.0"
+dependencies:
+  zuraffa:
+    git:
+      url: https://github.com/arrrrny/zuraffa
+dev_dependencies:
+  test: ^1.25.0
+  mocktail: ^1.0.4
+''');
+
+        final fs = FileSystem.create(root: projectRoot);
+        final builder = TestBuilder(
+          outputDir: outputDir,
+          options: const GeneratorOptions(force: true),
+          fileSystem: fs,
+          discovery: DiscoveryEngine(
+            projectRoot: projectRoot,
+            fileSystem: fs,
+          ),
+        );
+
+        // Generate a test for get (uses test framework import only).
+        final getFile = await builder.generateForMethod(
+          GeneratorConfig(
+            name: 'Product',
+            methods: const ['get'],
+            outputDir: outputDir,
+          ),
+          'get',
+        );
+
+        expect(
+          getFile.action,
+          isNot(equals('skipped')),
+          reason: 'get test should be generated, not skipped',
+        );
+        expect(getFile.content, isNotNull);
+        // Must NOT import flutter_test.
+        expect(getFile.content!, isNot(contains('flutter_test')));
+        // Must NOT import zuraffa_flutter.
+        expect(getFile.content!, isNot(contains('zuraffa_flutter')));
+        // Must import package:test/test.dart.
+        expect(getFile.content!, contains('package:test/test.dart'));
+        // Must import mocktail.
+        expect(getFile.content!, contains('package:mocktail/mocktail.dart'));
+
+        // Generate a test for update (uses zuraffa core import too).
+        final updateFile = await builder.generateForMethod(
+          GeneratorConfig(
+            name: 'Product',
+            methods: const ['update'],
+            outputDir: outputDir,
+          ),
+          'update',
+        );
+
+        expect(
+          updateFile.action,
+          isNot(equals('skipped')),
+          reason: 'update test should be generated',
+        );
+        expect(updateFile.content, isNotNull);
+        expect(updateFile.content!, isNot(contains('flutter_test')));
+        expect(updateFile.content!, isNot(contains('zuraffa_flutter')));
+        expect(updateFile.content!, contains('package:test/test.dart'));
+        // update needs zuraffa core import - must be zuraffa, not zuraffa_flutter.
+        expect(updateFile.content!, contains('package:zuraffa/zuraffa.dart'));
+      },
+    );
+
+    test(
+      'Flutter pubspec generates flutter_test + zuraffa_flutter imports',
+      () async {
+        // Write a Flutter pubspec.yaml (has flutter SDK dependency).
+        await File(
+          path.join(projectRoot, 'pubspec.yaml'),
+        ).writeAsString('''
+name: my_flutter_app
+environment:
+  sdk: ">=3.11.0 <4.0.0"
+dependencies:
+  flutter:
+    sdk: flutter
+  zuraffa_flutter:
+    git:
+      url: https://github.com/arrrrny/zuraffa
+      path: zuraffa_flutter
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  mocktail: ^1.0.4
+''');
+
+        final fs = FileSystem.create(root: projectRoot);
+        final builder = TestBuilder(
+          outputDir: outputDir,
+          options: const GeneratorOptions(force: true),
+          fileSystem: fs,
+          discovery: DiscoveryEngine(
+            projectRoot: projectRoot,
+            fileSystem: fs,
+          ),
+        );
+
+        // Generate a test for get.
+        final getFile = await builder.generateForMethod(
+          GeneratorConfig(
+            name: 'Product',
+            methods: const ['get'],
+            outputDir: outputDir,
+          ),
+          'get',
+        );
+
+        expect(getFile.action, isNot(equals('skipped')));
+        expect(getFile.content, isNotNull);
+        // Must import flutter_test.
+        expect(
+          getFile.content!,
+          contains('package:flutter_test/flutter_test.dart'),
+        );
+        // Must import mocktail.
+        expect(getFile.content!, contains('package:mocktail/mocktail.dart'));
+
+        // Generate a test for update (needs zuraffa_flutter core import).
+        final updateFile = await builder.generateForMethod(
+          GeneratorConfig(
+            name: 'Product',
+            methods: const ['update'],
+            outputDir: outputDir,
+          ),
+          'update',
+        );
+
+        expect(updateFile.action, isNot(equals('skipped')));
+        expect(updateFile.content, isNotNull);
+        expect(
+          updateFile.content!,
+          contains('package:flutter_test/flutter_test.dart'),
+        );
+        // update needs zuraffa core import - must be zuraffa_flutter for Flutter.
+        expect(
+          updateFile.content!,
+          contains('package:zuraffa_flutter/zuraffa_flutter.dart'),
+        );
+      },
+    );
+
+    test(
+      'missing pubspec.yaml defaults to pure-Dart (test + zuraffa imports)',
+      () async {
+        // Do NOT write a pubspec.yaml - the builder should fall back to
+        // pure-Dart (conservative default matching DependencyWirer).
+        final fs = FileSystem.create(root: projectRoot);
+        final builder = TestBuilder(
+          outputDir: outputDir,
+          options: const GeneratorOptions(force: true),
+          fileSystem: fs,
+          discovery: DiscoveryEngine(
+            projectRoot: projectRoot,
+            fileSystem: fs,
+          ),
+        );
+
+        final getFile = await builder.generateForMethod(
+          GeneratorConfig(
+            name: 'Product',
+            methods: const ['get'],
+            outputDir: outputDir,
+          ),
+          'get',
+        );
+
+        expect(getFile.action, isNot(equals('skipped')));
+        expect(getFile.content, isNotNull);
+        expect(getFile.content!, isNot(contains('flutter_test')));
+        expect(getFile.content!, contains('package:test/test.dart'));
+      },
+    );
+
+    test('custom test builder respects pure-Dart imports', () async {
+      // Write a pure-Dart pubspec.yaml.
+      await File(
+        path.join(projectRoot, 'pubspec.yaml'),
+      ).writeAsString('''
+name: my_pure_dart_app
+environment:
+  sdk: ">=3.11.0 <4.0.0"
+dependencies:
+  zuraffa:
+    git:
+      url: https://github.com/arrrrny/zuraffa
+''');
+
+      final fs = FileSystem.create(root: projectRoot);
+      final builder = TestBuilder(
+        outputDir: outputDir,
+        options: const GeneratorOptions(force: true),
+        fileSystem: fs,
+        discovery: DiscoveryEngine(
+          projectRoot: projectRoot,
+          fileSystem: fs,
+        ),
+      );
+
+      final file = await builder.generateCustom(
+        GeneratorConfig(
+          name: 'Product',
+          methods: const ['custom'],
+          outputDir: outputDir,
+        ),
+      );
+
+      expect(file.content, isNotNull);
+      expect(file.content!, isNot(contains('flutter_test')));
+      expect(file.content!, isNot(contains('zuraffa_flutter')));
+      expect(file.content!, contains('package:test/test.dart'));
+      expect(file.content!, contains('package:zuraffa/zuraffa.dart'));
+    });
+
+    test('orchestrator test builder respects pure-Dart imports', () async {
+      // Write a pure-Dart pubspec.yaml.
+      await File(
+        path.join(projectRoot, 'pubspec.yaml'),
+      ).writeAsString('''
+name: my_pure_dart_app
+environment:
+  sdk: ">=3.11.0 <4.0.0"
+dependencies:
+  zuraffa:
+    git:
+      url: https://github.com/arrrrny/zuraffa
+''');
+
+      final fs = FileSystem.create(root: projectRoot);
+      final builder = TestBuilder(
+        outputDir: outputDir,
+        options: const GeneratorOptions(force: true),
+        fileSystem: fs,
+        discovery: DiscoveryEngine(
+          projectRoot: projectRoot,
+          fileSystem: fs,
+        ),
+      );
+
+      final file = await builder.generateOrchestrator(
+        GeneratorConfig(
+          name: 'Product',
+          methods: const ['get', 'update'],
+          outputDir: outputDir,
+        ),
+      );
+
+      expect(file.content, isNotNull);
+      expect(file.content!, isNot(contains('flutter_test')));
+      expect(file.content!, isNot(contains('zuraffa_flutter')));
+      expect(file.content!, contains('package:test/test.dart'));
+      expect(file.content!, contains('package:zuraffa/zuraffa.dart'));
+    });
+
+    test('polymorphic test builder respects pure-Dart imports', () async {
+      // Write a pure-Dart pubspec.yaml.
+      await File(
+        path.join(projectRoot, 'pubspec.yaml'),
+      ).writeAsString('''
+name: my_pure_dart_app
+environment:
+  sdk: ">=3.11.0 <4.0.0"
+dependencies:
+  zuraffa:
+    git:
+      url: https://github.com/arrrrny/zuraffa
+''');
+
+      final fs = FileSystem.create(root: projectRoot);
+      final builder = TestBuilder(
+        outputDir: outputDir,
+        options: const GeneratorOptions(force: true),
+        fileSystem: fs,
+        discovery: DiscoveryEngine(
+          projectRoot: projectRoot,
+          fileSystem: fs,
+        ),
+      );
+
+      final files = await builder.generatePolymorphic(
+        GeneratorConfig(
+          name: 'Product',
+          methods: const ['get'],
+          variants: const ['Get'],
+          repo: 'Product',
+          outputDir: outputDir,
+        ),
+      );
+
+      expect(files, isNotEmpty);
+      for (final file in files) {
+        if (file.content == null) continue;
+        expect(
+          file.content!,
+          isNot(contains('flutter_test')),
+          reason:
+            'polymorphic test should not import flutter_test in pure-Dart',
+        );
+        expect(
+          file.content!,
+          isNot(contains('zuraffa_flutter')),
+          reason:
+            'polymorphic test should not import zuraffa_flutter in pure-Dart',
+        );
+        expect(
+          file.content!,
+          contains('package:test/test.dart'),
+          reason:
+            'polymorphic test must import package:test/test.dart in pure-Dart',
+        );
+        expect(
+          file.content!,
+          contains('package:zuraffa/zuraffa.dart'),
+          reason:
+            'polymorphic test must import package:zuraffa/zuraffa.dart in pure-Dart',
+        );
+      }
+    });
+  });
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Generated tests now use the appropriate Dart or Flutter testing framework and core libraries based on the project type.
  * Projects without a readable project configuration now default to pure-Dart test imports.
  * Custom, orchestrator, entity, and polymorphic test generation now supports pure-Dart projects correctly.

* **Tests**
  * Added regression coverage for Dart and Flutter import selection across supported test builders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->