### PR TITLE
chore(deps): zorphy ^2.0.0 + git override (zorphy master) — drop ref pin and ../zorphy path overrides

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -757,19 +757,19 @@ packages:
     dependency: "direct main"
     description:
       path: zorphy
-      ref: "fix/349-external-type-no-dollar-prefix-cli"
-      resolved-ref: e75c30b60030f03f7dca54f4c46e10a07c1acdc7
+      ref: master
+      resolved-ref: ea95773f4f17e074a96b30f6c4d390ea9f58a790
       url: "https://github.com/arrrrny/zorphy.git"
     source: git
-    version: "2.2.0"
+    version: "2.0.0"
   zorphy_annotation:
     dependency: "direct main"
     description:
       path: zorphy_annotation
-      ref: development
-      resolved-ref: "7e372469f7c1f0fd6dbad770b78969bd89f5000a"
+      ref: master
+      resolved-ref: ea95773f4f17e074a96b30f6c4d390ea9f58a790
       url: "https://github.com/arrrrny/zorphy.git"
     source: git
-    version: "2.2.0"
+    version: "2.0.0"
 sdks:
   dart: ">=3.11.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,39 +22,8 @@ dependencies:
   path: ^1.9.1
   yaml: ^3.1.0
   uuid: ^4.6.0
-  zorphy:
-    git:
-      url: https://github.com/arrrrny/zorphy.git
-      path: zorphy
-      # Issues #310 + #351 + #349: points to the fix branch carrying FOUR
-      # fixes not yet on zorphy/development:
-      #   1. #82/#310 plain-type fix (5ef9dc3 + faf94de, already on development)
-      #   2. #310 comment-safety hardening (2d093f1) — strips `//` and
-      #      `/* */` comments before the `abstract class $X` regex match.
-      #      Without it, a doc comment mentioning `abstract class $X`
-      #      would falsely match and re-emit the `$` prefix.
-      #   3. #351 cross-entity concrete reference recovery (c09d966) —
-      #      when a Zorphy entity has a field whose type is the CONCRETE
-      #      form of another Zorphy entity (e.g. `ParentThing? get parent`
-      #      with no `$` prefix), the analyzer cannot resolve the type
-      #      during build_runner and `typeToString` fell back to
-      #      `InvalidType`, breaking json_serializable and `zfa build`.
-      #      The fix recovers the type from source. Also drops
-      #      `required` on `dynamic` ctor params (no more
-      #      `required dynamic this.x`).
-      #   4. #349 external-type `!Type` marker (fix/349-external-type-
-      #      no-dollar-prefix-cli) — `FieldDefinition.isExternal` that
-      #      this package's #349 fix (def7d5f) depends on.
-      # Revert to "development" once all of
-      # https://github.com/arrrrny/zorphy/pull/85 (#310 hardening),
-      # the #351 PR, and zorphy PR #84 (#349 marker) are merged into
-      # zorphy/development.
-      ref: "fix/349-external-type-no-dollar-prefix-cli"
-  zorphy_annotation:
-    git:
-      url: https://github.com/arrrrny/zorphy.git
-      path: zorphy_annotation
-      ref: "development"
+  zorphy: ^2.0.0
+  zorphy_annotation: ^2.0.0
 
   json_annotation: ^4.12.0
 
@@ -75,6 +44,22 @@ dependencies:
 
 dependency_overrides:
   analyzer: 14.1.0
+  # Track the latest zorphy fixes locally/CI without hard-pinning to a commit
+  # or feature ref. 2.0.0 on pub.dev carries the #310/#351/#349 fixes, so the
+  # versioned deps above are the published contract; these git overrides
+  # resolve WITHOUT a sibling ../zorphy checkout. Note: zorphy's former
+  # `development` branch was merged into `master` (PR #93), so the override
+  # points at `master` — the continuation of that line.
+  zorphy:
+    git:
+      url: https://github.com/arrrrny/zorphy.git
+      path: zorphy
+      ref: master
+  zorphy_annotation:
+    git:
+      url: https://github.com/arrrrny/zorphy.git
+      path: zorphy_annotation
+      ref: master
 
 executables:
   zuraffa:

