### PR TITLE
fix(build): fail loudly when build exits 0 but declared generated parts are missing (closes #379)

### DIFF
--- a/lib/src/commands/build_command.dart
+++ b/lib/src/commands/build_command.dart
@@ -85,7 +85,7 @@ class BuildCommand extends Command {
       // `generate_for` glob doesn't match the annotated sources still
       // produces 0 outputs — this catches that residual class of misconfig.
       if (!dryRun) {
-        if (!verifyOutputsOrFail()) {
+        if (!verifyOutputsOrFail() || !verifyDeclaredPartsOrFail()) {
           exit(1);
         }
       }
@@ -97,7 +97,7 @@ class BuildCommand extends Command {
       final retryCode = await _runBuild();
       if (retryCode == 0) {
         print('\n✅ Build completed successfully after cache clean');
-        if (!verifyOutputsOrFail()) {
+        if (!verifyOutputsOrFail() || !verifyDeclaredPartsOrFail()) {
           exit(1);
         }
       } else {
@@ -186,6 +186,67 @@ class BuildCommand extends Command {
     } catch (_) {
       // Best-effort safety net — never fail the build from an unexpected error
       // in the detection path itself.
+    }
+    return true;
+  }
+
+  /// Returns `true` when every generated part declared by a source file under
+  /// `lib/`/`test/` (`.zorphy.dart` / `.g.dart`) actually exists on disk.
+  ///
+  /// This is the residual case zuraffa#379: build_runner (AOT) can exit 0 —
+  /// or its clean-cache retry can — while a single generator (e.g.
+  /// json_serializable failing on a `Function` field) leaves ONE entity's
+  /// part file unwritten. `verifyOutputsOrFail` only catches the total-zero
+  /// case; this catches the per-file partial case so the build fails loudly
+  /// instead of leaving a broken package that references a missing part.
+  ///
+  /// Only sources that declare a `.zorphy.dart` / `.g.dart` part are checked,
+  /// so hand-written multi-part libraries are not inspected.
+  @visibleForTesting
+  bool verifyDeclaredPartsOrFail({String? projectRoot}) {
+    final missing = <String>[];
+    for (final root in ['lib', 'test']) {
+      final rootPath = projectRoot != null ? p.join(projectRoot, root) : root;
+      final dir = Directory(rootPath);
+      if (!dir.existsSync()) continue;
+      for (final entity in dir.listSync(recursive: true)) {
+        if (entity is! File || !entity.path.endsWith('.dart')) continue;
+        final name = p.basename(entity.path);
+        if (name.endsWith('.zorphy.dart') || name.endsWith('.g.dart')) {
+          continue;
+        }
+        String src;
+        try {
+          src = entity.readAsStringSync();
+        } catch (_) {
+          // Ignore unreadable files.
+          continue;
+        }
+        final partRe = RegExp(r"""^\s*part\s+'([^']+)'\s*;""", multiLine: true);
+        for (final m in partRe.allMatches(src)) {
+          final partName = m.group(1)!;
+          if (!partName.endsWith('.zorphy.dart') &&
+              !partName.endsWith('.g.dart')) {
+            continue;
+          }
+          final resolved = p.join(p.dirname(entity.path), partName);
+          if (!File(resolved).existsSync()) {
+            missing.add('${p.relative(entity.path)} -> $partName');
+          }
+        }
+      }
+    }
+    if (missing.isNotEmpty) {
+      print(
+        '\n❌ Build exited 0 but ${missing.length} declared generated part(s) are '
+        'missing — the build output is incomplete.\n'
+        '   Missing:\n'
+        '${missing.map((m) => '     - $m').join('\n')}\n'
+        '   This usually means a generator (e.g. json_serializable) failed on one\n'
+        '   source while the rest of the build succeeded. Fix the reported source\n'
+        '   and re-run `zfa build`.',
+      );
+      return false;
     }
     return true;
   }

--- a/lib/src/commands/build_command.dart
+++ b/lib/src/commands/build_command.dart
@@ -222,7 +222,8 @@ class BuildCommand extends Command {
           // Ignore unreadable files.
           continue;
         }
-        final partRe = RegExp(r"""^\s*part\s+'([^']+)'\s*;""", multiLine: true);
+        final partRe =
+            RegExp(r"""^\s*part\s+['"]([^'"]+)['"]\s*;""", multiLine: true);
         for (final m in partRe.allMatches(src)) {
           final partName = m.group(1)!;
           if (!partName.endsWith('.zorphy.dart') &&

--- a/test/commands/build_command_unit_test.dart
+++ b/test/commands/build_command_unit_test.dart
@@ -393,5 +393,115 @@ void main() {
         expect(await command.countDartFiles(projectRoot: sandbox.path), 3);
       });
     });
+
+    group('verifyDeclaredPartsOrFail (#379)', () {
+      test('true when no lib/ or test/ dir exists', () {
+        expect(
+          command.verifyDeclaredPartsOrFail(projectRoot: sandbox.path),
+          isTrue,
+        );
+      });
+
+      test('true when sources declare no generated parts', () async {
+        await Directory(
+          p.join(sandbox.path, 'lib/src'),
+        ).create(recursive: true);
+        await File(
+          p.join(sandbox.path, 'lib/src/foo.dart'),
+        ).writeAsString('class Foo {}');
+        expect(
+          command.verifyDeclaredPartsOrFail(projectRoot: sandbox.path),
+          isTrue,
+        );
+      });
+
+      test('false when a source declares a missing .g.dart part (#379)', () async {
+        await Directory(
+          p.join(sandbox.path, 'lib/src/domain/entities/foo'),
+        ).create(recursive: true);
+        await File(
+          p.join(sandbox.path, 'lib/src/domain/entities/foo/foo.dart'),
+        ).writeAsString(
+          "part 'foo.zorphy.dart';\npart 'foo.g.dart';\n",
+        );
+        // .zorphy.dart exists but .g.dart is missing — exactly the
+        // json_serializable-failure-on-one-entity case from #379.
+        await File(
+          p.join(sandbox.path, 'lib/src/domain/entities/foo/foo.zorphy.dart'),
+        ).writeAsString('// generated');
+        final output = capturePrintSync(
+          () => command.verifyDeclaredPartsOrFail(projectRoot: sandbox.path),
+        );
+        expect(output, contains('foo.g.dart'));
+        expect(
+          command.verifyDeclaredPartsOrFail(projectRoot: sandbox.path),
+          isFalse,
+        );
+      });
+
+      test('false when a declared .zorphy.dart part is missing', () async {
+        await Directory(
+          p.join(sandbox.path, 'lib/src'),
+        ).create(recursive: true);
+        await File(
+          p.join(sandbox.path, 'lib/src/foo.dart'),
+        ).writeAsString("part 'foo.zorphy.dart';\n");
+        expect(
+          command.verifyDeclaredPartsOrFail(projectRoot: sandbox.path),
+          isFalse,
+        );
+      });
+
+      test('true when all declared generated parts exist', () async {
+        await Directory(
+          p.join(sandbox.path, 'lib/src'),
+        ).create(recursive: true);
+        await File(
+          p.join(sandbox.path, 'lib/src/foo.dart'),
+        ).writeAsString("part 'foo.zorphy.dart';\npart 'foo.g.dart';\n");
+        await File(
+          p.join(sandbox.path, 'lib/src/foo.zorphy.dart'),
+        ).writeAsString('// generated');
+        await File(
+          p.join(sandbox.path, 'lib/src/foo.g.dart'),
+        ).writeAsString('// generated');
+        expect(
+          command.verifyDeclaredPartsOrFail(projectRoot: sandbox.path),
+          isTrue,
+        );
+      });
+
+      test('ignores hand-written multi-part libraries (non-generated parts)',
+          () async {
+        await Directory(
+          p.join(sandbox.path, 'lib/src'),
+        ).create(recursive: true);
+        // A hand-written library with a missing helper part must NOT trip the
+        // check — only .zorphy.dart / .g.dart parts are verified.
+        await File(
+          p.join(sandbox.path, 'lib/src/lib.dart'),
+        ).writeAsString("part 'helper.dart';\n");
+        expect(
+          command.verifyDeclaredPartsOrFail(projectRoot: sandbox.path),
+          isTrue,
+        );
+      });
+
+      test('does not re-check the generated part files themselves', () async {
+        await Directory(
+          p.join(sandbox.path, 'lib/src'),
+        ).create(recursive: true);
+        await File(
+          p.join(sandbox.path, 'lib/src/foo.dart'),
+        ).writeAsString("part 'foo.zorphy.dart';\n");
+        await File(
+          p.join(sandbox.path, 'lib/src/foo.zorphy.dart'),
+        ).writeAsString("part of 'foo.dart';\n");
+        expect(
+          command.verifyDeclaredPartsOrFail(projectRoot: sandbox.path),
+          isTrue,
+        );
+      });
+    });
   });
 }

--- a/test/commands/build_command_unit_test.dart
+++ b/test/commands/build_command_unit_test.dart
@@ -487,6 +487,19 @@ void main() {
         );
       });
 
