### PR TITLE
fix(test): align regression fixtures with hosted zorphy ^2.0.0

### DIFF
--- a/test/regression/issue_306_keyword_enum_values_test.dart
+++ b/test/regression/issue_306_keyword_enum_values_test.dart
@@ -39,8 +39,10 @@ import 'dart:io';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
+import '../helpers/project_root.dart';
+
 /// Resolve package root at discovery time, before any test changes CWD.
-final _zfaRoot = Directory.current.path;
+late final String _zfaRoot;
 
 void main() {
   group('#306 — zfa entity enum keyword values generate valid Dart', () {
@@ -54,8 +56,12 @@ void main() {
       ], workingDirectory: workspace.path);
     }
 
-    setUp(() async {
+    setUpAll(() async {
+      _zfaRoot = await findProjectRoot();
       zfaBin = p.join(_zfaRoot, 'bin', 'zfa.dart');
+    });
+
+    setUp(() async {
       workspace = await Directory.systemTemp.createTemp('issue_306_');
       // The entity command's dependency check scans pubspec.yaml for the
       // strings `zorphy_annotation:` and `build_runner:`. The strings are

--- a/test/regression/issue_313_field_named_values_enum_test.dart
+++ b/test/regression/issue_313_field_named_values_enum_test.dart
@@ -92,10 +92,10 @@ void main() {
       // json_serializable are pulled in transitively. We also list
       // `zorphy_annotation` directly because `EntityCommand`'s dependency
       // check scans pubspec.yaml for the literal string `zorphy_annotation:`
-      // before doing any work. The zorphy refs mirror zuraffa's own
-      // pubspec (git deps, no sibling-checkout paths — CI has no `../zorphy`
-      // and this is what carries the fixed zorphy that generates the
-      // escaped `.zorphy.dart` file).
+      // before doing any work. Since zuraffa now depends on the published
+      // `zorphy_annotation: ^2.0.0` (hosted, carries the #313 fix), the
+      // fixture mirrors that versioned constraint — no git refs, no sibling
+      // checkout needed.
       await File(p.join(workspace.path, 'pubspec.yaml')).writeAsString('''
 name: issue_313_test_app
 environment:
@@ -103,11 +103,7 @@ environment:
 dependencies:
   zuraffa:
     path: $_zfaRoot
-  zorphy_annotation:
-    git:
-      url: https://github.com/arrrrny/zorphy.git
-      path: zorphy_annotation
-      ref: development
+  zorphy_annotation: ^2.0.0
   json_annotation: ^4.12.0
 dev_dependencies:
   build_runner: ^2.4.0


### PR DESCRIPTION
Follow-up to #371 (merged). The pubspec migration to hosted `zorphy: ^2.0.0` left two regression fixtures broken on CI, so the merged `development` commit ran red on `dart_core` and `test`:

1. **issue_313** — temp-app pubspec declared `zorphy_annotation` from **git**, which conflicts with zuraffa's hosted `^2.0.0` (git vs hosted source unification fails: "zorphy_annotation from hosted is required"). Mirror the versioned dep.
2. **issue_306** — `_zfaRoot` was captured from `Directory.current` at library load, unreliable when other test files (e.g. issue_348) change CWD concurrently → resolve via the CWD-independent `findProjectRoot()` helper (same pattern as issue_313).

Both fixes verified locally (6/6 pass). This restores `development` to green.