--- a/zuraffa_flutter/pubspec.lock
+++ b/zuraffa_flutter/pubspec.lock
@@ -696,21 +696,19 @@ packages:
   zorphy:
     dependency: transitive
     description:
-      path: zorphy
-      ref: "fix/349-external-type-no-dollar-prefix-cli"
-      resolved-ref: e75c30b60030f03f7dca54f4c46e10a07c1acdc7
-      url: "https://github.com/arrrrny/zorphy.git"
-    source: git
-    version: "2.2.0"
+      name: zorphy
+      sha256: bd69acaa30ce2fdeac93f8f0923c99f337cdcc1be62ba0300eadb9abab7888e4
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   zorphy_annotation:
     dependency: transitive
     description:
-      path: zorphy_annotation
-      ref: development
-      resolved-ref: "7e372469f7c1f0fd6dbad770b78969bd89f5000a"
-      url: "https://github.com/arrrrny/zorphy.git"
-    source: git
-    version: "2.2.0"
+      name: zorphy_annotation
+      sha256: bafd4f79054b3305ad2983966345e9c11e3ee792ec024c483a9291ba74d75033
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   zuraffa:
     dependency: "direct main"
     description:


### PR DESCRIPTION
## What & why

zuraffa now consumes zorphy **2.0.0** from pub.dev (carries all four previously-ref-pinned fixes: #310 comment-safety, #351 cross-entity concrete refs, #349 `!Type` marker — `ZorphyKind` verified in 2.0.0's `generation_config.dart`).

**Main deps** — replaced the git blocks (ref `fix/349-external-type-no-dollar-prefix-cli`) with the versioned contract:
- `zorphy: ^2.0.0`
- `zorphy_annotation: ^2.0.0`

**dependency_overrides** — keep tracking the latest zorphy line locally/CI without hard-pinning, and drop the (already-removed) `../zorphy` path overrides for good:
- `zorphy` / `zorphy_annotation` → git `https://github.com/arrrrny/zorphy.git` @ `master` (see note)
- `analyzer: 14.1.0` kept

**Note on the ref:** zorphy's former `development` branch was merged into `master` (zorphy PR #93 — head commit `ea95773` `Merge pull request #93 from arrrrny/development`); `ref: development` no longer resolves on the remote. `master` IS the continuation of that line (version 2.0.0, contains the v2.0.0 tag), so the override points there. Git overrides resolve without a sibling `../zorphy` checkout — CI works.

**zuraffa_flutter:** declares `zuraffa: path: ../` and no zorphy deps itself — it inherits via zuraffa; no change needed there. Its lockfile now resolves zorphy 2.0.0 from pub.dev.

**Test fixtures (2nd commit):** the `dart_core` job revealed two fixtures that needed aligning:
- `issue_313`: temp-app pubspec declared `zorphy_annotation` from **git**, which conflicts with zuraffa's hosted `^2.0.0` (git vs hosted source unification fails) → mirror the versioned dep.
- `issue_306`: `_zfaRoot` was captured from `Directory.current` at library load, which is unreliable when other test files (e.g. `issue_348`) change CWD concurrently → use the CWD-independent `findProjectRoot()` helper (same pattern as `issue_313`).

## Verification

- `dart pub get` — resolves, no `../zorphy`; overrides pull zorphy@master (ea9577).
- `dart analyze lib test` / root `flutter analyze` — clean (only pre-existing non-fatal warnings/infos; CI uses `--no-fatal-warnings`).
- `zuraffa_flutter` `flutter analyze` — **No issues found** (the ZorphyKind gate that failed with the old ref).
- Fixed fixtures verified locally: `issue_306` (4) + `issue_313` (2) — 6/6 pass with the new deps.
- `dart test` + `flutter test` run in CI (full suite).

## Follow-up (out of scope here)

`DependencyWirer.standardSet()` still emits `zorphy_annotation` as a **git** dep on the (now deleted) zorphy `development` branch for projects generated via `zfa setup`/init. Newly generated projects would fail pub resolution against the hosted `^2.0.0` contract. Tracked as a separate follow-up (source + `dependency_wirer_test` change).