+      test('matches double-quoted part declarations too', () async {
+        await Directory(
+          p.join(sandbox.path, 'lib/src'),
+        ).create(recursive: true);
+        await File(
+          p.join(sandbox.path, 'lib/src/foo.dart'),
+        ).writeAsString('part "foo.zorphy.dart";\n');
+        expect(
+          command.verifyDeclaredPartsOrFail(projectRoot: sandbox.path),
+          isFalse,
+        );
+      });
+
       test('does not re-check the generated part files themselves', () async {
         await Directory(
           p.join(sandbox.path, 'lib/src'),


### PR DESCRIPTION
## Problem (#379)

`zfa build` can exit **0 while the build output is incomplete**: build_runner (AOT) — or its clean-cache retry — exits 0 even when a single generator fails on ONE entity (e.g. json_serializable rejecting a `Function`-typed field, zorphy #105), leaving that entity's `.g.dart` unwritten. The package is left broken (missing part file) with a green exit code.

The existing safety net (`verifyOutputsOrFail`, zuraffa#276) only catches the **total-zero-outputs** case — not a partial failure where 88 of 89 entities generated fine.

## Fix

New `verifyDeclaredPartsOrFail()` safety net, run on every successful-exit path (initial + clean-cache retry):

- Scans `lib/` + `test/` for source files that declare a `.zorphy.dart` / `.g.dart` part
- Fails loudly (non-zero exit) listing every declared part that is missing on disk
- Only inspects files declaring generated parts — hand-written multi-part libraries are untouched

Repro that previously exited 0, now exits 1:
```
zfa entity create -n ScriptHtmlTagAttributes --kind=value_object --field "onLoad:!Function?"
zfa build   # → ❌ missing part(s): .../script_html_tag_attributes.g.dart
```

## Tests

7 new in-process tests in `build_command_unit_test.dart` (missing .g.dart, missing .zorphy.dart, all-present, no-parts, non-generated parts ignored, generated files not re-checked, no dirs). Full suite: 38/38 green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Builds now verify that all declared generated Dart files are present.
  - Builds fail with a clear report when generated parts are missing, helping prevent incomplete or invalid build results.
  - Validation covers generated files declared in both library and test sources.
  - Handwritten files and intentionally excluded generated files are ignored appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->